### PR TITLE
Add example binary for timing file loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version =  "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
 quick-xml = "0.12.0"
-druid = { git="https://github.com/xi-editor/druid/", rev="8164adf", optional=true }
+druid = { git="https://github.com/xi-editor/druid/", rev="05f8744", optional=true }
 
 [dev-dependencies]
 failure = "0.1.5"

--- a/examples/open_ufo.rs
+++ b/examples/open_ufo.rs
@@ -1,0 +1,45 @@
+//! A small program that loads a UFO file and prints the glyph count.
+
+use std::env;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use norad::Ufo;
+
+fn main() {
+    let path = get_path_or_exit();
+
+    let start = Instant::now();
+    let ufo = Ufo::load(&path).expect("failed to load file");
+
+    let duration = start.elapsed();
+    let time_str = format_time(duration);
+    let font_name = ufo
+        .font_info
+        .as_ref()
+        .and_then(|f| f.family_name.clone())
+        .unwrap_or_else(|| "an unnamed font".into());
+
+    println!("loaded {} glyphs from {} in {}.", ufo.glyph_count(), font_name, time_str);
+}
+
+fn get_path_or_exit() -> PathBuf {
+    match env::args().skip(1).next().map(PathBuf::from) {
+        Some(ref p) if p.exists() && p.extension() == Some(OsStr::new("ufo")) => p.to_owned(),
+        Some(ref p) => {
+            eprintln!("path {:?} is not an existing .glif file, exiting", p);
+            std::process::exit(1);
+        }
+        None => {
+            eprintln!("Please supply a path to a glif file");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn format_time(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    let millis = duration.subsec_millis();
+    format!("{}.{}s", secs, millis)
+}


### PR DESCRIPTION
@madig with this patch, you can run `cargo run --release --examples=open_ufo ./path/to/font.ufo` and it will print out how long it takes to load.