### PR TITLE
Allow 'advance' to contain both a width and a height

### DIFF
--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -99,11 +99,12 @@ pub enum GlifVersion {
     V2 = 2,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// Horizontal and vertical metrics.
+#[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]
-pub enum Advance {
-    Width(f32),
-    Height(f32),
+pub struct Advance {
+    pub height: f32,
+    pub width: f32,
 }
 
 /// Identifiers are optional attributes of several objects in the UFO.

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -82,9 +82,12 @@ impl GlifVersion {
 impl Advance {
     fn to_event(&self) -> Event {
         let mut start = BytesStart::borrowed_name(b"advance");
-        match self {
-            Advance::Width(w) => start.push_attribute(("width", w.to_string().as_str())),
-            Advance::Height(h) => start.push_attribute(("height", h.to_string().as_str())),
+        if self.width != 0. {
+            start.push_attribute(("width", self.width.to_string().as_str()));
+        }
+
+        if self.height != 0. {
+            start.push_attribute(("height", self.height.to_string().as_str()));
         }
         Event::Empty(start)
     }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -38,7 +38,7 @@ fn guidelines() {
     let glyph = parse_glyph(bytes).unwrap();
     assert_eq!(glyph.guidelines.as_ref().map(Vec::len), Some(8));
     assert_eq!(glyph.outline.as_ref().map(|o| o.contours.len()), Some(2));
-    assert_eq!(glyph.advance, Some(Advance::Width(364.)));
+    assert_eq!(glyph.advance, Some(Advance { width: 364., height: 0. }));
 }
 
 #[test]
@@ -85,6 +85,12 @@ fn save() {
     assert_eq!(glyph.image, glyph2.image);
     assert_eq!(glyph.anchors, glyph2.anchors);
     assert_eq!(glyph.guidelines, glyph2.guidelines);
+}
+
+#[test]
+fn notdef_failure() {
+    let bytes = include_bytes!("../../testdata/noto-cjk-notdef.glif");
+    let _ = parse_glyph(bytes).unwrap();
 }
 
 #[cfg(feature = "druid")]

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -90,7 +90,7 @@ mod tests {
         assert!(Path::new(layer_path).exists(), "missing test data. Did you `git submodule init`?");
         let layer = Layer::load(layer_path).unwrap();
         let glyph = layer.get_glyph("A").expect("failed to load glyph 'A'");
-        assert_eq!(glyph.advance, Some(Advance::Width(1290.)));
+        assert_eq!(glyph.advance, Some(Advance { width: 1290., height: 0. }));
         assert_eq!(glyph.codepoints.as_ref().map(Vec::len), Some(1));
         assert_eq!(glyph.codepoints.as_ref().unwrap()[0], 'A');
     }
@@ -110,9 +110,9 @@ mod tests {
         let layer_path = "testdata/mutatorSans/MutatorSansBoldWide.ufo/glyphs";
         let mut layer = Layer::load(layer_path).unwrap();
         let mut glyph = Glyph::new_named("A");
-        glyph.advance = Some(Advance::Height(69.));
+        glyph.advance = Some(Advance { height: 69., width: 0. });
         layer.set_glyph("A_.glif", glyph);
         let glyph = layer.get_glyph("A").expect("failed to load glyph 'A'");
-        assert_eq!(glyph.advance, Some(Advance::Height(69.)));
+        assert_eq!(glyph.advance, Some(Advance { height: 69., width: 0. }));
     }
 }

--- a/testdata/noto-cjk-notdef.glif
+++ b/testdata/noto-cjk-notdef.glif
@@ -1,0 +1,39 @@
+<!--Parse fail with 'unexpected duplicate element'. This is from noto-CJK-->
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name=".notdef" format="2">
+  <advance height="1000" width="1000"/>
+  <outline>
+    <contour>
+      <point x="100" y="-120" type="line"/>
+      <point x="900" y="-120" type="line"/>
+      <point x="900" y="880" type="line"/>
+      <point x="100" y="880" type="line"/>
+    </contour>
+    <contour>
+      <point x="500" y="421" type="line"/>
+      <point x="182" y="830" type="line"/>
+      <point x="818" y="830" type="line"/>
+    </contour>
+    <contour>
+      <point x="532" y="380" type="line"/>
+      <point x="850" y="789" type="line"/>
+      <point x="850" y="-29" type="line"/>
+    </contour>
+    <contour>
+      <point x="182" y="-70" type="line"/>
+      <point x="500" y="339" type="line"/>
+      <point x="818" y="-70" type="line"/>
+    </contour>
+    <contour>
+      <point x="150" y="789" type="line"/>
+      <point x="468" y="380" type="line"/>
+      <point x="150" y="-29" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>public.verticalOrigin</key>
+      <integer>880</integer>
+    </dict>
+  </lib>
+</glyph>


### PR DESCRIPTION
I'd misread the spec initially, and thought that these were mutually
exclusive; came across a counter example when playing around with noto CJK.