### PR TITLE
WIP: Upconvert UFO v1 and v2 fontinfo and feature data

### DIFF
--- a/testdata/fontinfotest_v1.ufo/fontinfo.plist
+++ b/testdata/fontinfotest_v1.ufo/fontinfo.plist
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ascender</key>
+	<integer>750</integer>
+	<key>capHeight</key>
+	<integer>750</integer>
+	<key>copyright</key>
+	<string>Copyright Some Foundry.</string>
+	<key>createdBy</key>
+	<string>Some Foundry</string>
+	<key>defaultWidth</key>
+	<integer>400</integer>
+	<key>descender</key>
+	<integer>-250</integer>
+	<key>designer</key>
+	<string>Some Designer</string>
+	<key>designerURL</key>
+	<string>http://somedesigner.com</string>
+	<key>familyName</key>
+	<string>Some Font (Family Name)</string>
+	<key>fondID</key>
+	<integer>15000</integer>
+	<key>fondName</key>
+	<string>SomeFont Regular (FOND Name)</string>
+	<key>fontName</key>
+	<string>SomeFont-Regular (Postscript Font Name)</string>
+	<key>fontStyle</key>
+	<integer>64</integer>
+	<key>fullName</key>
+	<string>Some Font-Regular (Postscript Full Name)</string>
+	<key>italicAngle</key>
+	<real>-12.5</real>
+	<key>license</key>
+	<string>License info for Some Foundry.</string>
+	<key>licenseURL</key>
+	<string>http://somefoundry.com/license</string>
+	<key>menuName</key>
+	<string>Some Font Regular (Style Map Family Name)</string>
+	<key>msCharSet</key>
+	<integer>0</integer>
+	<key>note</key>
+	<string>A note.</string>
+	<key>notice</key>
+	<string>Some Font by Some Designer for Some Foundry.</string>
+	<key>otFamilyName</key>
+	<string>Some Font (Preferred Family Name)</string>
+	<key>otMacName</key>
+	<string>Some Font Regular (Compatible Full Name)</string>
+	<key>otStyleName</key>
+	<string>Regular (Preferred Subfamily Name)</string>
+	<key>slantAngle</key>
+	<real>-12.5</real>
+	<key>styleName</key>
+	<string>Regular (Style Name)</string>
+	<key>trademark</key>
+	<string>Trademark Some Foundry</string>
+	<key>ttUniqueID</key>
+	<string>OpenType name Table Unique ID</string>
+	<key>ttVendor</key>
+	<string>SOME</string>
+	<key>ttVersion</key>
+	<string>OpenType name Table Version</string>
+	<key>uniqueID</key>
+	<integer>4000000</integer>
+	<key>unitsPerEm</key>
+	<integer>1000</integer>
+	<key>vendorURL</key>
+	<string>http://somefoundry.com</string>
+	<key>versionMajor</key>
+	<integer>1</integer>
+	<key>versionMinor</key>
+	<integer>0</integer>
+	<key>weightName</key>
+	<string>Medium</string>
+	<key>weightValue</key>
+	<integer>500</integer>
+	<key>widthName</key>
+	<string>Medium (normal)</string>
+	<key>xHeight</key>
+	<integer>500</integer>
+	<key>year</key>
+	<integer>2008</integer>
+</dict>
+</plist>
+

--- a/testdata/fontinfotest_v1.ufo/glyphs/A_.glif
+++ b/testdata/fontinfotest_v1.ufo/glyphs/A_.glif
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="A" format="1">
+  <advance width="740"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="20" y="0" type="line"/>
+      <point x="720" y="0" type="line"/>
+      <point x="720" y="700" type="line"/>
+      <point x="20" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/testdata/fontinfotest_v1.ufo/glyphs/B_.glif
+++ b/testdata/fontinfotest_v1.ufo/glyphs/B_.glif
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="B" format="1">
+  <advance width="740"/>
+  <unicode hex="0042"/>
+  <outline>
+    <contour>
+      <point x="20" y="350" type="curve" smooth="yes"/>
+      <point x="20" y="157"/>
+      <point x="177" y="0"/>
+      <point x="370" y="0" type="curve" smooth="yes"/>
+      <point x="563" y="0"/>
+      <point x="720" y="157"/>
+      <point x="720" y="350" type="curve" smooth="yes"/>
+      <point x="720" y="543"/>
+      <point x="563" y="700"/>
+      <point x="370" y="700" type="curve" smooth="yes"/>
+      <point x="177" y="700"/>
+      <point x="20" y="543"/>
+    </contour>
+  </outline>
+</glyph>

--- a/testdata/fontinfotest_v1.ufo/glyphs/contents.plist
+++ b/testdata/fontinfotest_v1.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>A</key>
+	<string>A_.glif</string>
+	<key>B</key>
+	<string>B_.glif</string>
+</dict>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/groups.plist
+++ b/testdata/fontinfotest_v1.ufo/groups.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>group1</key>
+	<array>
+		<string>A</string>
+	</array>
+	<key>group2</key>
+	<array>
+		<string>A</string>
+		<string>B</string>
+	</array>
+</dict>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/kerning.plist
+++ b/testdata/fontinfotest_v1.ufo/kerning.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>A</key>
+	<dict>
+		<key>B</key>
+		<integer>100</integer>
+	</dict>
+	<key>B</key>
+	<dict>
+		<key>A</key>
+		<integer>-200</integer>
+	</dict>
+</dict>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/lib.plist
+++ b/testdata/fontinfotest_v1.ufo/lib.plist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>org.robofab.opentype.classes</key>
+	<string>@myClass = [A B];
+</string>
+	<key>org.robofab.opentype.featureorder</key>
+	<array>
+		<string>liga</string>
+	</array>
+	<key>org.robofab.opentype.features</key>
+	<dict>
+		<key>liga</key>
+		<string>feature liga {
+    sub A A by b;
+} liga;
+</string>
+	</dict>
+	<key>org.robofab.postScriptHintData</key>
+	<dict>
+		<key>blueFuzz</key>
+		<integer>1</integer>
+		<key>blueScale</key>
+		<real>0.039625</real>
+		<key>blueShift</key>
+		<integer>7</integer>
+		<key>blueValues</key>
+		<array>
+			<array>
+				<integer>500</integer>
+				<integer>510</integer>
+			</array>
+		</array>
+		<key>familyBlues</key>
+		<array>
+			<array>
+				<integer>500</integer>
+				<integer>510</integer>
+			</array>
+		</array>
+		<key>familyOtherBlues</key>
+		<array>
+			<array>
+				<integer>-260</integer>
+				<integer>-250</integer>
+			</array>
+		</array>
+		<key>forceBold</key>
+		<true/>
+		<key>hStems</key>
+		<array>
+			<integer>100</integer>
+			<integer>120</integer>
+		</array>
+		<key>otherBlues</key>
+		<array>
+			<array>
+				<integer>-260</integer>
+				<integer>-250</integer>
+			</array>
+		</array>
+		<key>vStems</key>
+		<array>
+			<integer>80</integer>
+			<integer>90</integer>
+		</array>
+	</dict>
+	<key>org.robofab.testFontLibData</key>
+	<string>Foo Bar</string>
+</dict>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/metainfo.plist
+++ b/testdata/fontinfotest_v1.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>creator</key>
+	<string>org.robofab.ufoLib</string>
+	<key>formatVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
There's a bit to do here.

- UFO v1 stored feature code and the Postscript info attributes in lib.plist, which need to be sourced when upconverting: https://github.com/robotools/defcon/blob/a1e9d2852bb9d531ae5ec5b707fa0ab51aa202f1/Lib/defcon/objects/font.py#L1531-L1589
- UFO v1 had different names for the fontinfo attributes, some of which  need conversion: https://github.com/fonttools/fonttools/blob/master/Lib/fontTools/ufoLib/__init__.py#L1934-L1962 (and possibly more code)
- UFO v2 and v3 have the same attribute names (v3 just has more), but v3 also updates the data types for some attributes (e.g. unitsPerEm are made positive)

ufoLib is apparently made to upgrade v1 -> v2 -> v3, but I think I should go anything -> v3 directly.