### PR TITLE
A batch of changes motivated by runebender

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,3 @@ druid = { git="https://github.com/xi-editor/druid/", rev="22dfeae", optional=tru
 
 [dev-dependencies]
 failure = "0.1.5"
-
-[features]
-druid_data = ["druid"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [dependencies]
-plist = "0.4"
+plist = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_repr = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ exclude = [
 
 [dependencies]
 plist = "0.5"
-serde = "1.0"
+serde = { version =  "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
 quick-xml = "0.12.0"
-druid = { git="https://github.com/xi-editor/druid/", rev="22dfeae", optional=true }
+druid = { git="https://github.com/xi-editor/druid/", rev="8164adf", optional=true }
 
 [dev-dependencies]
 failure = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "norad"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_repr = "0.1"
 quick-xml = "0.12.0"
+druid = { git="https://github.com/xi-editor/druid/", rev="22dfeae", optional=true }
 
 [dev-dependencies]
 failure = "0.1.5"
+
+[features]
+druid_data = ["druid"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,6 @@ pub enum Error {
     IoError(IoError),
     ParseError(XmlError),
     Glif(GlifError),
-    MissingGlyph,
     PlistError(PlistError),
     /// A wrapper for stashing errors for later use.
     SavedError(Rc<Error>),
@@ -65,7 +64,6 @@ impl std::fmt::Display for Error {
             Error::Glif(GlifError { path, position, kind }) => {
                 write!(f, "Glif error in {:?} index {}: '{}", path, position, kind)
             }
-            Error::MissingGlyph => write!(f, "Missing glyph"),
             Error::PlistError(e) => e.fmt(f),
             Error::SavedError(e) => e.fmt(f),
         }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -5,8 +5,18 @@ mod serialize;
 #[cfg(test)]
 mod tests;
 
-use crate::error::{Error, GlifError, GlifErrorInternal};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error::{Error, GlifError, GlifErrorInternal};
+
+/// The name of a glyph.
+///
+/// This is a newtype so we can work with serde.
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct GlyphName(Rc<String>);
 
 //FIXME: actually load the 'lib' data
 type Plist = ();
@@ -16,7 +26,7 @@ type Plist = ();
 /// [glif]: http://unifiedfontobject.org/versions/ufo3/glyphs/glif/
 #[derive(Debug, Clone, PartialEq)]
 pub struct Glyph {
-    pub name: String,
+    pub name: GlyphName,
     pub format: GlifVersion,
     pub advance: Option<Advance>,
     pub codepoints: Option<Vec<char>>,
@@ -54,7 +64,7 @@ impl Glyph {
 
     pub(crate) fn new(name: String, format: GlifVersion) -> Self {
         Glyph {
-            name,
+            name: GlyphName::new(name),
             format,
             advance: None,
             codepoints: None,
@@ -229,4 +239,52 @@ pub struct Image {
     pub file_name: PathBuf,
     pub color: Option<Color>,
     pub transform: AffineTransform,
+}
+
+impl GlyphName {
+    /// Create a new `GlyphName`.
+    pub(crate) fn new(s: impl Into<String>) -> Self {
+        GlyphName(Rc::new(s.into()))
+    }
+
+    /// Consumes the `GlyphName` and returns the inner `Rc<String>`.
+    pub fn into_inner(self) -> Rc<String> {
+        self.0
+    }
+
+    /// Returns the name as a string slice.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl std::convert::AsRef<str> for GlyphName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Serialize for GlyphName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for GlyphName {
+    fn deserialize<D>(deserializer: D) -> Result<GlyphName, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let inner = String::deserialize(deserializer)?;
+        Ok(GlyphName(Rc::new(inner)))
+    }
+}
+
+impl std::borrow::Borrow<str> for GlyphName {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
 }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -11,16 +11,10 @@ use std::sync::Arc;
 #[cfg(feature = "druid")]
 use druid::Data;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::error::{Error, GlifError, GlifErrorInternal};
 
 /// The name of a glyph.
-///
-/// This is a newtype so we can work with serde.
-#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "druid", derive(Data))]
-pub struct GlyphName(Arc<String>);
+pub type GlyphName = Arc<str>;
 
 //FIXME: actually load the 'lib' data
 type Plist = ();
@@ -68,7 +62,7 @@ impl Glyph {
 
     pub(crate) fn new(name: String, format: GlifVersion) -> Self {
         Glyph {
-            name: GlyphName::new(name),
+            name: GlyphName::from(name),
             format,
             advance: None,
             codepoints: None,
@@ -263,54 +257,6 @@ pub struct Image {
     pub file_name: PathBuf,
     pub color: Option<Color>,
     pub transform: AffineTransform,
-}
-
-impl GlyphName {
-    /// Create a new `GlyphName`.
-    pub(crate) fn new(s: impl Into<String>) -> Self {
-        GlyphName(Arc::new(s.into()))
-    }
-
-    /// Consumes the `GlyphName` and returns the inner `Arc<String>`.
-    pub fn into_inner(self) -> Arc<String> {
-        self.0
-    }
-
-    /// Returns the name as a string slice.
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl std::convert::AsRef<str> for GlyphName {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Serialize for GlyphName {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&self.0)
-    }
-}
-
-impl<'de> Deserialize<'de> for GlyphName {
-    fn deserialize<D>(deserializer: D) -> Result<GlyphName, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let inner = String::deserialize(deserializer)?;
-        Ok(GlyphName(Arc::new(inner)))
-    }
-}
-
-impl std::borrow::Borrow<str> for GlyphName {
-    fn borrow(&self) -> &str {
-        &self.0
-    }
 }
 
 #[cfg(feature = "druid")]

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -17,7 +17,7 @@ impl Glyph {
         let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 2);
         writer.write_event(Event::Decl(BytesDecl::new(b"1.1", Some(b"UTF-8"), None)))?;
         let mut start = BytesStart::borrowed_name(b"glyph");
-        start.push_attribute(("name", self.name.as_str()));
+        start.push_attribute(("name", &*self.name));
         start.push_attribute(("format", self.format.as_str()));
         writer.write_event(Event::Start(start))?;
 

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -12,7 +12,7 @@ fn transform() {
 fn parse() {
     let bytes = include_bytes!("../../testdata/sample_period.glif");
     let glyph = parse_glyph(bytes).unwrap();
-    assert_eq!(glyph.name.as_str(), "period");
+    assert_eq!(&*glyph.name, "period");
     assert_eq!(
         glyph.image.as_ref().map(|img| img.file_name.clone()),
         Some(PathBuf::from("period sketch.png"))
@@ -91,7 +91,7 @@ fn save() {
 #[test]
 fn druid_from_color() {
     let color = druid::piet::Color::rgba(1.0, 0.11, 0.5, 0.23);
-    let color2: druid::piet::Color = Color { red: 1.0, green: 0.11, blue: 0.5, alpha: 0.23}.into();
+    let color2: druid::piet::Color = Color { red: 1.0, green: 0.11, blue: 0.5, alpha: 0.23 }.into();
     assert_eq!(color2.as_rgba_u32(), color.as_rgba_u32());
 }
 

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -87,6 +87,14 @@ fn save() {
     assert_eq!(glyph.guidelines, glyph2.guidelines);
 }
 
+#[cfg(feature = "druid")]
+#[test]
+fn druid_from_color() {
+    let color = druid::piet::Color::rgba(1.0, 0.11, 0.5, 0.23);
+    let color2: druid::piet::Color = Color { red: 1.0, green: 0.11, blue: 0.5, alpha: 0.23}.into();
+    assert_eq!(color2.as_rgba_u32(), color.as_rgba_u32());
+}
+
 //#[test]
 //fn parse_utf16() {
 //let bytes = include_bytes!("../../testdata/utf16-glyph.xml");

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -12,7 +12,7 @@ fn transform() {
 fn parse() {
     let bytes = include_bytes!("../../testdata/sample_period.glif");
     let glyph = parse_glyph(bytes).unwrap();
-    assert_eq!(&glyph.name, "period");
+    assert_eq!(glyph.name.as_str(), "period");
     assert_eq!(
         glyph.image.as_ref().map(|img| img.file_name.clone()),
         Some(PathBuf::from("period sketch.png"))

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -14,7 +15,7 @@ static CONTENTS_FILE: &str = "contents.plist";
 /// [layer]: http://unifiedfontobject.org/versions/ufo3/glyphs/
 #[derive(Debug, Default)]
 pub struct Layer {
-    glyphs: BTreeMap<GlyphName, Rc<Glyph>>,
+    pub glyphs: BTreeMap<GlyphName, Rc<Glyph>>,
 }
 
 impl Layer {
@@ -31,9 +32,22 @@ impl Layer {
         Ok(Layer { glyphs })
     }
 
-    /// Returns the glyph with the given name, if it exists.
-    pub fn get_glyph(&self, glyph: &str) -> Option<Rc<Glyph>> {
-        self.glyphs.get(glyph).map(Rc::clone)
+    /// Returns a reference the glyph with the given name, if it exists.
+    pub fn get_glyph<K>(&self, glyph: &K) -> Option<&Rc<Glyph>>
+    where
+        GlyphName: Borrow<K>,
+        K: Ord + ?Sized,
+    {
+        self.glyphs.get(glyph)
+    }
+
+    /// Returns a mutable reference to the glyph with the given name, if it exists.
+    pub fn get_glyph_mut<K>(&mut self, glyph: &K) -> Option<&mut Rc<Glyph>>
+    where
+        GlyphName: Borrow<K>,
+        K: Ord + ?Sized,
+    {
+        self.glyphs.get_mut(glyph)
     }
 
     /// Returns `true` if this layer contains a glyph with this name.

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -22,12 +22,15 @@ impl Layer {
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Layer, Error> {
         let path = path.as_ref();
         let contents_path = path.join(CONTENTS_FILE);
-        let contents: BTreeMap<GlyphName, PathBuf> = plist::from_file(contents_path)?;
+        // these keys are never used; a future optimization would be to skip the
+        // names and deserialize to a vec; that would not be a one-liner, though.
+        let contents: BTreeMap<String, PathBuf> = plist::from_file(contents_path)?;
         let mut glyphs = BTreeMap::new();
-        for (name, glyph_path) in contents.iter() {
+        for (_, glyph_path) in contents.iter() {
             let glyph_path = path.join(glyph_path);
             let glyph = Glyph::load(glyph_path)?;
-            glyphs.insert(name.clone(), Rc::new(glyph));
+            // reuse the name in the glyph to avoid having two copies of each
+            glyphs.insert(glyph.name.clone(), Rc::new(glyph));
         }
         Ok(Layer { glyphs })
     }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::glyph::GlyphName;
 use crate::{Error, Glyph};
@@ -15,7 +15,7 @@ static CONTENTS_FILE: &str = "contents.plist";
 /// [layer]: http://unifiedfontobject.org/versions/ufo3/glyphs/
 #[derive(Debug, Default)]
 pub struct Layer {
-    pub glyphs: BTreeMap<GlyphName, Rc<Glyph>>,
+    pub glyphs: BTreeMap<GlyphName, Arc<Glyph>>,
 }
 
 impl Layer {
@@ -30,13 +30,13 @@ impl Layer {
             let glyph_path = path.join(glyph_path);
             let glyph = Glyph::load(glyph_path)?;
             // reuse the name in the glyph to avoid having two copies of each
-            glyphs.insert(glyph.name.clone(), Rc::new(glyph));
+            glyphs.insert(glyph.name.clone(), Arc::new(glyph));
         }
         Ok(Layer { glyphs })
     }
 
     /// Returns a reference the glyph with the given name, if it exists.
-    pub fn get_glyph<K>(&self, glyph: &K) -> Option<&Rc<Glyph>>
+    pub fn get_glyph<K>(&self, glyph: &K) -> Option<&Arc<Glyph>>
     where
         GlyphName: Borrow<K>,
         K: Ord + ?Sized,
@@ -45,7 +45,7 @@ impl Layer {
     }
 
     /// Returns a mutable reference to the glyph with the given name, if it exists.
-    pub fn get_glyph_mut<K>(&mut self, glyph: &K) -> Option<&mut Rc<Glyph>>
+    pub fn get_glyph_mut<K>(&mut self, glyph: &K) -> Option<&mut Arc<Glyph>>
     where
         GlyphName: Borrow<K>,
         K: Ord + ?Sized,
@@ -64,7 +64,7 @@ impl Layer {
         //FIXME: figure out what bookkeeping we have to do with this path
         let _path = path.into();
         let name = glyph.name.clone();
-        self.glyphs.insert(name, Rc::new(glyph));
+        self.glyphs.insert(name, Arc::new(glyph));
     }
 
     /// Remove the named glyph from this layer.
@@ -73,8 +73,8 @@ impl Layer {
     }
 
     /// Iterate over the glyphs in this layer.
-    pub fn iter_contents<'a>(&'a self) -> impl Iterator<Item = Rc<Glyph>> + 'a {
-        self.glyphs.values().map(Rc::clone)
+    pub fn iter_contents<'a>(&'a self) -> impl Iterator<Item = Arc<Glyph>> + 'a {
+        self.glyphs.values().map(Arc::clone)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! let mut font_obj = Ufo::load(path).expect("failed to load font");
 //! let layer = font_obj.find_layer(|layer| layer.name == "glyphs").unwrap();
 //! let glyph_a = layer.get_glyph("A").expect("missing glyph");
-//! assert_eq!(glyph_a.name.as_str(), "A");
+//! assert_eq!(glyph_a.name.as_ref(), "A");
 //! ```
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,6 @@ mod layer;
 mod ufo;
 
 pub use error::Error;
-pub use glyph::Glyph;
+pub use glyph::{Glyph, GlyphName};
 pub use layer::Layer;
-pub use ufo::{FontInfo, LayerInfo, Ufo};
+pub use ufo::{FontInfo, FormatVersion, LayerInfo, MetaInfo, Ufo};

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -2,9 +2,11 @@
 
 #![deny(intra_doc_link_resolution_failure)]
 
+use std::collections::BTreeSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
+use crate::glyph::GlyphName;
 use crate::layer::Layer;
 use crate::Error;
 
@@ -20,6 +22,7 @@ pub struct Ufo {
     meta: MetaInfo,
     pub font_info: Option<FontInfo>,
     layers: Vec<LayerInfo>,
+    glyph_names: BTreeSet<GlyphName>,
 }
 
 /// A [font layer], along with its name and path.
@@ -110,7 +113,12 @@ impl Ufo {
                     Ok(LayerInfo { name, path: p, layer })
                 })
                 .collect();
-            Ok(Ufo { layers: layers?, meta, font_info })
+            let layers = layers?;
+            let glyph_names = layers
+                .iter()
+                .flat_map(|info| info.layer.iter_contents().map(|g| g.name.clone()))
+                .collect();
+            Ok(Ufo { layers, meta, font_info, glyph_names })
         }
     }
 

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -6,7 +6,7 @@ use std::borrow::Borrow;
 use std::collections::BTreeSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::glyph::{Glyph, GlyphName};
 use crate::layer::Layer;
@@ -190,7 +190,7 @@ impl Ufo {
     //FIXME: support for multiple layers.
     /// Returns a reference to the glyph with the given name,
     /// IN THE DEFAULT LAYER, if it exists.
-    pub fn get_glyph<K>(&self, key: &K) -> Option<&Rc<Glyph>>
+    pub fn get_glyph<K>(&self, key: &K) -> Option<&Arc<Glyph>>
     where
         GlyphName: Borrow<K>,
         K: Ord + ?Sized,
@@ -200,7 +200,7 @@ impl Ufo {
 
     /// Returns a mutable reference to the glyph with the given name,
     /// IN THE DEFAULT LAYER, if it exists.
-    pub fn get_glyph_mut<K>(&mut self, key: &K) -> Option<&mut Rc<Glyph>>
+    pub fn get_glyph_mut<K>(&mut self, key: &K) -> Option<&mut Arc<Glyph>>
     where
         GlyphName: Borrow<K>,
         K: Ord + ?Sized,

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -114,18 +114,36 @@ impl Ufo {
         }
     }
 
-    /// Returns the first layer matching a predicate. The predicate takes a
-    /// `LayerInfo` struct, which includes the layer's name and path as well
-    /// as the layer itself.
-    pub fn find_layer<P>(&mut self, mut predicate: P) -> Option<&mut Layer>
+    /// Returns a reference to the first layer matching a predicate.
+    /// The predicate takes a `LayerInfo` struct, which includes the layer's
+    /// name and path as well as the layer itself.
+    pub fn find_layer<P>(&self, mut predicate: P) -> Option<&Layer>
+    where
+        P: FnMut(&LayerInfo) -> bool,
+    {
+        self.layers.iter().find(|l| predicate(l)).map(|l| &l.layer)
+    }
+
+    /// Returns a mutable reference to the first layer matching a predicate.
+    /// The predicate takes a `LayerInfo` struct, which includes the layer's
+    /// name and path as well as the layer itself.
+    pub fn find_layer_mut<P>(&mut self, mut predicate: P) -> Option<&mut Layer>
     where
         P: FnMut(&LayerInfo) -> bool,
     {
         self.layers.iter_mut().find(|l| predicate(l)).map(|l| &mut l.layer)
     }
 
-    /// Returns the default layer, if it exists.
-    pub fn get_default_layer(&mut self) -> Option<&mut Layer> {
+    /// Returns a reference to the default layer, if it exists.
+    pub fn get_default_layer(&self) -> Option<&Layer> {
+        self.layers
+            .iter()
+            .find(|l| l.path.file_name() == Some(OsStr::new(DEFAULT_GLYPHS_DIRNAME)))
+            .map(|l| &l.layer)
+    }
+
+    /// Returns a mutable reference to the default layer, if it exists.
+    pub fn get_default_layer_mut(&mut self) -> Option<&mut Layer> {
         self.layers
             .iter_mut()
             .find(|l| l.path.file_name() == Some(OsStr::new(DEFAULT_GLYPHS_DIRNAME)))
@@ -145,7 +163,7 @@ mod tests {
     #[test]
     fn loading() {
         let path = "testdata/mutatorSans/MutatorSansLightWide.ufo";
-        let mut font_obj = Ufo::load(path).unwrap();
+        let font_obj = Ufo::load(path).unwrap();
         assert_eq!(font_obj.iter().count(), 2);
         font_obj
             .find_layer(|l| l.path.to_str() == Some("glyphs.background"))


### PR DESCRIPTION
this has been my working branch for the past week or two, and I'm happy enough with these changes that I'd like to bring them in.

Major things:

- we now just load everything up front, which makes life simpler
- we use `Arc<str>` for glyph names, and keep loaded glyphs behind `Arc`s as well, so that we can play more nicely with `Data`. 
- more stuff is public
- there's a `druid` feature that turns on various conversions and `Data` impls.