### PR TITLE
Fontinfo: Opportunistically convert IntegerOrFloat to int

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ pub enum Error {
     GroupsError(GroupsValidationError),
     GroupsUpconversionError(GroupsValidationError),
     ExpectedPlistDictionaryError,
+    ExpectedPositiveValue,
 }
 
 /// An error representing a failure to validate UFO groups.
@@ -102,6 +103,7 @@ impl std::fmt::Display for Error {
             Error::GroupsError(ge) => ge.fmt(f),
             Error::GroupsUpconversionError(ge) => write!(f, "Upconverting UFO v1 or v2 kerning data to v3 failed: {}", ge),
             Error::ExpectedPlistDictionaryError => write!(f, "The files groups.plist, kerning.plist and lib.plist must contain plist dictionaries."),
+            Error::ExpectedPositiveValue => write!(f, "PositiveIntegerOrFloat expects a positive value."),
         }
     }
 }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1,6 +1,3 @@
-use std::convert::TryFrom;
-use std::ops::Deref;
-
 use serde::de::Deserializer;
 use serde::ser::{SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
@@ -178,7 +175,9 @@ mod types {
     }
 }
 
-use types::{Integer, IntegerOrFloat, Float, NonNegativeInteger, NonNegativeIntegerOrFloat, Bitlist};
+use types::{
+    Bitlist, Float, Integer, IntegerOrFloat, NonNegativeInteger, NonNegativeIntegerOrFloat,
+};
 
 /// The contents of the [`fontinfo.plist`][] file. This structure is hard-wired to the
 /// available attributes in UFO version 3.
@@ -864,6 +863,7 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom;
     use super::*;
     use serde_test::{assert_tokens, Token};
 

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -169,10 +169,7 @@ mod types {
             D: Deserializer<'de>,
         {
             let value: f64 = Deserialize::deserialize(deserializer)?;
-            match NonNegativeIntegerOrFloat::try_from(value) {
-                Ok(v) => Ok(v),
-                Err(_) => Err(serde::de::Error::custom("Value must be positive.")),
-            }
+            Ok(NonNegativeIntegerOrFloat::try_from(value).map_err(serde::de::Error::custom)?)
         }
     }
 }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::shared_types::Guideline;
 use crate::Error;
 
+/// Fontinfo value types are put into a module so that code on this level cannot access the
+/// literal constructors.
 mod types {
     use std::convert::TryFrom;
     use std::ops::Deref;

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1002,6 +1002,15 @@ mod tests {
         assert_tokens(&n1, &[Token::F64(1.1)]);
         let n1 = IntegerOrFloat(1.0);
         assert_tokens(&n1, &[Token::I32(1)]);
+        let n1 = IntegerOrFloat(-1.1);
+        assert_tokens(&n1, &[Token::F64(-1.1)]);
+        let n1 = IntegerOrFloat(-1.0);
+        assert_tokens(&n1, &[Token::I32(-1)]);
+
+        let n1 = PositiveIntegerOrFloat(1.1);
+        assert_tokens(&n1, &[Token::F64(1.1)]);
+        let n1 = PositiveIntegerOrFloat(1.0);
+        assert_tokens(&n1, &[Token::I32(1)]);
     }
 
     #[test]

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -863,9 +863,9 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
     use super::*;
     use serde_test::{assert_tokens, Token};
+    use std::convert::TryFrom;
 
     #[test]
     fn fontinfo() {

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -2,181 +2,11 @@ use serde::de::Deserializer;
 use serde::ser::{SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
 
-use crate::shared_types::Guideline;
-use crate::Error;
-
-/// Fontinfo value types are put into a module so that code on this level cannot access the
-/// literal constructors.
-mod types {
-    use std::convert::TryFrom;
-    use std::ops::Deref;
-
-    use serde::de::Deserializer;
-    use serde::ser::Serializer;
-    use serde::{Deserialize, Serialize};
-
-    use super::Error;
-
-    pub type Integer = i32;
-    pub type NonNegativeInteger = u32;
-    pub type Float = f64;
-    pub type Bitlist = Vec<u8>;
-
-    /// IntegerOrFloat represents a number that can be an integer or float. It should
-    /// serialize to an integer if it effectively represents one.
-    #[derive(Debug, Clone, Copy, PartialEq)]
-    pub struct IntegerOrFloat(f64);
-
-    impl IntegerOrFloat {
-        pub fn new(value: f64) -> Self {
-            IntegerOrFloat(value)
-        }
-
-        pub fn get(&self) -> f64 {
-            self.0
-        }
-
-        pub fn set(&mut self, value: f64) {
-            self.0 = value
-        }
-
-        pub fn is_integer(&self) -> bool {
-            (self.0 - self.round()).abs() < std::f64::EPSILON
-        }
-    }
-
-    impl Deref for IntegerOrFloat {
-        type Target = f64;
-
-        fn deref(&self) -> &f64 {
-            &self.0
-        }
-    }
-
-    impl From<i32> for IntegerOrFloat {
-        fn from(value: i32) -> Self {
-            IntegerOrFloat(value as f64)
-        }
-    }
-
-    impl From<f64> for IntegerOrFloat {
-        fn from(value: f64) -> Self {
-            IntegerOrFloat(value)
-        }
-    }
-
-    impl Serialize for IntegerOrFloat {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            if self.is_integer() {
-                serializer.serialize_i32(self.0 as i32)
-            } else {
-                serializer.serialize_f64(self.0)
-            }
-        }
-    }
-
-    impl<'de> Deserialize<'de> for IntegerOrFloat {
-        fn deserialize<D>(deserializer: D) -> Result<IntegerOrFloat, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let value: f64 = Deserialize::deserialize(deserializer)?;
-            Ok(IntegerOrFloat(value))
-        }
-    }
-
-    /// NonNegativeIntegerOrFloat represents a number that can be a positive integer or float. It should
-    /// serialize to an integer if it effectively represents one.
-    #[derive(Debug, Clone, Copy, PartialEq)]
-    pub struct NonNegativeIntegerOrFloat(f64);
-
-    impl NonNegativeIntegerOrFloat {
-        pub fn new(value: f64) -> Option<Self> {
-            if value.is_sign_positive() {
-                Some(NonNegativeIntegerOrFloat(value))
-            } else {
-                None
-            }
-        }
-
-        pub fn get(&self) -> f64 {
-            self.0
-        }
-
-        pub fn try_set(&mut self, value: f64) -> Result<(), Error> {
-            if value.is_sign_positive() {
-                self.0 = value;
-                Ok(())
-            } else {
-                Err(Error::ExpectedPositiveValue)
-            }
-        }
-
-        pub fn is_integer(&self) -> bool {
-            (self.0 - self.round()).abs() < std::f64::EPSILON
-        }
-    }
-
-    impl Deref for NonNegativeIntegerOrFloat {
-        type Target = f64;
-
-        fn deref(&self) -> &f64 {
-            &self.0
-        }
-    }
-
-    impl TryFrom<i32> for NonNegativeIntegerOrFloat {
-        type Error = Error;
-
-        fn try_from(value: i32) -> Result<Self, Self::Error> {
-            match NonNegativeIntegerOrFloat::new(value as f64) {
-                Some(v) => Ok(v),
-                _ => Err(Error::ExpectedPositiveValue),
-            }
-        }
-    }
-
-    impl TryFrom<f64> for NonNegativeIntegerOrFloat {
-        type Error = Error;
-
-        fn try_from(value: f64) -> Result<Self, Self::Error> {
-            match NonNegativeIntegerOrFloat::new(value) {
-                Some(v) => Ok(v),
-                _ => Err(Error::ExpectedPositiveValue),
-            }
-        }
-    }
-
-    impl Serialize for NonNegativeIntegerOrFloat {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            if self.is_integer() {
-                serializer.serialize_i32(self.0 as i32)
-            } else {
-                serializer.serialize_f64(self.0)
-            }
-        }
-    }
-
-    impl<'de> Deserialize<'de> for NonNegativeIntegerOrFloat {
-        fn deserialize<D>(deserializer: D) -> Result<NonNegativeIntegerOrFloat, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let value: f64 = Deserialize::deserialize(deserializer)?;
-            Ok(NonNegativeIntegerOrFloat::try_from(value).map_err(serde::de::Error::custom)?)
-        }
-    }
-}
-
-use types::{
-    Bitlist, Float, Integer, IntegerOrFloat, NonNegativeInteger, NonNegativeIntegerOrFloat,
+use crate::shared_types::{
+    Bitlist, Float, Guideline, Integer, IntegerOrFloat, NonNegativeInteger,
+    NonNegativeIntegerOrFloat,
 };
+use crate::Error;
 
 /// The contents of the [`fontinfo.plist`][] file. This structure is hard-wired to the
 /// available attributes in UFO version 3.
@@ -864,7 +694,6 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 mod tests {
     use super::*;
     use serde_test::{assert_tokens, Token};
-    use std::convert::TryFrom;
 
     #[test]
     fn fontinfo() {
@@ -1006,32 +835,6 @@ mod tests {
         assert_tokens(&s3, &[Token::Str("bold")]);
         let s4 = StyleMapStyle::BoldItalic;
         assert_tokens(&s4, &[Token::Str("bold italic")]);
-    }
-
-    #[test]
-    fn test_integer_or_float_type() {
-        let n1 = IntegerOrFloat::new(1.1);
-        assert_tokens(&n1, &[Token::F64(1.1)]);
-        let n1 = IntegerOrFloat::new(1.0);
-        assert_tokens(&n1, &[Token::I32(1)]);
-        let n1 = IntegerOrFloat::new(-1.1);
-        assert_tokens(&n1, &[Token::F64(-1.1)]);
-        let n1 = IntegerOrFloat::new(-1.0);
-        assert_tokens(&n1, &[Token::I32(-1)]);
-
-        let n1 = NonNegativeIntegerOrFloat::new(1.1).unwrap();
-        assert_tokens(&n1, &[Token::F64(1.1)]);
-        let n1 = NonNegativeIntegerOrFloat::new(1.0).unwrap();
-        assert_tokens(&n1, &[Token::I32(1)]);
-    }
-
-    #[test]
-    fn test_positive_int_or_float() {
-        assert!(NonNegativeIntegerOrFloat::try_from(-1.0).is_err());
-
-        let mut v = NonNegativeIntegerOrFloat::try_from(1.0).unwrap();
-        assert!(v.try_set(-1.0).is_err());
-        assert!(v.try_set(1.0).is_ok());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,5 +31,7 @@ pub use error::Error;
 pub use fontinfo::FontInfo;
 pub use glyph::{Glyph, GlyphName};
 pub use layer::Layer;
-pub use shared_types::{Color, Guideline, Identifier, Line};
+pub use shared_types::{
+    Color, Guideline, Identifier, IntegerOrFloat, Line, NonNegativeIntegerOrFloat,
+};
 pub use ufo::{FormatVersion, LayerInfo, MetaInfo, Ufo};


### PR DESCRIPTION
Turn `IntegerOrFloat` from a type alias to a newtype.

One additional detail: `units_per_em` was a bare f64 before, is a `IntegerOrFloat` now. The v3 spec says it must be positive, which the `validate` continues to ensure. I think once the library has matured, _someone_ should think about how to do this more elegantly maybe, like ensuring that the data can never be negative by construction.