### PR TITLE
Error out on UFO version downgrading

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     /// An error representing our refusal to save a UFO file that was
     /// not originally created by norad.
     NotCreatedHere,
+    /// An error returned when trying to save an UFO in anything less than the latest version.
+    DowngradeUnsupported,
     IoError(IoError),
     ParseError(XmlError),
     Glif(GlifError),
@@ -83,6 +85,9 @@ impl std::fmt::Display for Error {
         match self {
             Error::NotCreatedHere => {
                 write!(f, "To prevent data loss, norad will not save files created elsewhere.")
+            }
+            Error::DowngradeUnsupported => {
+                write!(f, "Downgrading below UFO v3 is not currently supported.")
             }
             Error::IoError(e) => e.fmt(f),
             Error::ParseError(e) => e.fmt(f),

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -237,6 +237,10 @@ impl Ufo {
     }
 
     fn save_impl(&self, path: &Path) -> Result<(), Error> {
+        if self.meta.format_version != FormatVersion::V3 {
+            return Err(Error::DowngradeUnsupported);
+        }
+
         if self.meta.creator.as_str() != DEFAULT_METAINFO_CREATOR {
             return Err(Error::NotCreatedHere);
         }
@@ -408,6 +412,19 @@ mod tests {
     fn new_is_v3() {
         let font = Ufo::new();
         assert_eq!(font.meta.format_version, FormatVersion::V3);
+    }
+
+    #[test]
+    fn downgrade_unsupported() {
+        let dir = tempdir::TempDir::new("Test.ufo").unwrap();
+
+        let mut font = Ufo::new();
+        font.meta.format_version = FormatVersion::V1;
+        assert_eq!(font.save(&dir).is_err(), true);
+        font.meta.format_version = FormatVersion::V2;
+        assert_eq!(font.save(&dir).is_err(), true);
+        font.meta.format_version = FormatVersion::V3;
+        assert_eq!(font.save(&dir).is_ok(), true);
     }
 
     #[test]


### PR DESCRIPTION
(I thought about testing for the exact error in `assert_eq!` but that would require deriving `PartialEq` for all the errors?)