### PR TITLE
Wire up basic object saving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "norad"
-version = "0.0.4"
-authors = ["Colin Rofls <colin@cmyr.net>"]
+version = "0.1.0"
+authors = ["Colin Rofls <colin@cmyr.net>", "Nikolaus Waxweiler <madigens@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 keywords = ["font", "ufo", "fonts"]
@@ -28,3 +28,4 @@ optional = true
 [dev-dependencies]
 failure = "0.1.6"
 serde_test = "1.0.102"
+tempdir = "0.3.7"

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -12,8 +12,14 @@ use super::{
     Identifier, Image, Line, PointType,
 };
 
+use crate::error::GlifWriteError;
+
 impl Glyph {
-    pub(crate) fn encode_xml(&self) -> Result<Vec<u8>, XmlError> {
+    pub(crate) fn encode_xml(&self) -> Result<Vec<u8>, GlifWriteError> {
+        self.encode_xml_impl().map_err(|inner| GlifWriteError { name: self.name.clone(), inner })
+    }
+
+    fn encode_xml_impl(&self) -> Result<Vec<u8>, XmlError> {
         let mut writer = Writer::new_with_indent(Cursor::new(Vec::new()), b' ', 2);
         writer.write_event(Event::Decl(BytesDecl::new(b"1.1", Some(b"UTF-8"), None)))?;
         let mut start = BytesStart::borrowed_name(b"glyph");

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -1,0 +1,46 @@
+//! Testing saving files.
+
+use norad::{Glyph, Layer, MetaInfo, Ufo};
+
+#[test]
+fn save_new_file() {
+    let mut my_ufo = Ufo::new(MetaInfo::default());
+    let mut my_glyph = Glyph::new_named("A");
+    my_glyph.codepoints = Some(vec!['A']);
+    my_glyph.note = Some("I did a glyph!".into());
+    my_ufo.get_default_layer_mut().unwrap().insert_glyph(my_glyph);
+
+    let dir = tempdir::TempDir::new("Test.ufo").unwrap();
+    my_ufo.save(&dir).unwrap();
+
+    assert!(dir.path().join("glyphs").exists());
+    assert!(dir.path().join("glyphs/contents.plist").exists());
+    assert!(dir.path().join("glyphs/A_.glif").exists());
+
+    let loaded = Ufo::load(dir).unwrap();
+    assert!(loaded.get_default_layer().unwrap().get_glyph("A").is_some());
+    let glyph = loaded.get_default_layer().unwrap().get_glyph("A").unwrap();
+    assert_eq!(glyph.codepoints.as_ref(), Some(&vec!['A']));
+}
+
+#[test]
+fn save_fancy() {
+    let mut my_ufo = Ufo::new(MetaInfo::default());
+    let layer_path = "testdata/mutatorSans/MutatorSansBoldWide.ufo/glyphs";
+    let layer = Layer::load(layer_path).unwrap();
+    *my_ufo.get_default_layer_mut().unwrap() = layer;
+
+    let dir = tempdir::TempDir::new("Fancy.ufo").unwrap();
+    my_ufo.save(&dir).unwrap();
+
+    let loaded = Ufo::load(dir).unwrap();
+    let pre_layer = my_ufo.get_default_layer().unwrap();
+    let post_layer = loaded.get_default_layer().unwrap();
+    assert_eq!(pre_layer.iter_contents().count(), post_layer.iter_contents().count());
+
+    for glyph in pre_layer.iter_contents() {
+        let other = post_layer.get_glyph(&glyph.name);
+        assert!(other.is_some(), "missing {}", &glyph.name);
+        assert_eq!(&glyph, other.unwrap());
+    }
+}


### PR DESCRIPTION
A bunch of the file saving code was already in place, but just
wasn't really exposed or used at all.

This attempts to cover the bare minimum case; for the time being
we will only save files that are marked as having been created in norad.