### PR TITLE
Tweak Ufo::load & run rustfmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "norad"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 license = "MIT/Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
AsRef<Path> is a better fit since we don't need an owned path,
and this also ensures that we monomorphize the least code possible.