### PR TITLE
Upconvert UFO v1 and v2 fontinfo and feature data

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,7 @@ pub enum Error {
     GlifWrite(GlifWriteError),
     PlistError(PlistError),
     FontInfoError,
+    FontInfoUpconversionError,
     GroupsError(GroupsValidationError),
     GroupsUpconversionError(GroupsValidationError),
     ExpectedPlistDictionaryError,
@@ -100,6 +101,7 @@ impl std::fmt::Display for Error {
             }
             Error::PlistError(e) => e.fmt(f),
             Error::FontInfoError => write!(f, "FontInfo contains invalid data"),
+            Error::FontInfoUpconversionError => write!(f, "FontInfo contains invalid data after upconversion"),
             Error::GroupsError(ge) => ge.fmt(f),
             Error::GroupsUpconversionError(ge) => write!(f, "Upconverting UFO v1 or v2 kerning data to v3 failed: {}", ge),
             Error::ExpectedPlistDictionaryError => write!(f, "The files groups.plist, kerning.plist and lib.plist must contain plist dictionaries."),

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde::de::Deserializer;
 use serde::ser::{SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
@@ -6,7 +8,7 @@ use crate::shared_types::{
     Bitlist, Float, Guideline, Integer, IntegerOrFloat, NonNegativeInteger,
     NonNegativeIntegerOrFloat,
 };
-use crate::Error;
+use crate::{Error, FormatVersion};
 
 /// The contents of the [`fontinfo.plist`][] file. This structure is hard-wired to the
 /// available attributes in UFO version 3.
@@ -163,7 +165,444 @@ pub struct FontInfo {
     pub year: Option<Integer>,
 }
 
+/// The contents of the [`fontinfo.plist`][] file specified for UFO version 2. Its only purpose is
+/// to enable upconversion.
+///
+/// [`fontinfo.plist`]: http://unifiedfontobject.org/versions/ufo2/fontinfo.plist/
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(non_snake_case)]
+struct FontInfoV2 {
+    ascender: Option<IntegerOrFloat>,
+    capHeight: Option<IntegerOrFloat>,
+    copyright: Option<String>,
+    descender: Option<IntegerOrFloat>,
+    familyName: Option<String>,
+    italicAngle: Option<IntegerOrFloat>,
+    macintoshFONDFamilyID: Option<Integer>,
+    macintoshFONDName: Option<String>,
+    note: Option<String>,
+    openTypeHeadCreated: Option<String>,
+    openTypeHeadFlags: Option<Bitlist>,
+    openTypeHeadLowestRecPPEM: Option<IntegerOrFloat>,
+    openTypeHheaAscender: Option<IntegerOrFloat>,
+    openTypeHheaCaretOffset: Option<IntegerOrFloat>,
+    openTypeHheaCaretSlopeRise: Option<Integer>,
+    openTypeHheaCaretSlopeRun: Option<Integer>,
+    openTypeHheaDescender: Option<IntegerOrFloat>,
+    openTypeHheaLineGap: Option<IntegerOrFloat>,
+    openTypeNameCompatibleFullName: Option<String>,
+    openTypeNameDescription: Option<String>,
+    openTypeNameDesigner: Option<String>,
+    openTypeNameDesignerURL: Option<String>,
+    openTypeNameLicense: Option<String>,
+    openTypeNameLicenseURL: Option<String>,
+    openTypeNameManufacturer: Option<String>,
+    openTypeNameManufacturerURL: Option<String>,
+    openTypeNamePreferredFamilyName: Option<String>,
+    openTypeNamePreferredSubfamilyName: Option<String>,
+    openTypeNameSampleText: Option<String>,
+    openTypeNameUniqueID: Option<String>,
+    openTypeNameVersion: Option<String>,
+    openTypeNameWWSFamilyName: Option<String>,
+    openTypeNameWWSSubfamilyName: Option<String>,
+    openTypeOS2CodePageRanges: Option<Bitlist>,
+    openTypeOS2FamilyClass: Option<OS2FamilyClass>,
+    openTypeOS2Panose: Option<OS2PanoseV2>,
+    openTypeOS2Selection: Option<Bitlist>,
+    openTypeOS2StrikeoutPosition: Option<IntegerOrFloat>,
+    openTypeOS2StrikeoutSize: Option<IntegerOrFloat>,
+    openTypeOS2SubscriptXOffset: Option<IntegerOrFloat>,
+    openTypeOS2SubscriptXSize: Option<IntegerOrFloat>,
+    openTypeOS2SubscriptYOffset: Option<IntegerOrFloat>,
+    openTypeOS2SubscriptYSize: Option<IntegerOrFloat>,
+    openTypeOS2SuperscriptXOffset: Option<IntegerOrFloat>,
+    openTypeOS2SuperscriptXSize: Option<IntegerOrFloat>,
+    openTypeOS2SuperscriptYOffset: Option<IntegerOrFloat>,
+    openTypeOS2SuperscriptYSize: Option<IntegerOrFloat>,
+    openTypeOS2Type: Option<Bitlist>,
+    openTypeOS2TypoAscender: Option<IntegerOrFloat>,
+    openTypeOS2TypoDescender: Option<IntegerOrFloat>,
+    openTypeOS2TypoLineGap: Option<IntegerOrFloat>,
+    openTypeOS2UnicodeRanges: Option<Bitlist>,
+    openTypeOS2VendorID: Option<String>,
+    openTypeOS2WeightClass: Option<NonNegativeInteger>,
+    openTypeOS2WidthClass: Option<OS2WidthClass>,
+    openTypeOS2WinAscent: Option<IntegerOrFloat>,
+    openTypeOS2WinDescent: Option<IntegerOrFloat>,
+    openTypeVheaCaretOffset: Option<IntegerOrFloat>,
+    openTypeVheaCaretSlopeRise: Option<Integer>,
+    openTypeVheaCaretSlopeRun: Option<Integer>,
+    openTypeVheaVertTypoAscender: Option<IntegerOrFloat>,
+    openTypeVheaVertTypoDescender: Option<IntegerOrFloat>,
+    openTypeVheaVertTypoLineGap: Option<IntegerOrFloat>,
+    postscriptBlueFuzz: Option<IntegerOrFloat>,
+    postscriptBlueScale: Option<Float>,
+    postscriptBlueShift: Option<IntegerOrFloat>,
+    postscriptBlueValues: Option<Vec<IntegerOrFloat>>,
+    postscriptDefaultCharacter: Option<String>,
+    postscriptDefaultWidthX: Option<IntegerOrFloat>,
+    postscriptFamilyBlues: Option<Vec<IntegerOrFloat>>,
+    postscriptFamilyOtherBlues: Option<Vec<IntegerOrFloat>>,
+    postscriptFontName: Option<String>,
+    postscriptForceBold: Option<bool>,
+    postscriptFullName: Option<String>,
+    postscriptIsFixedPitch: Option<bool>,
+    postscriptNominalWidthX: Option<IntegerOrFloat>,
+    postscriptOtherBlues: Option<Vec<IntegerOrFloat>>,
+    postscriptSlantAngle: Option<IntegerOrFloat>,
+    postscriptStemSnapH: Option<Vec<IntegerOrFloat>>,
+    postscriptStemSnapV: Option<Vec<IntegerOrFloat>>,
+    postscriptUnderlinePosition: Option<IntegerOrFloat>,
+    postscriptUnderlineThickness: Option<IntegerOrFloat>,
+    postscriptUniqueID: Option<Integer>,
+    postscriptWeightName: Option<String>,
+    postscriptWindowsCharacterSet: Option<PostscriptWindowsCharacterSet>,
+    styleMapFamilyName: Option<String>,
+    styleMapStyleName: Option<StyleMapStyle>,
+    styleName: Option<String>,
+    trademark: Option<String>,
+    unitsPerEm: Option<IntegerOrFloat>,
+    versionMajor: Option<Integer>,
+    versionMinor: Option<Integer>,
+    xHeight: Option<IntegerOrFloat>,
+    year: Option<Integer>,
+}
+
+/// The contents of the [`fontinfo.plist`][] file specified for UFO version 1. Its only purpose is
+/// to enable upconversion.
+///
+/// [`fontinfo.plist`]: http://unifiedfontobject.org/versions/ufo1/fontinfo.plist/
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+#[allow(non_snake_case)]
+struct FontInfoV1 {
+    ascender: Option<IntegerOrFloat>,
+    capHeight: Option<IntegerOrFloat>,
+    copyright: Option<String>,
+    createdBy: Option<String>,
+    defaultWidth: Option<IntegerOrFloat>,
+    descender: Option<IntegerOrFloat>,
+    designer: Option<String>,
+    designerURL: Option<String>,
+    familyName: Option<String>,
+    fondID: Option<Integer>,
+    fondName: Option<String>,
+    fontName: Option<String>,
+    fontStyle: Option<Integer>,
+    fullName: Option<String>,
+    italicAngle: Option<IntegerOrFloat>,
+    license: Option<String>,
+    licenseURL: Option<String>,
+    menuName: Option<String>,
+    msCharSet: Option<Integer>,
+    note: Option<String>,
+    notice: Option<String>,
+    otFamilyName: Option<String>,
+    otMacName: Option<String>,
+    otStyleName: Option<String>,
+    slantAngle: Option<IntegerOrFloat>,
+    styleName: Option<String>,
+    trademark: Option<String>,
+    ttUniqueID: Option<String>,
+    ttVendor: Option<String>,
+    ttVersion: Option<String>,
+    uniqueID: Option<Integer>,
+    unitsPerEm: Option<IntegerOrFloat>,
+    vendorURL: Option<String>,
+    versionMajor: Option<Integer>,
+    versionMinor: Option<Integer>,
+    weightName: Option<String>,
+    weightValue: Option<Integer>,
+    widthName: Option<String>,
+    xHeight: Option<IntegerOrFloat>, // Does not appear in spec but ufoLib.
+    year: Option<Integer>,           // Does not appear in spec but ufoLib.
+}
+
 impl FontInfo {
+    /// Create FontInfo from a file, upgrading from the supplied format_version to the highest
+    /// internally supported version.
+    ///
+    /// The conversion follows what ufoLib and defcon are doing, e.g. various fields that were
+    /// implicitly signed integers before and are unsigned integers in the newest spec, are
+    /// converted by taking their absolute value. Fields that could be floats before and are
+    /// integers now are rounded. Fields that could be floats before and are unsigned integers
+    /// now are rounded before taking their absolute value.
+    pub fn from_file<P: AsRef<Path>>(
+        path: P,
+        format_version: FormatVersion,
+    ) -> Result<Self, Error> {
+        match format_version {
+            FormatVersion::V3 => {
+                let fontinfo: FontInfo = plist::from_file(path)?;
+                fontinfo.validate()?;
+                Ok(fontinfo)
+            }
+            FormatVersion::V2 => {
+                let fontinfo_v2: FontInfoV2 = plist::from_file(path)?;
+                let fontinfo = FontInfo {
+                    ascender: fontinfo_v2.ascender,
+                    cap_height: fontinfo_v2.capHeight,
+                    copyright: fontinfo_v2.copyright,
+                    descender: fontinfo_v2.descender,
+                    family_name: fontinfo_v2.familyName,
+                    italic_angle: fontinfo_v2.italicAngle,
+                    macintosh_fond_family_id: fontinfo_v2.macintoshFONDFamilyID,
+                    macintosh_fond_name: fontinfo_v2.macintoshFONDName,
+                    note: fontinfo_v2.note,
+                    open_type_head_created: fontinfo_v2.openTypeHeadCreated,
+                    open_type_head_flags: fontinfo_v2.openTypeHeadFlags,
+                    open_type_head_lowest_rec_ppem: fontinfo_v2
+                        .openTypeHeadLowestRecPPEM
+                        .map(|v| v.round().abs() as NonNegativeInteger),
+                    open_type_hhea_ascender: fontinfo_v2
+                        .openTypeHheaAscender
+                        .map(|v| v.round() as Integer),
+                    open_type_hhea_caret_offset: fontinfo_v2
+                        .openTypeHheaCaretOffset
+                        .map(|v| v.round() as Integer),
+                    open_type_hhea_caret_slope_rise: fontinfo_v2.openTypeHheaCaretSlopeRise,
+                    open_type_hhea_caret_slope_run: fontinfo_v2.openTypeHheaCaretSlopeRun,
+                    open_type_hhea_descender: fontinfo_v2
+                        .openTypeHheaDescender
+                        .map(|v| v.round() as Integer),
+                    open_type_hhea_line_gap: fontinfo_v2
+                        .openTypeHheaLineGap
+                        .map(|v| v.round() as Integer),
+                    open_type_name_compatible_full_name: fontinfo_v2.openTypeNameCompatibleFullName,
+                    open_type_name_description: fontinfo_v2.openTypeNameDescription,
+                    open_type_name_designer: fontinfo_v2.openTypeNameDesigner,
+                    open_type_name_designer_url: fontinfo_v2.openTypeNameDesignerURL,
+                    open_type_name_license: fontinfo_v2.openTypeNameLicense,
+                    open_type_name_license_url: fontinfo_v2.openTypeNameLicenseURL,
+                    open_type_name_manufacturer: fontinfo_v2.openTypeNameManufacturer,
+                    open_type_name_manufacturer_url: fontinfo_v2.openTypeNameManufacturerURL,
+                    open_type_name_preferred_family_name: fontinfo_v2
+                        .openTypeNamePreferredFamilyName,
+                    open_type_name_preferred_subfamily_name: fontinfo_v2
+                        .openTypeNamePreferredSubfamilyName,
+                    open_type_name_sample_text: fontinfo_v2.openTypeNameSampleText,
+                    open_type_name_unique_id: fontinfo_v2.openTypeNameUniqueID,
+                    open_type_name_version: fontinfo_v2.openTypeNameVersion,
+                    open_type_name_wws_family_name: fontinfo_v2.openTypeNameWWSFamilyName,
+                    open_type_name_wws_subfamily_name: fontinfo_v2.openTypeNameWWSSubfamilyName,
+                    open_type_os2_code_page_ranges: fontinfo_v2.openTypeOS2CodePageRanges,
+                    open_type_os2_family_class: fontinfo_v2.openTypeOS2FamilyClass,
+                    open_type_os2_panose: fontinfo_v2.openTypeOS2Panose.map(OS2Panose::from),
+                    open_type_os2_selection: fontinfo_v2.openTypeOS2Selection,
+                    open_type_os2_strikeout_position: fontinfo_v2
+                        .openTypeOS2StrikeoutPosition
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_strikeout_size: fontinfo_v2
+                        .openTypeOS2StrikeoutSize
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_subscript_x_offset: fontinfo_v2
+                        .openTypeOS2SubscriptXOffset
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_subscript_x_size: fontinfo_v2
+                        .openTypeOS2SubscriptXSize
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_subscript_y_offset: fontinfo_v2
+                        .openTypeOS2SubscriptYOffset
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_subscript_y_size: fontinfo_v2
+                        .openTypeOS2SubscriptYSize
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_superscript_x_offset: fontinfo_v2
+                        .openTypeOS2SuperscriptXOffset
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_superscript_x_size: fontinfo_v2
+                        .openTypeOS2SuperscriptXSize
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_superscript_y_offset: fontinfo_v2
+                        .openTypeOS2SuperscriptYOffset
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_superscript_y_size: fontinfo_v2
+                        .openTypeOS2SuperscriptYSize
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_type: fontinfo_v2.openTypeOS2Type,
+                    open_type_os2_typo_ascender: fontinfo_v2
+                        .openTypeOS2TypoAscender
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_typo_descender: fontinfo_v2
+                        .openTypeOS2TypoDescender
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_typo_line_gap: fontinfo_v2
+                        .openTypeOS2TypoLineGap
+                        .map(|v| v.round() as Integer),
+                    open_type_os2_unicode_ranges: fontinfo_v2.openTypeOS2UnicodeRanges,
+                    open_type_os2_vendor_id: fontinfo_v2.openTypeOS2VendorID,
+                    open_type_os2_weight_class: fontinfo_v2.openTypeOS2WeightClass,
+                    open_type_os2_width_class: fontinfo_v2.openTypeOS2WidthClass,
+                    open_type_os2_win_ascent: fontinfo_v2
+                        .openTypeOS2WinAscent
+                        .map(|v| v.round().abs() as NonNegativeInteger),
+                    open_type_os2_win_descent: fontinfo_v2
+                        .openTypeOS2WinDescent
+                        .map(|v| v.round().abs() as NonNegativeInteger),
+                    open_type_vhea_caret_offset: fontinfo_v2
+                        .openTypeVheaCaretOffset
+                        .map(|v| v.round() as Integer),
+                    open_type_vhea_caret_slope_rise: fontinfo_v2.openTypeVheaCaretSlopeRise,
+                    open_type_vhea_caret_slope_run: fontinfo_v2.openTypeVheaCaretSlopeRun,
+                    open_type_vhea_vert_typo_ascender: fontinfo_v2
+                        .openTypeVheaVertTypoAscender
+                        .map(|v| v.round() as Integer),
+                    open_type_vhea_vert_typo_descender: fontinfo_v2
+                        .openTypeVheaVertTypoDescender
+                        .map(|v| v.round() as Integer),
+                    open_type_vhea_vert_typo_line_gap: fontinfo_v2
+                        .openTypeVheaVertTypoLineGap
+                        .map(|v| v.round() as Integer),
+                    postscript_blue_fuzz: fontinfo_v2.postscriptBlueFuzz,
+                    postscript_blue_scale: fontinfo_v2.postscriptBlueScale,
+                    postscript_blue_shift: fontinfo_v2.postscriptBlueShift,
+                    postscript_blue_values: fontinfo_v2.postscriptBlueValues,
+                    postscript_default_character: fontinfo_v2.postscriptDefaultCharacter,
+                    postscript_default_width_x: fontinfo_v2.postscriptDefaultWidthX,
+                    postscript_family_blues: fontinfo_v2.postscriptFamilyBlues,
+                    postscript_family_other_blues: fontinfo_v2.postscriptFamilyOtherBlues,
+                    postscript_font_name: fontinfo_v2.postscriptFontName,
+                    postscript_force_bold: fontinfo_v2.postscriptForceBold,
+                    postscript_full_name: fontinfo_v2.postscriptFullName,
+                    postscript_is_fixed_pitch: fontinfo_v2.postscriptIsFixedPitch,
+                    postscript_nominal_width_x: fontinfo_v2.postscriptNominalWidthX,
+                    postscript_other_blues: fontinfo_v2.postscriptOtherBlues,
+                    postscript_slant_angle: fontinfo_v2.postscriptSlantAngle,
+                    postscript_stem_snap_h: fontinfo_v2.postscriptStemSnapH,
+                    postscript_stem_snap_v: fontinfo_v2.postscriptStemSnapV,
+                    postscript_underline_position: fontinfo_v2.postscriptUnderlinePosition,
+                    postscript_underline_thickness: fontinfo_v2.postscriptUnderlineThickness,
+                    postscript_unique_id: fontinfo_v2.postscriptUniqueID,
+                    postscript_weight_name: fontinfo_v2.postscriptWeightName,
+                    postscript_windows_character_set: fontinfo_v2.postscriptWindowsCharacterSet,
+                    style_map_family_name: fontinfo_v2.styleMapFamilyName,
+                    style_map_style_name: fontinfo_v2.styleMapStyleName,
+                    style_name: fontinfo_v2.styleName,
+                    trademark: fontinfo_v2.trademark,
+                    units_per_em: fontinfo_v2
+                        .unitsPerEm
+                        .map(|v| NonNegativeIntegerOrFloat::new(v.abs()).unwrap()),
+                    version_major: fontinfo_v2.versionMajor,
+                    version_minor: fontinfo_v2.versionMinor.map(|v| v.abs() as NonNegativeInteger),
+                    x_height: fontinfo_v2.xHeight,
+                    year: fontinfo_v2.year,
+                    ..FontInfo::default()
+                };
+                fontinfo.validate().map_err(|_| Error::FontInfoUpconversionError)?;
+                Ok(fontinfo)
+            }
+            FormatVersion::V1 => {
+                let fontinfo_v1: FontInfoV1 = plist::from_file(path)?;
+                let fontinfo = FontInfo {
+                    ascender: fontinfo_v1.ascender,
+                    cap_height: fontinfo_v1.capHeight,
+                    copyright: fontinfo_v1.copyright,
+                    descender: fontinfo_v1.descender,
+                    family_name: fontinfo_v1.familyName,
+                    italic_angle: fontinfo_v1.italicAngle,
+                    macintosh_fond_family_id: fontinfo_v1.fondID,
+                    macintosh_fond_name: fontinfo_v1.fondName,
+                    note: fontinfo_v1.note,
+                    open_type_name_compatible_full_name: fontinfo_v1.otMacName,
+                    open_type_name_description: fontinfo_v1.notice,
+                    open_type_name_designer_url: fontinfo_v1.designerURL,
+                    open_type_name_designer: fontinfo_v1.designer,
+                    open_type_name_license_url: fontinfo_v1.licenseURL,
+                    open_type_name_license: fontinfo_v1.license,
+                    open_type_name_manufacturer_url: fontinfo_v1.vendorURL,
+                    open_type_name_manufacturer: fontinfo_v1.createdBy,
+                    open_type_name_preferred_family_name: fontinfo_v1.otFamilyName,
+                    open_type_name_preferred_subfamily_name: fontinfo_v1.otStyleName,
+                    open_type_name_unique_id: fontinfo_v1.ttUniqueID,
+                    open_type_name_version: fontinfo_v1.ttVersion,
+                    open_type_os2_vendor_id: fontinfo_v1.ttVendor,
+                    open_type_os2_weight_class: match fontinfo_v1.weightValue {
+                        Some(v) => match v {
+                            -1 => None,
+                            _ => Some(v.abs() as NonNegativeInteger),
+                        },
+                        None => None,
+                    },
+                    open_type_os2_width_class: match fontinfo_v1.widthName {
+                        Some(v) => match v.as_ref() {
+                            "Ultra-condensed" => Some(OS2WidthClass::UltraCondensed),
+                            "Extra-condensed" => Some(OS2WidthClass::ExtraCondensed),
+                            "Condensed" => Some(OS2WidthClass::Condensed),
+                            "Semi-condensed" => Some(OS2WidthClass::SemiCondensed),
+                            "Medium (normal)" => Some(OS2WidthClass::Normal),
+                            "Normal" => Some(OS2WidthClass::Normal),
+                            "All" => Some(OS2WidthClass::Normal),
+                            "medium" => Some(OS2WidthClass::Normal),
+                            "Medium" => Some(OS2WidthClass::Normal),
+                            "Semi-expanded" => Some(OS2WidthClass::SemiExpanded),
+                            "Expanded" => Some(OS2WidthClass::Expanded),
+                            "Extra-expanded" => Some(OS2WidthClass::ExtraExpanded),
+                            "Ultra-expanded" => Some(OS2WidthClass::UltraExpanded),
+                            _ => return Err(Error::FontInfoError),
+                        },
+                        None => None,
+                    },
+                    postscript_default_width_x: fontinfo_v1.defaultWidth,
+                    postscript_font_name: fontinfo_v1.fontName,
+                    postscript_full_name: fontinfo_v1.fullName,
+                    postscript_slant_angle: fontinfo_v1.slantAngle,
+                    postscript_unique_id: fontinfo_v1.uniqueID,
+                    postscript_weight_name: fontinfo_v1.weightName,
+                    postscript_windows_character_set: match fontinfo_v1.msCharSet {
+                        Some(v) => match v {
+                            0 => Some(PostscriptWindowsCharacterSet::ANSI),
+                            1 => Some(PostscriptWindowsCharacterSet::Default),
+                            2 => Some(PostscriptWindowsCharacterSet::Symbol),
+                            77 => Some(PostscriptWindowsCharacterSet::Macintosh),
+                            128 => Some(PostscriptWindowsCharacterSet::ShiftJIS),
+                            129 => Some(PostscriptWindowsCharacterSet::Hangul),
+                            130 => Some(PostscriptWindowsCharacterSet::HangulJohab),
+                            134 => Some(PostscriptWindowsCharacterSet::GB2312),
+                            136 => Some(PostscriptWindowsCharacterSet::ChineseBIG5),
+                            161 => Some(PostscriptWindowsCharacterSet::Greek),
+                            162 => Some(PostscriptWindowsCharacterSet::Turkish),
+                            163 => Some(PostscriptWindowsCharacterSet::Vietnamese),
+                            177 => Some(PostscriptWindowsCharacterSet::Hebrew),
+                            178 => Some(PostscriptWindowsCharacterSet::Arabic),
+                            186 => Some(PostscriptWindowsCharacterSet::Baltic),
+                            200 => Some(PostscriptWindowsCharacterSet::Bitstream),
+                            204 => Some(PostscriptWindowsCharacterSet::Cyrillic),
+                            222 => Some(PostscriptWindowsCharacterSet::Thai),
+                            238 => Some(PostscriptWindowsCharacterSet::EasternEuropean),
+                            255 => Some(PostscriptWindowsCharacterSet::OEM),
+                            _ => return Err(Error::FontInfoError),
+                        },
+                        None => None,
+                    },
+                    style_map_family_name: fontinfo_v1.menuName,
+                    style_map_style_name: match fontinfo_v1.fontStyle {
+                        Some(v) => match v {
+                            0 | 64 => Some(StyleMapStyle::Regular),
+                            1 => Some(StyleMapStyle::Italic),
+                            32 => Some(StyleMapStyle::Bold),
+                            33 => Some(StyleMapStyle::BoldItalic),
+                            _ => return Err(Error::FontInfoError),
+                        },
+                        None => None,
+                    },
+                    style_name: fontinfo_v1.styleName,
+                    trademark: fontinfo_v1.trademark,
+                    units_per_em: fontinfo_v1
+                        .unitsPerEm
+                        .map(|v| NonNegativeIntegerOrFloat::new(v.abs()).unwrap()),
+                    version_major: fontinfo_v1.versionMajor,
+                    version_minor: fontinfo_v1.versionMinor.map(|v| v.abs() as NonNegativeInteger),
+                    x_height: fontinfo_v1.xHeight,
+                    year: fontinfo_v1.year,
+                    ..FontInfo::default()
+                };
+                fontinfo.validate().map_err(|_| Error::FontInfoUpconversionError)?;
+                Ok(fontinfo)
+            }
+        }
+    }
+
     /// Validates various fields according to the [specification][].
     ///
     /// [specification]: http://unifiedfontobject.org/versions/ufo3/fontinfo.plist/
@@ -443,6 +882,66 @@ impl<'de> Deserialize<'de> for OS2Panose {
         }
 
         Ok(OS2Panose {
+            family_type: values[0],
+            serif_style: values[1],
+            weight: values[2],
+            proportion: values[3],
+            contrast: values[4],
+            stroke_variation: values[5],
+            arm_style: values[6],
+            letterform: values[7],
+            midline: values[8],
+            x_height: values[9],
+        })
+    }
+}
+
+impl From<OS2PanoseV2> for OS2Panose {
+    fn from(value: OS2PanoseV2) -> Self {
+        OS2Panose {
+            family_type: value.family_type.abs() as NonNegativeInteger,
+            serif_style: value.serif_style.abs() as NonNegativeInteger,
+            weight: value.weight.abs() as NonNegativeInteger,
+            proportion: value.proportion.abs() as NonNegativeInteger,
+            contrast: value.contrast.abs() as NonNegativeInteger,
+            stroke_variation: value.stroke_variation.abs() as NonNegativeInteger,
+            arm_style: value.arm_style.abs() as NonNegativeInteger,
+            letterform: value.letterform.abs() as NonNegativeInteger,
+            midline: value.midline.abs() as NonNegativeInteger,
+            x_height: value.x_height.abs() as NonNegativeInteger,
+        }
+    }
+}
+
+/// OS2PanoseV2 is from UFO v2 and allows negative integers, while the OpenType specification
+/// specifies unsigned integers.
+#[derive(Debug, Clone, Default, PartialEq)]
+struct OS2PanoseV2 {
+    family_type: Integer,
+    serif_style: Integer,
+    weight: Integer,
+    proportion: Integer,
+    contrast: Integer,
+    stroke_variation: Integer,
+    arm_style: Integer,
+    letterform: Integer,
+    midline: Integer,
+    x_height: Integer,
+}
+
+impl<'de> Deserialize<'de> for OS2PanoseV2 {
+    fn deserialize<D>(deserializer: D) -> Result<OS2PanoseV2, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let values: Vec<Integer> = Deserialize::deserialize(deserializer)?;
+        if values.len() != 10 {
+            return Err(serde::de::Error::custom(
+                "openTypeOS2Panose must have exactly ten elements.",
+            ));
+        }
+
+        Ok(OS2PanoseV2 {
             family_type: values[0],
             serif_style: values[1],
             weight: values[2],

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -12,7 +12,7 @@ use crate::Error;
 /// available attributes in UFO version 3.
 ///
 /// [`fontinfo.plist`]: http://unifiedfontobject.org/versions/ufo3/fontinfo.plist/
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct FontInfo {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -18,7 +18,7 @@ static CONTENTS_FILE: &str = "contents.plist";
 /// is just a collection of glyphs.
 ///
 /// [layer]: http://unifiedfontobject.org/versions/ufo3/glyphs/
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Layer {
     pub(crate) glyphs: BTreeMap<GlyphName, Arc<Glyph>>,
     contents: BTreeMap<GlyphName, PathBuf>,

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -132,10 +132,10 @@ impl Ufo {
         fn load_impl(path: &Path) -> Result<Ufo, Error> {
             let meta_path = path.join(METAINFO_FILE);
             let mut meta: MetaInfo = plist::from_file(meta_path)?;
+
             let fontinfo_path = path.join(FONTINFO_FILE);
-            let font_info = if fontinfo_path.exists() {
-                let font_info: FontInfo = plist::from_file(fontinfo_path)?;
-                font_info.validate()?;
+            let mut font_info = if fontinfo_path.exists() {
+                let font_info: FontInfo = FontInfo::from_file(fontinfo_path, meta.format_version)?;
                 Some(font_info)
             } else {
                 None

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -15,7 +15,7 @@ use crate::fontinfo::FontInfo;
 use crate::glyph::{Glyph, GlyphName};
 use crate::layer::Layer;
 use crate::names::NameList;
-use crate::upconversion::upconvert_kerning;
+use crate::upconversion;
 use crate::Error;
 
 static LAYER_CONTENTS_FILE: &str = "layercontents.plist";
@@ -142,10 +142,10 @@ impl Ufo {
             };
 
             let lib_path = path.join(LIB_FILE);
-            let lib = if lib_path.exists() {
+            let mut lib = if lib_path.exists() {
                 // Value::as_dictionary(_mut) will only borrow the data, but we want to own it.
                 // https://github.com/ebarnard/rust-plist/pull/48
-                match plist::Value::from_file(lib_path)? {
+                match plist::Value::from_file(&lib_path)? {
                     plist::Value::Dictionary(dict) => Some(dict),
                     _ => return Err(Error::ExpectedPlistDictionaryError),
                 }
@@ -171,7 +171,7 @@ impl Ufo {
             };
 
             let features_path = path.join(FEATURES_FILE);
-            let features = if features_path.exists() {
+            let mut features = if features_path.exists() {
                 let features = fs::read_to_string(features_path)?;
                 Some(features)
             } else {
@@ -205,11 +205,33 @@ impl Ufo {
                 (_, None, k) => (None, k), // Without a groups.plist, there's nothing to upgrade.
                 (_, Some(g), k) => {
                     let (groups, kerning) =
-                        upconvert_kerning(&g, &k.unwrap_or_default(), &glyph_names);
+                        upconversion::upconvert_kerning(&g, &k.unwrap_or_default(), &glyph_names);
                     validate_groups(&groups).map_err(Error::GroupsUpconversionError)?;
                     (Some(groups), Some(kerning))
                 }
             };
+
+            // The v1 format stores some Postscript hinting related data in the lib,
+            // which we only import into fontinfo if we're reading a v1 UFO.
+            if meta.format_version == FormatVersion::V1 {
+                let mut feature_text = String::new();
+                let mut fontinfo =
+                    if let Some(fontinfo) = font_info { fontinfo } else { FontInfo::default() };
+
+                if let Some(lib_data) = &mut lib {
+                    upconversion::upconvert_ufov1_robofab_data(
+                        &lib_path,
+                        lib_data,
+                        &mut feature_text,
+                        &mut fontinfo,
+                    )?;
+                }
+
+                if !feature_text.is_empty() {
+                    features = Some(feature_text);
+                }
+                font_info = Some(fontinfo);
+            }
 
             meta.format_version = FormatVersion::V3;
 
@@ -407,6 +429,7 @@ fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidationError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shared_types::IntegerOrFloat;
 
     #[test]
     fn new_is_v3() {
@@ -443,6 +466,73 @@ mod tests {
         assert_eq!(font_obj.groups.unwrap().get("public.kern1.@MMK_L_A"), Some(&vec!["A".into()]));
         assert_eq!(font_obj.kerning.unwrap().get("B").unwrap().get("H").unwrap(), &-40.0);
         assert_eq!(font_obj.features.unwrap(), "# this is the feature from lightWide\n");
+    }
+
+    #[test]
+    fn upconvert_ufov1_robofab_data() {
+        let path = "testdata/fontinfotest_v1.ufo";
+        let font = Ufo::load(path).unwrap();
+
+        assert_eq!(font.meta.format_version, FormatVersion::V3);
+
+        let font_info = font.font_info.unwrap();
+        assert_eq!(font_info.postscript_blue_fuzz, Some(IntegerOrFloat::from(1)));
+        assert_eq!(font_info.postscript_blue_scale, Some(0.039625));
+        assert_eq!(font_info.postscript_blue_shift, Some(IntegerOrFloat::from(7)));
+        assert_eq!(
+            font_info.postscript_blue_values,
+            Some(vec![
+                IntegerOrFloat::from(-10),
+                IntegerOrFloat::from(0),
+                IntegerOrFloat::from(482),
+                IntegerOrFloat::from(492),
+                IntegerOrFloat::from(694),
+                IntegerOrFloat::from(704),
+                IntegerOrFloat::from(739),
+                IntegerOrFloat::from(749)
+            ])
+        );
+        assert_eq!(
+            font_info.postscript_other_blues,
+            Some(vec![IntegerOrFloat::from(-260), IntegerOrFloat::from(-250)])
+        );
+        assert_eq!(
+            font_info.postscript_family_blues,
+            Some(vec![IntegerOrFloat::from(500.0), IntegerOrFloat::from(510.0)])
+        );
+        assert_eq!(
+            font_info.postscript_family_other_blues,
+            Some(vec![IntegerOrFloat::from(-260), IntegerOrFloat::from(-250)])
+        );
+        assert_eq!(font_info.postscript_force_bold, Some(true));
+        assert_eq!(
+            font_info.postscript_stem_snap_h,
+            Some(vec![IntegerOrFloat::from(100), IntegerOrFloat::from(120)])
+        );
+        assert_eq!(
+            font_info.postscript_stem_snap_v,
+            Some(vec![IntegerOrFloat::from(80), IntegerOrFloat::from(90)])
+        );
+
+        assert_eq!(
+            font.lib.unwrap().keys().collect::<Vec<&String>>(),
+            vec!["org.robofab.testFontLibData"]
+        );
+
+        assert_eq!(
+            font.features.unwrap(),
+            "@myClass = [A B];\n\nfeature liga {\n    sub A A by b;\n} liga;\n"
+        );
+    }
+
+    #[test]
+    fn upconversion_fontinfo_v123() {
+        let ufo_v1 = Ufo::load("testdata/fontinfotest_v1.ufo").unwrap();
+        let ufo_v2 = Ufo::load("testdata/fontinfotest_v2.ufo").unwrap();
+        let ufo_v3 = Ufo::load("testdata/fontinfotest_v3.ufo").unwrap();
+
+        assert_eq!(ufo_v1, ufo_v3);
+        assert_eq!(ufo_v2, ufo_v3);
     }
 
     #[test]

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -38,7 +38,7 @@ pub type Groups = BTreeMap<String, Vec<GlyphName>>;
 pub type Kerning = BTreeMap<String, BTreeMap<String, f32>>;
 
 /// A Unified Font Object.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Ufo {
     pub meta: MetaInfo,
     pub font_info: Option<FontInfo>,
@@ -76,7 +76,7 @@ impl Default for Ufo {
 /// This corresponds to a 'glyphs' directory on disk.
 ///
 /// [font layer]: http://unifiedfontobject.org/versions/ufo3/glyphs/
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LayerInfo {
     pub name: String,
     pub path: PathBuf,
@@ -97,7 +97,7 @@ pub enum FormatVersion {
 /// The contents of the [`metainfo.plist`] file.
 ///
 /// [`metainfo.plist`]: http://unifiedfontobject.org/versions/ufo3/metainfo.plist/
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetaInfo {
     pub creator: String,

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -214,21 +214,20 @@ impl Ufo {
             // The v1 format stores some Postscript hinting related data in the lib,
             // which we only import into fontinfo if we're reading a v1 UFO.
             if meta.format_version == FormatVersion::V1 {
-                let mut feature_text = String::new();
                 let mut fontinfo =
                     if let Some(fontinfo) = font_info { fontinfo } else { FontInfo::default() };
 
+                let mut features_upgraded: Option<String> = None;
                 if let Some(lib_data) = &mut lib {
-                    upconversion::upconvert_ufov1_robofab_data(
+                    features_upgraded = upconversion::upconvert_ufov1_robofab_data(
                         &lib_path,
                         lib_data,
-                        &mut feature_text,
                         &mut fontinfo,
                     )?;
                 }
 
-                if !feature_text.is_empty() {
-                    features = Some(feature_text);
+                if features_upgraded.is_some() && !features_upgraded.as_ref().unwrap().is_empty() {
+                    features = features_upgraded;
                 }
                 font_info = Some(fontinfo);
             }

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -115,9 +115,8 @@ fn find_known_kerning_groups(groups: &Groups) -> (HashSet<String>, HashSet<Strin
 pub(crate) fn upconvert_ufov1_robofab_data(
     lib_path: &std::path::PathBuf,
     lib: &mut plist::Dictionary,
-    features: &mut String,
     fontinfo: &mut FontInfo,
-) -> Result<(), Error> {
+) -> Result<Option<String>, Error> {
     #[derive(Debug, Deserialize)]
     struct LibData {
         #[serde(rename = "org.robofab.postScriptHintData")]
@@ -150,7 +149,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     let lib_data: LibData = plist::from_file(lib_path)?;
 
     // Convert features.
-    features.clear();
+    let mut features = String::new();
 
     if let Some(feature_classes) = lib_data.feature_classes {
         features.push_str(&feature_classes);
@@ -203,7 +202,11 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     lib.remove("org.robofab.opentype.featureorder");
     lib.remove("org.robofab.opentype.features");
 
-    Ok(())
+    if features.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(features))
+    }
 }
 
 #[cfg(test)]

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -1,7 +1,10 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use crate::fontinfo::FontInfo;
 use crate::names::NameList;
+use crate::shared_types::IntegerOrFloat;
 use crate::ufo::{Groups, Kerning};
+use crate::Error;
 
 /// Convert kerning groups and pairs from v1 and v2 informal conventions to v3 formal conventions.
 /// Converted groups are added (duplicated) rather than replacing the old ones to preserve all data
@@ -102,6 +105,105 @@ fn find_known_kerning_groups(groups: &Groups) -> (HashSet<String>, HashSet<Strin
     }
 
     (groups_first, groups_second)
+}
+
+/// Migrate UFO v1 era feature and PostScript hinting data to the current data model. It re-reads
+/// the lib.plist file to filter out the relevant data and then update the passed in lib, features
+/// and fontinfo in-place. It tries to follow what [defcon is doing][1].
+///
+/// [1]: https://github.com/robotools/defcon/blob/76a7ac408e62f68c09eaf24ca6d9ad04523dd19c/Lib/defcon/objects/font.py#L1571-L1629
+pub(crate) fn upconvert_ufov1_robofab_data(
+    lib_path: &std::path::PathBuf,
+    lib: &mut plist::Dictionary,
+    features: &mut String,
+    fontinfo: &mut FontInfo,
+) -> Result<(), Error> {
+    #[derive(Debug, Deserialize)]
+    struct LibData {
+        #[serde(rename = "org.robofab.postScriptHintData")]
+        ps_hinting_data: Option<PsHintingData>,
+
+        #[serde(rename = "org.robofab.opentype.classes")]
+        feature_classes: Option<String>,
+        #[serde(rename = "org.robofab.opentype.featureorder")]
+        feature_order: Option<Vec<String>>,
+        #[serde(rename = "org.robofab.opentype.features")]
+        features: Option<HashMap<String, String>>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct PsHintingData {
+        blue_fuzz: Option<IntegerOrFloat>,
+        blue_scale: Option<f64>,
+        blue_shift: Option<IntegerOrFloat>,
+        blue_values: Option<Vec<Vec<IntegerOrFloat>>>,
+        family_blues: Option<Vec<Vec<IntegerOrFloat>>>,
+        family_other_blues: Option<Vec<Vec<IntegerOrFloat>>>,
+        force_bold: Option<bool>,
+        other_blues: Option<Vec<Vec<IntegerOrFloat>>>,
+        h_stems: Option<Vec<IntegerOrFloat>>,
+        v_stems: Option<Vec<IntegerOrFloat>>,
+    }
+
+    // Reead lib.plist again because it is easier than pulling out the data manually.
+    let lib_data: LibData = plist::from_file(lib_path)?;
+
+    // Convert features.
+    features.clear();
+
+    if let Some(feature_classes) = lib_data.feature_classes {
+        features.push_str(&feature_classes);
+    }
+
+    if let Some(features_split) = lib_data.features {
+        let order: Vec<String> = if let Some(feature_order) = lib_data.feature_order {
+            feature_order
+        } else {
+            features_split.keys().cloned().collect::<Vec<String>>()
+        };
+
+        features.push_str(&"\n");
+
+        for key in order {
+            // Ignore non-existant keys because defcon does it, too.
+            if let Some(txt) = features_split.get(&key) {
+                features.push_str(&txt);
+            }
+        }
+    }
+
+    // Convert PostScript hinting data.
+    if let Some(ps_hinting_data) = lib_data.ps_hinting_data {
+        fontinfo.postscript_blue_fuzz = ps_hinting_data.blue_fuzz;
+        fontinfo.postscript_blue_scale = ps_hinting_data.blue_scale;
+        fontinfo.postscript_blue_shift = ps_hinting_data.blue_shift;
+        if let Some(blue_values) = ps_hinting_data.blue_values {
+            fontinfo.postscript_blue_values = Some(blue_values.into_iter().flatten().collect());
+        };
+        if let Some(other_blues) = ps_hinting_data.other_blues {
+            fontinfo.postscript_other_blues = Some(other_blues.into_iter().flatten().collect());
+        };
+        if let Some(family_blues) = ps_hinting_data.family_blues {
+            fontinfo.postscript_family_blues = Some(family_blues.into_iter().flatten().collect());
+        };
+        if let Some(family_other_blues) = ps_hinting_data.family_other_blues {
+            fontinfo.postscript_family_other_blues =
+                Some(family_other_blues.into_iter().flatten().collect());
+        };
+        fontinfo.postscript_force_bold = ps_hinting_data.force_bold;
+        fontinfo.postscript_stem_snap_h = ps_hinting_data.h_stems;
+        fontinfo.postscript_stem_snap_v = ps_hinting_data.v_stems;
+
+        fontinfo.validate().map_err(|_| Error::FontInfoUpconversionError)?;
+    }
+
+    lib.remove("org.robofab.postScriptHintData");
+    lib.remove("org.robofab.opentype.classes");
+    lib.remove("org.robofab.opentype.featureorder");
+    lib.remove("org.robofab.opentype.features");
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/testdata/fontinfotest_v1.ufo/fontinfo.plist
+++ b/testdata/fontinfotest_v1.ufo/fontinfo.plist
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>750</integer>
+    <key>copyright</key>
+    <string>Copyright Some Foundry.</string>
+    <key>createdBy</key>
+    <string>Some Foundry</string>
+    <key>defaultWidth</key>
+    <integer>400</integer>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>designer</key>
+    <string>Some Designer</string>
+    <key>designerURL</key>
+    <string>http://somedesigner.com</string>
+    <key>familyName</key>
+    <string>Some Font (Family Name)</string>
+    <key>fondID</key>
+    <integer>15000</integer>
+    <key>fondName</key>
+    <string>SomeFont Regular (FOND Name)</string>
+    <key>fontName</key>
+    <string>SomeFont-Regular (Postscript Font Name)</string>
+    <key>fontStyle</key>
+    <integer>64</integer>
+    <key>fullName</key>
+    <string>Some Font-Regular (Postscript Full Name)</string>
+    <key>italicAngle</key>
+    <real>-12.5</real>
+    <key>license</key>
+    <string>License info for Some Foundry.</string>
+    <key>licenseURL</key>
+    <string>http://somefoundry.com/license</string>
+    <key>menuName</key>
+    <string>Some Font Regular (Style Map Family Name)</string>
+    <key>msCharSet</key>
+    <integer>0</integer>
+    <key>note</key>
+    <string>A note.</string>
+    <key>notice</key>
+    <string>Some Font by Some Designer for Some Foundry.</string>
+    <key>otFamilyName</key>
+    <string>Some Font (Preferred Family Name)</string>
+    <key>otMacName</key>
+    <string>Some Font Regular (Compatible Full Name)</string>
+    <key>otStyleName</key>
+    <string>Regular (Preferred Subfamily Name)</string>
+    <key>slantAngle</key>
+    <real>-12.5</real>
+    <key>styleName</key>
+    <string>Regular (Style Name)</string>
+    <key>trademark</key>
+    <string>Trademark Some Foundry</string>
+    <key>ttUniqueID</key>
+    <string>OpenType name Table Unique ID</string>
+    <key>ttVendor</key>
+    <string>SOME</string>
+    <key>ttVersion</key>
+    <string>OpenType name Table Version</string>
+    <key>uniqueID</key>
+    <integer>4000000</integer>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>vendorURL</key>
+    <string>http://somefoundry.com</string>
+    <key>versionMajor</key>
+    <integer>1</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+    <key>weightName</key>
+    <string>Medium</string>
+    <key>weightValue</key>
+    <integer>500</integer>
+    <key>widthName</key>
+    <string>Medium (normal)</string>
+    <key>xHeight</key>
+    <integer>500</integer>
+    <key>year</key>
+    <integer>2008</integer>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/glyphs/contents.plist
+++ b/testdata/fontinfotest_v1.ufo/glyphs/contents.plist
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict/>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/groups.plist
+++ b/testdata/fontinfotest_v1.ufo/groups.plist
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>group1</key>
+    <array>
+      <string>A</string>
+    </array>
+    <key>group2</key>
+    <array>
+      <string>A</string>
+      <string>B</string>
+    </array>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/kerning.plist
+++ b/testdata/fontinfotest_v1.ufo/kerning.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>A</key>
+	<dict>
+		<key>B</key>
+		<integer>100</integer>
+	</dict>
+	<key>B</key>
+	<dict>
+		<key>A</key>
+		<integer>-200</integer>
+	</dict>
+</dict>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/lib.plist
+++ b/testdata/fontinfotest_v1.ufo/lib.plist
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>org.robofab.opentype.classes</key>
+    <string>@myClass = [A B];
+</string>
+    <key>org.robofab.opentype.featureorder</key>
+    <array>
+      <string>liga</string>
+    </array>
+    <key>org.robofab.opentype.features</key>
+    <dict>
+      <key>liga</key>
+      <string>feature liga {
+    sub A A by b;
+} liga;
+</string>
+    </dict>
+    <key>org.robofab.postScriptHintData</key>
+    <dict>
+      <key>blueFuzz</key>
+      <integer>1</integer>
+      <key>blueScale</key>
+      <real>0.039625</real>
+      <key>blueShift</key>
+      <integer>7</integer>
+      <key>blueValues</key>
+      <array>
+        <array>
+          <integer>-10</integer>
+          <integer>0</integer>
+        </array>
+        <array>
+          <integer>482</integer>
+          <integer>492</integer>
+        </array>
+        <array>
+          <integer>694</integer>
+          <integer>704</integer>
+        </array>
+        <array>
+          <integer>739</integer>
+          <integer>749</integer>
+        </array>
+      </array>
+      <key>familyBlues</key>
+      <array>
+        <array>
+          <integer>500</integer>
+          <integer>510</integer>
+        </array>
+      </array>
+      <key>familyOtherBlues</key>
+      <array>
+        <array>
+          <integer>-260</integer>
+          <integer>-250</integer>
+        </array>
+      </array>
+      <key>forceBold</key>
+      <true/>
+      <key>hStems</key>
+      <array>
+        <integer>100</integer>
+        <integer>120</integer>
+      </array>
+      <key>otherBlues</key>
+      <array>
+        <array>
+          <integer>-260</integer>
+          <integer>-250</integer>
+        </array>
+      </array>
+      <key>vStems</key>
+      <array>
+        <integer>80</integer>
+        <integer>90</integer>
+      </array>
+    </dict>
+    <key>org.robofab.testFontLibData</key>
+    <string>Foo Bar</string>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v1.ufo/metainfo.plist
+++ b/testdata/fontinfotest_v1.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>1</integer>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v2.ufo/features.fea
+++ b/testdata/fontinfotest_v2.ufo/features.fea
@@ -1,0 +1,5 @@
+@myClass = [A B];
+
+feature liga {
+    sub A A by b;
+} liga;

--- a/testdata/fontinfotest_v2.ufo/fontinfo.plist
+++ b/testdata/fontinfotest_v2.ufo/fontinfo.plist
@@ -1,0 +1,130 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>750</integer>
+    <key>copyright</key>
+    <string>Copyright Some Foundry.</string>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>Some Font (Family Name)</string>
+    <key>italicAngle</key>
+    <real>-12.5</real>
+    <key>macintoshFONDFamilyID</key>
+    <integer>15000</integer>
+    <key>macintoshFONDName</key>
+    <string>SomeFont Regular (FOND Name)</string>
+    <key>note</key>
+    <string>A note.</string>
+    <key>openTypeNameCompatibleFullName</key>
+    <string>Some Font Regular (Compatible Full Name)</string>
+    <key>openTypeNameDescription</key>
+    <string>Some Font by Some Designer for Some Foundry.</string>
+    <key>openTypeNameDesigner</key>
+    <string>Some Designer</string>
+    <key>openTypeNameDesignerURL</key>
+    <string>http://somedesigner.com</string>
+    <key>openTypeNameLicense</key>
+    <string>License info for Some Foundry.</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>http://somefoundry.com/license</string>
+    <key>openTypeNameManufacturer</key>
+    <string>Some Foundry</string>
+    <key>openTypeNameManufacturerURL</key>
+    <string>http://somefoundry.com</string>
+    <key>openTypeNamePreferredFamilyName</key>
+    <string>Some Font (Preferred Family Name)</string>
+    <key>openTypeNamePreferredSubfamilyName</key>
+    <string>Regular (Preferred Subfamily Name)</string>
+    <key>openTypeNameUniqueID</key>
+    <string>OpenType name Table Unique ID</string>
+    <key>openTypeNameVersion</key>
+    <string>OpenType name Table Version</string>
+    <key>openTypeOS2VendorID</key>
+    <string>SOME</string>
+    <key>openTypeOS2WeightClass</key>
+    <integer>500</integer>
+    <key>openTypeOS2WidthClass</key>
+    <integer>5</integer>
+    <key>postscriptBlueFuzz</key>
+    <integer>1</integer>
+    <key>postscriptBlueScale</key>
+    <real>0.039625</real>
+    <key>postscriptBlueShift</key>
+    <integer>7</integer>
+    <key>postscriptBlueValues</key>
+    <array>
+      <integer>-10</integer>
+      <integer>0</integer>
+      <integer>482</integer>
+      <integer>492</integer>
+      <integer>694</integer>
+      <integer>704</integer>
+      <integer>739</integer>
+      <integer>749</integer>
+    </array>
+    <key>postscriptDefaultWidthX</key>
+    <integer>400</integer>
+    <key>postscriptFamilyBlues</key>
+    <array>
+      <integer>500</integer>
+      <integer>510</integer>
+    </array>
+    <key>postscriptFamilyOtherBlues</key>
+    <array>
+      <integer>-260</integer>
+      <integer>-250</integer>
+    </array>
+    <key>postscriptFontName</key>
+    <string>SomeFont-Regular (Postscript Font Name)</string>
+    <key>postscriptForceBold</key>
+    <true/>
+    <key>postscriptFullName</key>
+    <string>Some Font-Regular (Postscript Full Name)</string>
+    <key>postscriptOtherBlues</key>
+    <array>
+      <integer>-260</integer>
+      <integer>-250</integer>
+    </array>
+    <key>postscriptSlantAngle</key>
+    <real>-12.5</real>
+    <key>postscriptStemSnapH</key>
+    <array>
+      <integer>100</integer>
+      <integer>120</integer>
+    </array>
+    <key>postscriptStemSnapV</key>
+    <array>
+      <integer>80</integer>
+      <integer>90</integer>
+    </array>
+    <key>postscriptUniqueID</key>
+    <integer>4000000</integer>
+    <key>postscriptWeightName</key>
+    <string>Medium</string>
+    <key>postscriptWindowsCharacterSet</key>
+    <integer>1</integer>
+    <key>styleMapFamilyName</key>
+    <string>Some Font Regular (Style Map Family Name)</string>
+    <key>styleMapStyleName</key>
+    <string>regular</string>
+    <key>styleName</key>
+    <string>Regular (Style Name)</string>
+    <key>trademark</key>
+    <string>Trademark Some Foundry</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>versionMajor</key>
+    <integer>1</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+    <key>year</key>
+    <integer>2008</integer>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v2.ufo/glyphs/contents.plist
+++ b/testdata/fontinfotest_v2.ufo/glyphs/contents.plist
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict/>
+</plist>

--- a/testdata/fontinfotest_v2.ufo/groups.plist
+++ b/testdata/fontinfotest_v2.ufo/groups.plist
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>group1</key>
+    <array>
+      <string>A</string>
+    </array>
+    <key>group2</key>
+    <array>
+      <string>A</string>
+      <string>B</string>
+    </array>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v2.ufo/kerning.plist
+++ b/testdata/fontinfotest_v2.ufo/kerning.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>A</key>
+    <dict>
+      <key>B</key>
+      <integer>100</integer>
+    </dict>
+    <key>B</key>
+    <dict>
+      <key>A</key>
+      <integer>-200</integer>
+    </dict>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v2.ufo/lib.plist
+++ b/testdata/fontinfotest_v2.ufo/lib.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>org.robofab.testFontLibData</key>
+    <string>Foo Bar</string>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v2.ufo/metainfo.plist
+++ b/testdata/fontinfotest_v2.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>2</integer>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v3.ufo/features.fea
+++ b/testdata/fontinfotest_v3.ufo/features.fea
@@ -1,0 +1,5 @@
+@myClass = [A B];
+
+feature liga {
+    sub A A by b;
+} liga;

--- a/testdata/fontinfotest_v3.ufo/fontinfo.plist
+++ b/testdata/fontinfotest_v3.ufo/fontinfo.plist
@@ -1,0 +1,130 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>750</integer>
+    <key>capHeight</key>
+    <integer>750</integer>
+    <key>copyright</key>
+    <string>Copyright Some Foundry.</string>
+    <key>descender</key>
+    <integer>-250</integer>
+    <key>familyName</key>
+    <string>Some Font (Family Name)</string>
+    <key>italicAngle</key>
+    <real>-12.5</real>
+    <key>macintoshFONDFamilyID</key>
+    <integer>15000</integer>
+    <key>macintoshFONDName</key>
+    <string>SomeFont Regular (FOND Name)</string>
+    <key>note</key>
+    <string>A note.</string>
+    <key>openTypeNameCompatibleFullName</key>
+    <string>Some Font Regular (Compatible Full Name)</string>
+    <key>openTypeNameDescription</key>
+    <string>Some Font by Some Designer for Some Foundry.</string>
+    <key>openTypeNameDesigner</key>
+    <string>Some Designer</string>
+    <key>openTypeNameDesignerURL</key>
+    <string>http://somedesigner.com</string>
+    <key>openTypeNameLicense</key>
+    <string>License info for Some Foundry.</string>
+    <key>openTypeNameLicenseURL</key>
+    <string>http://somefoundry.com/license</string>
+    <key>openTypeNameManufacturer</key>
+    <string>Some Foundry</string>
+    <key>openTypeNameManufacturerURL</key>
+    <string>http://somefoundry.com</string>
+    <key>openTypeNamePreferredFamilyName</key>
+    <string>Some Font (Preferred Family Name)</string>
+    <key>openTypeNamePreferredSubfamilyName</key>
+    <string>Regular (Preferred Subfamily Name)</string>
+    <key>openTypeNameUniqueID</key>
+    <string>OpenType name Table Unique ID</string>
+    <key>openTypeNameVersion</key>
+    <string>OpenType name Table Version</string>
+    <key>openTypeOS2VendorID</key>
+    <string>SOME</string>
+    <key>openTypeOS2WeightClass</key>
+    <integer>500</integer>
+    <key>openTypeOS2WidthClass</key>
+    <integer>5</integer>
+    <key>postscriptBlueFuzz</key>
+    <integer>1</integer>
+    <key>postscriptBlueScale</key>
+    <real>0.039625</real>
+    <key>postscriptBlueShift</key>
+    <integer>7</integer>
+    <key>postscriptBlueValues</key>
+    <array>
+      <integer>-10</integer>
+      <integer>0</integer>
+      <integer>482</integer>
+      <integer>492</integer>
+      <integer>694</integer>
+      <integer>704</integer>
+      <integer>739</integer>
+      <integer>749</integer>
+    </array>
+    <key>postscriptDefaultWidthX</key>
+    <integer>400</integer>
+    <key>postscriptFamilyBlues</key>
+    <array>
+      <integer>500</integer>
+      <integer>510</integer>
+    </array>
+    <key>postscriptFamilyOtherBlues</key>
+    <array>
+      <integer>-260</integer>
+      <integer>-250</integer>
+    </array>
+    <key>postscriptFontName</key>
+    <string>SomeFont-Regular (Postscript Font Name)</string>
+    <key>postscriptForceBold</key>
+    <true/>
+    <key>postscriptFullName</key>
+    <string>Some Font-Regular (Postscript Full Name)</string>
+    <key>postscriptOtherBlues</key>
+    <array>
+      <integer>-260</integer>
+      <integer>-250</integer>
+    </array>
+    <key>postscriptSlantAngle</key>
+    <real>-12.5</real>
+    <key>postscriptStemSnapH</key>
+    <array>
+      <integer>100</integer>
+      <integer>120</integer>
+    </array>
+    <key>postscriptStemSnapV</key>
+    <array>
+      <integer>80</integer>
+      <integer>90</integer>
+    </array>
+    <key>postscriptUniqueID</key>
+    <integer>4000000</integer>
+    <key>postscriptWeightName</key>
+    <string>Medium</string>
+    <key>postscriptWindowsCharacterSet</key>
+    <integer>1</integer>
+    <key>styleMapFamilyName</key>
+    <string>Some Font Regular (Style Map Family Name)</string>
+    <key>styleMapStyleName</key>
+    <string>regular</string>
+    <key>styleName</key>
+    <string>Regular (Style Name)</string>
+    <key>trademark</key>
+    <string>Trademark Some Foundry</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>versionMajor</key>
+    <integer>1</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+    <key>year</key>
+    <integer>2008</integer>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v3.ufo/glyphs/contents.plist
+++ b/testdata/fontinfotest_v3.ufo/glyphs/contents.plist
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict/>
+</plist>

--- a/testdata/fontinfotest_v3.ufo/groups.plist
+++ b/testdata/fontinfotest_v3.ufo/groups.plist
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>group1</key>
+    <array>
+      <string>A</string>
+    </array>
+    <key>group2</key>
+    <array>
+      <string>A</string>
+      <string>B</string>
+    </array>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v3.ufo/kerning.plist
+++ b/testdata/fontinfotest_v3.ufo/kerning.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>A</key>
+    <dict>
+      <key>B</key>
+      <integer>100</integer>
+    </dict>
+    <key>B</key>
+    <dict>
+      <key>A</key>
+      <integer>-200</integer>
+    </dict>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v3.ufo/layercontents.plist
+++ b/testdata/fontinfotest_v3.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/testdata/fontinfotest_v3.ufo/lib.plist
+++ b/testdata/fontinfotest_v3.ufo/lib.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>org.robofab.testFontLibData</key>
+    <string>Foo Bar</string>
+  </dict>
+</plist>

--- a/testdata/fontinfotest_v3.ufo/metainfo.plist
+++ b/testdata/fontinfotest_v3.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>


### PR DESCRIPTION
This does a bit of work.

- UFO v1 stored feature code and the Postscript info attributes in lib.plist, which need to be sourced when upconverting: https://github.com/robotools/defcon/blob/a1e9d2852bb9d531ae5ec5b707fa0ab51aa202f1/Lib/defcon/objects/font.py#L1531-L1589
- UFO v1 had different names for the fontinfo attributes, some of which  need conversion: https://github.com/fonttools/fonttools/blob/master/Lib/fontTools/ufoLib/__init__.py#L1934-L1962 (and possibly more code)
- UFO v2 and v3 have the same attribute names (v3 just has more), but v3 also updates the data types for some attributes (e.g. unitsPerEm are made positive)

ufoLib supports converting the versions up and down, but I think forcibly one-way upgrading the data to the latest supported version is the way to go for Norad.

The fontinfo error messages remain... rudimentary. I think they need to be revisited to return more useful error messages at a later point. I don't know how to get serde to include the field name in error messages if a field contains invalid data.