### PR TITLE
Add 'rayon' feature for faster glyph loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version =  "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
 quick-xml = "0.18.0"
+rayon = { version = "1.3.0", optional = true }
 
 [dependencies.druid]
 #git = "https://github.com/xi-editor/druid.git"

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -5,7 +5,6 @@ mod serialize;
 #[cfg(test)]
 mod tests;
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -13,6 +12,7 @@ use std::sync::Arc;
 use druid::{Data, Lens};
 
 use crate::error::{Error, GlifError, GlifErrorInternal};
+use crate::names::NameList;
 use crate::shared_types::{Color, Guideline, Identifier, Line};
 
 /// The name of a glyph.
@@ -47,11 +47,11 @@ impl Glyph {
     /// between instances.
     pub fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
-        let mut names = HashSet::new();
-        Glyph::load_with_names(path, &mut names)
+        let names = NameList::default();
+        Glyph::load_with_names(path, &names)
     }
 
-    pub fn load_with_names(path: &Path, names: &mut HashSet<GlyphName>) -> Result<Self, Error> {
+    pub fn load_with_names(path: &Path, names: &NameList) -> Result<Self, Error> {
         let data = std::fs::read(path)?;
         parse::GlifParser::from_xml(&data, Some(names)).map_err(|e| match e {
             GlifErrorInternal::Xml(e) => e.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod error;
 pub mod fontinfo;
 pub mod glyph;
 mod layer;
+mod names;
 mod shared_types;
 mod ufo;
 mod upconversion;

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,0 +1,91 @@
+#[cfg(not(feature = "rayon"))]
+use std::cell::RefCell;
+use std::collections::HashSet;
+#[cfg(feature = "rayon")]
+use std::sync::RwLock;
+
+use crate::glyph::GlyphName;
+
+/// Manages interned names
+///
+/// We store names as `Arc<str>`, and we want to reuse the same pointer
+/// for all instances of the same name.
+#[derive(Debug, Default)]
+pub struct NameList {
+    #[cfg(feature = "rayon")]
+    inner: ParNameList,
+    #[cfg(not(feature = "rayon"))]
+    inner: SeqNameList,
+}
+
+#[derive(Debug)]
+#[cfg(feature = "rayon")]
+struct ParNameList(RwLock<HashSet<GlyphName>>);
+
+#[derive(Debug, Default)]
+#[cfg(not(feature = "rayon"))]
+struct SeqNameList(RefCell<HashSet<GlyphName>>);
+
+impl NameList {
+    pub(crate) fn get(&self, name: &GlyphName) -> GlyphName {
+        self.inner.get(name)
+    }
+
+    pub(crate) fn contains(&self, key: impl AsRef<str>) -> bool {
+        self.inner.contains(key)
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl ParNameList {
+    pub(crate) fn get(&self, name: &GlyphName) -> GlyphName {
+        let existing = self.0.read().unwrap().get(name).cloned();
+        match existing {
+            Some(name) => name,
+            None => {
+                self.0.write().unwrap().insert(name.clone());
+                name.clone()
+            }
+        }
+    }
+
+    pub(crate) fn contains(&self, key: impl AsRef<str>) -> bool {
+        self.0.read().unwrap().contains(key.as_ref())
+    }
+}
+
+#[cfg(not(feature = "rayon"))]
+impl SeqNameList {
+    pub(crate) fn get(&self, name: &GlyphName) -> GlyphName {
+        let existing = self.0.borrow().get(name).cloned();
+        match existing {
+            Some(name) => name,
+            None => {
+                self.0.borrow_mut().insert(name.clone());
+                name.clone()
+            }
+        }
+    }
+
+    pub(crate) fn contains(&self, key: impl AsRef<str>) -> bool {
+        self.0.borrow().contains(key.as_ref())
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl Default for ParNameList {
+    fn default() -> Self {
+        ParNameList(RwLock::new(HashSet::new()))
+    }
+}
+
+impl<T: Into<GlyphName>> std::iter::FromIterator<T> for NameList {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let names = NameList::default();
+
+        for i in iter {
+            names.get(&i.into());
+        }
+        names
+    }
+}

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -14,6 +14,7 @@ use crate::error::GroupsValidationError;
 use crate::fontinfo::FontInfo;
 use crate::glyph::{Glyph, GlyphName};
 use crate::layer::Layer;
+use crate::names::NameList;
 use crate::upconversion::upconvert_kerning;
 use crate::Error;
 
@@ -177,7 +178,7 @@ impl Ufo {
                 None
             };
 
-            let mut glyph_names = HashSet::new();
+            let glyph_names = NameList::default();
             let mut contents = match meta.format_version {
                 FormatVersion::V3 => {
                     let contents_path = path.join(LAYER_CONTENTS_FILE);
@@ -191,7 +192,7 @@ impl Ufo {
                 .drain(..)
                 .map(|(name, p)| {
                     let layer_path = path.join(&p);
-                    let layer = Layer::load_impl(&layer_path, &mut glyph_names)?;
+                    let layer = Layer::load_impl(&layer_path, &glyph_names)?;
                     Ok(LayerInfo { name, path: p, layer })
                 })
                 .collect();

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use crate::glyph::GlyphName;
+use crate::names::NameList;
 use crate::ufo::{Groups, Kerning};
 
 /// Convert kerning groups and pairs from v1 and v2 informal conventions to v3 formal conventions.
@@ -9,10 +9,10 @@ use crate::ufo::{Groups, Kerning};
 ///
 /// This is an adaptation from the fontTools.ufoLib reference implementation. It will not check if
 /// the upgraded groups pass validation.
-pub fn upconvert_kerning(
+pub(crate) fn upconvert_kerning(
     groups: &Groups,
     kerning: &Kerning,
-    glyph_set: &HashSet<GlyphName>,
+    glyph_set: &NameList,
 ) -> (Groups, Kerning) {
     // Gather known kerning groups based on the prefixes. This will catch groups that exist in
     // `groups` but are not referenced in `kerning`.
@@ -109,6 +109,7 @@ mod tests {
     extern crate maplit;
 
     use super::*;
+    use crate::glyph::GlyphName;
     use crate::ufo::{FormatVersion, Ufo};
     use maplit::btreemap;
 
@@ -127,20 +128,10 @@ mod tests {
             "foo".into() => vec![],
         };
         let kerning: Kerning = Kerning::new();
-        let glyph_set: HashSet<GlyphName> = vec![
-            "a".into(),
-            "b".into(),
-            "c".into(),
-            "d".into(),
-            "e".into(),
-            "f".into(),
-            "g".into(),
-            "h".into(),
-            "i".into(),
-            "j".into(),
-        ]
-        .into_iter()
-        .collect();
+        let glyph_set: NameList = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+            .iter()
+            .map(|s| GlyphName::from(*s))
+            .collect();
 
         let (groups_new, kerning_new) = upconvert_kerning(&groups, &kerning, &glyph_set);
 
@@ -195,7 +186,7 @@ mod tests {
                 "DGroup".into() => 12.0,
             },
         };
-        let glyph_set: HashSet<GlyphName> = HashSet::new();
+        let glyph_set = NameList::default();
 
         let (groups_new, kerning_new) = upconvert_kerning(&groups, &kerning, &glyph_set);
 
@@ -266,7 +257,7 @@ mod tests {
                 "@MMK_R_DGroup".into() => 12.0,
             },
         };
-        let glyph_set: HashSet<GlyphName> = HashSet::new();
+        let glyph_set = NameList::default();
 
         let (groups_new, kerning_new) = upconvert_kerning(&groups, &kerning, &glyph_set);
 
@@ -340,7 +331,7 @@ mod tests {
                 "DGroup".into() => 12.0,
             },
         };
-        let glyph_set: HashSet<GlyphName> = HashSet::new();
+        let glyph_set = NameList::default();
 
         let (groups_new, kerning_new) = upconvert_kerning(&groups, &kerning, &glyph_set);
 


### PR DESCRIPTION
On my macbook (4 cores) this cuts down the loading time of NotoCJK
from 7-12 seconds to 2-3.5 seconds.