### PR TITLE
Intern glyph names

### DIFF
--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -160,7 +160,7 @@ impl Anchor {
 impl Component {
     fn to_event(&self) -> Event {
         let mut start = BytesStart::borrowed_name(b"component");
-        start.push_attribute(("base", self.base.as_str()));
+        start.push_attribute(("base", &*self.base));
         start.push_attribute(("xScale", self.transform.x_scale.to_string().as_str()));
         start.push_attribute(("yScale", self.transform.y_scale.to_string().as_str()));
         start.push_attribute(("xyScale", self.transform.xy_scale.to_string().as_str()));

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -3,6 +3,7 @@
 #![deny(intra_doc_link_resolution_failure)]
 
 use std::borrow::Borrow;
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -104,6 +105,8 @@ impl Ufo {
             } else {
                 None
             };
+
+            let mut glyph_names = HashSet::new();
             let mut contents = match meta.format_version {
                 FormatVersion::V3 => {
                     let contents_path = path.join(LAYER_CONTENTS_FILE);
@@ -117,7 +120,7 @@ impl Ufo {
                 .drain(..)
                 .map(|(name, p)| {
                     let layer_path = path.join(&p);
-                    let layer = Layer::load(layer_path)?;
+                    let layer = Layer::load_impl(&layer_path, &mut glyph_names)?;
                     Ok(LayerInfo { name, path: p, layer })
                 })
                 .collect();


### PR DESCRIPTION
This began with me just wanting to change Component to use
GlyphName instead of String, but it felt bad that we were going to
be storing multiple copies of the names, so I also implemented
a basic interning scheme; while parsing we pass along a HashSet of
names; before using a name, we check that it doesn't already exist in
the map.

When we implement parallel loading we will need to put this HashSet
behind a RwLock or similar, but that shouldn't be too difficult.