### PR TITLE
Implement more of the UFO spec

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,14 @@ pub enum Error {
     GlifWrite(GlifWriteError),
     PlistError(PlistError),
     FontInfoError,
-    GroupsError,
+    Groups(GroupsError),
+    ExpectedPlistDictionaryError,
+}
+
+#[derive(Debug)]
+pub enum GroupsError {
+    InvalidName,
+    OverlappingKerningGroups { glyph_name: String, group_name: String },
 }
 
 /// An error that occurs while parsing a .glif file
@@ -85,9 +92,12 @@ impl std::fmt::Display for Error {
             }
             Error::PlistError(e) => e.fmt(f),
             Error::FontInfoError => write!(f, "FontInfo contains invalid data"),
-            Error::GroupsError => {
-                write!(f, "Groups contain the same glyph in multiple kern1 or kern2 groups or the same group contains the same glyph multiple times.")
-            }
+            Error::Groups(ge) =>
+                match ge {
+                    GroupsError::InvalidName => write!(f, "A kerning group name must have at least one character after the common 'public.kernN.' prefix."),
+                    GroupsError::OverlappingKerningGroups {glyph_name, group_name} => write!(f, "The glyph '{}' appears in more than one kerning group. Last found in '{}'", glyph_name, group_name)
+                }
+            Error::ExpectedPlistDictionaryError => write!(f, "The files groups.plist, kerning.plist and lib.plist must contain plist dictionaries."),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@ pub enum Error {
     GlifWrite(GlifWriteError),
     PlistError(PlistError),
     FontInfoError,
+    GroupsError,
 }
 
 /// An error that occurs while parsing a .glif file
@@ -84,6 +85,9 @@ impl std::fmt::Display for Error {
             }
             Error::PlistError(e) => e.fmt(f),
             Error::FontInfoError => write!(f, "FontInfo contains invalid data"),
+            Error::GroupsError => {
+                write!(f, "Groups contain the same glyph in multiple kern1 or kern2 groups or the same group contains the same glyph multiple times.")
+            }
         }
     }
 }

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -1,11 +1,11 @@
 //! Writing out .glif files
 
-use std::io::{Cursor, Write};
-
 use quick_xml::{
     events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event},
     Error as XmlError, Writer,
 };
+use std::f32;
+use std::io::{Cursor, Write};
 
 use super::{
     Advance, Anchor, Color, Component, Contour, ContourPoint, GlifVersion, Glyph, Guideline,
@@ -162,7 +162,7 @@ impl Component {
         let mut start = BytesStart::borrowed_name(b"component");
         start.push_attribute(("base", &*self.base));
 
-        if self.transform.x_scale != 1.0 {
+        if (self.transform.x_scale - 1.0).abs() > f32::EPSILON {
             start.push_attribute(("xScale", self.transform.x_scale.to_string().as_str()));
         }
 
@@ -174,7 +174,7 @@ impl Component {
             start.push_attribute(("yxScale", self.transform.yx_scale.to_string().as_str()));
         }
 
-        if self.transform.y_scale != 1.0 {
+        if (self.transform.y_scale - 1.0).abs() > f32::EPSILON {
             start.push_attribute(("yScale", self.transform.y_scale.to_string().as_str()));
         }
 
@@ -261,7 +261,7 @@ impl Image {
         let mut start = BytesStart::borrowed_name(b"image");
         start.push_attribute(("fileName", self.file_name.to_str().unwrap_or("missing path")));
 
-        if self.transform.x_scale != 1.0 {
+        if (self.transform.x_scale - 1.0).abs() > f32::EPSILON {
             start.push_attribute(("xScale", self.transform.x_scale.to_string().as_str()));
         }
 
@@ -273,7 +273,7 @@ impl Image {
             start.push_attribute(("yxScale", self.transform.yx_scale.to_string().as_str()));
         }
 
-        if self.transform.y_scale != 1.0 {
+        if (self.transform.y_scale - 1.0).abs() > f32::EPSILON {
             start.push_attribute(("yScale", self.transform.y_scale.to_string().as_str()));
         }
 

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -43,6 +43,10 @@ impl Glyph {
             writer.write_event(Event::End(BytesEnd::borrowed(b"note")))?;
         }
 
+        if let Some(ref image) = self.image {
+            writer.write_event(image.to_event())?;
+        }
+
         if let Some(guides) = self.guidelines.as_ref() {
             for guide in guides.iter() {
                 writer.write_event(guide.to_event())?;
@@ -65,10 +69,6 @@ impl Glyph {
                 contour.write_xml(&mut writer)?;
             }
             writer.write_event(Event::End(BytesEnd::borrowed(b"outline")))?;
-        }
-
-        if let Some(ref image) = self.image {
-            writer.write_event(image.to_event())?;
         }
         writer.write_event(Event::End(BytesEnd::borrowed(b"glyph")))?;
 
@@ -124,12 +124,12 @@ impl Guideline {
             start.push_attribute(("name", name.as_str()));
         }
 
-        if let Some(Identifier(id)) = &self.identifier {
-            start.push_attribute(("identifier", id.as_str()));
-        }
-
         if let Some(color) = &self.color {
             start.push_attribute(("color", color.to_rgba_string().as_str()));
+        }
+
+        if let Some(Identifier(id)) = &self.identifier {
+            start.push_attribute(("identifier", id.as_str()));
         }
         Event::Empty(start)
     }
@@ -161,12 +161,30 @@ impl Component {
     fn to_event(&self) -> Event {
         let mut start = BytesStart::borrowed_name(b"component");
         start.push_attribute(("base", &*self.base));
-        start.push_attribute(("xScale", self.transform.x_scale.to_string().as_str()));
-        start.push_attribute(("yScale", self.transform.y_scale.to_string().as_str()));
-        start.push_attribute(("xyScale", self.transform.xy_scale.to_string().as_str()));
-        start.push_attribute(("yxScale", self.transform.yx_scale.to_string().as_str()));
-        start.push_attribute(("xOffset", self.transform.x_offset.to_string().as_str()));
-        start.push_attribute(("yOffset", self.transform.y_offset.to_string().as_str()));
+
+        if self.transform.x_scale != 1.0 {
+            start.push_attribute(("xScale", self.transform.x_scale.to_string().as_str()));
+        }
+
+        if self.transform.xy_scale != 0.0 {
+            start.push_attribute(("xyScale", self.transform.xy_scale.to_string().as_str()));
+        }
+
+        if self.transform.yx_scale != 0.0 {
+            start.push_attribute(("yxScale", self.transform.yx_scale.to_string().as_str()));
+        }
+
+        if self.transform.y_scale != 1.0 {
+            start.push_attribute(("yScale", self.transform.y_scale.to_string().as_str()));
+        }
+
+        if self.transform.x_offset != 0.0 {
+            start.push_attribute(("xOffset", self.transform.x_offset.to_string().as_str()));
+        }
+
+        if self.transform.y_offset != 0.0 {
+            start.push_attribute(("yOffset", self.transform.y_offset.to_string().as_str()));
+        }
 
         if let Some(Identifier(id)) = &self.identifier {
             start.push_attribute(("identifier", id.as_str()));
@@ -199,9 +217,15 @@ impl ContourPoint {
 
         start.push_attribute(("x", self.x.to_string().as_str()));
         start.push_attribute(("y", self.y.to_string().as_str()));
-        let smooth = if self.smooth { "yes" } else { "no" };
-        start.push_attribute(("smooth", smooth));
-        start.push_attribute(("type", self.typ.as_str()));
+
+        match self.typ {
+            PointType::OffCurve => {}
+            _ => start.push_attribute(("type", self.typ.as_str())),
+        }
+
+        if self.smooth {
+            start.push_attribute(("smooth", "yes"));
+        }
 
         if let Some(name) = &self.name {
             start.push_attribute(("name", name.as_str()));
@@ -236,12 +260,30 @@ impl Image {
     fn to_event(&self) -> Event {
         let mut start = BytesStart::borrowed_name(b"image");
         start.push_attribute(("fileName", self.file_name.to_str().unwrap_or("missing path")));
-        start.push_attribute(("xScale", self.transform.x_scale.to_string().as_str()));
-        start.push_attribute(("yScale", self.transform.y_scale.to_string().as_str()));
-        start.push_attribute(("xyScale", self.transform.xy_scale.to_string().as_str()));
-        start.push_attribute(("yxScale", self.transform.yx_scale.to_string().as_str()));
-        start.push_attribute(("xOffset", self.transform.x_offset.to_string().as_str()));
-        start.push_attribute(("yOffset", self.transform.y_offset.to_string().as_str()));
+
+        if self.transform.x_scale != 1.0 {
+            start.push_attribute(("xScale", self.transform.x_scale.to_string().as_str()));
+        }
+
+        if self.transform.xy_scale != 0.0 {
+            start.push_attribute(("xyScale", self.transform.xy_scale.to_string().as_str()));
+        }
+
+        if self.transform.yx_scale != 0.0 {
+            start.push_attribute(("yxScale", self.transform.yx_scale.to_string().as_str()));
+        }
+
+        if self.transform.y_scale != 1.0 {
+            start.push_attribute(("yScale", self.transform.y_scale.to_string().as_str()));
+        }
+
+        if self.transform.x_offset != 0.0 {
+            start.push_attribute(("xOffset", self.transform.x_offset.to_string().as_str()));
+        }
+
+        if self.transform.y_offset != 0.0 {
+            start.push_attribute(("yOffset", self.transform.y_offset.to_string().as_str()));
+        }
 
         if let Some(color) = &self.color {
             start.push_attribute(("color", color.to_rgba_string().as_str()));


### PR DESCRIPTION
1. When serializing, order glif attributes like in the specification: http://unifiedfontobject.org/versions/ufo3/glyphs/glif/ -- that is what https://github.com/unified-font-object/ufoNormalizer/ is doing.
2. Do not serialize default glif attribute values.
3. Implement loading and serializing features.fea, groups.plist, kerning.plist and lib.plist.