### PR TITLE
Implement Glif v1 upconversion and minor fixups

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -78,6 +78,7 @@ pub enum ErrorKind {
     BadImage,
     UnexpectedDuplicate,
     UnexpectedElement,
+    UnexpectedAttribute,
     UnexpectedEof,
 }
 
@@ -135,6 +136,7 @@ impl std::fmt::Display for ErrorKind {
             ErrorKind::BadImage => write!(f, "Bad image"),
             ErrorKind::UnexpectedDuplicate => write!(f, "Unexpected duplicate"),
             ErrorKind::UnexpectedElement => write!(f, "Unexpected element"),
+            ErrorKind::UnexpectedAttribute => write!(f, "Unexpected attribute"),
             ErrorKind::UnexpectedEof => write!(f, "Unexpected EOF"),
         }
     }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -46,12 +46,12 @@ pub struct FontInfo {
     #[serde(rename = "openTypeNameDesignerURL")]
     pub open_type_name_designer_url: Option<String>,
     pub open_type_name_designer: Option<String>,
+    pub open_type_name_license: Option<String>,
     #[serde(rename = "openTypeNameLicenseURL")]
     pub open_type_name_license_url: Option<String>,
-    pub open_type_name_license: Option<String>,
+    pub open_type_name_manufacturer: Option<String>,
     #[serde(rename = "openTypeNameManufacturerURL")]
     pub open_type_name_manufacturer_url: Option<String>,
-    pub open_type_name_manufacturer: Option<String>,
     pub open_type_name_preferred_family_name: Option<String>,
     pub open_type_name_preferred_subfamily_name: Option<String>,
     pub open_type_name_records: Option<Vec<NameRecord>>,

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -63,6 +63,9 @@ impl Glyph {
 
     #[doc(hidden)]
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        if self.format != GlifVersion::V2 {
+            return Err(Error::DowngradeUnsupported);
+        }
         let data = self.encode_xml()?;
         std::fs::write(path, &data)?;
         Ok(())

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -249,6 +249,10 @@ impl<'names> GlifParser<'names> {
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
     ) -> Result<(), Error> {
+        if self.glyph.advance.is_some() {
+            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
+        }
+
         let mut advance = Advance::default();
         for attr in data.attributes() {
             let attr = attr?;
@@ -262,9 +266,6 @@ impl<'names> GlifParser<'names> {
                     _ => unreachable!(),
                 };
             }
-        }
-        if self.glyph.advance.is_some() {
-            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
         }
         self.glyph.advance = Some(advance);
         Ok(())

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -90,7 +90,7 @@ impl<'names> GlifParser<'names> {
                 }
                 Event::End(ref end) if end.name() == b"outline" => break,
                 Event::Eof => return Err(err!(reader, ErrorKind::UnexpectedEof)),
-                _other => (),
+                _other => return Err(err!(reader, ErrorKind::UnexpectedElement)),
             }
         }
         Ok(())

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -151,12 +151,8 @@ impl<'names> GlifParser<'names> {
                 identifier: None,
                 color: None,
             };
-            // Create anchors vector unless already present.
-            if let Some(anchors) = self.glyph.anchors.as_mut() {
-                anchors.push(anchor);
-            } else {
-                self.glyph.anchors = Some(vec![anchor]);
-            }
+
+            self.glyph.anchors.get_or_insert(Vec::new()).push(anchor);
         } else {
             self.glyph.outline.as_mut().unwrap().contours.push(Contour { identifier, points });
         }

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -138,11 +138,7 @@ impl<'names> GlifParser<'names> {
 
         // In the Glif v1 spec, single-point contours that have a "move" type and a name should
         // be treated as anchors and upgraded.
-        if self.glyph.format == GlifVersion::V1
-            && points.len() == 1
-            && points[0].typ == PointType::Move
-            && points[0].name.is_some()
-        {
+        if contour_is_v1_anchor(&self.glyph.format, &points) {
             let anchor_point = points.remove(0);
             let anchor = Anchor {
                 name: anchor_point.name,
@@ -490,6 +486,14 @@ fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<Glyph, Error> 
         }
     }
     Err(err!(reader, ErrorKind::WrongFirstElement))
+}
+
+/// Check if a contour is really an informal anchor according to the Glif v2 specification.
+fn contour_is_v1_anchor(format: &GlifVersion, points: &[ContourPoint]) -> bool {
+    *format == GlifVersion::V1
+        && points.len() == 1
+        && points[0].typ == PointType::Move
+        && points[0].name.is_some()
 }
 
 impl FromStr for GlifVersion {

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -171,6 +171,10 @@ impl<'names> GlifParser<'names> {
     }
 
     fn parse_lib(&mut self, reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<(), Error> {
+        if self.glyph.lib.is_some() {
+            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
+        }
+
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"lib" => break,
@@ -182,6 +186,10 @@ impl<'names> GlifParser<'names> {
     }
 
     fn parse_note(&mut self, reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<(), Error> {
+        if self.glyph.note.is_some() {
+            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
+        }
+
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"note" => break,

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -61,12 +61,12 @@ impl Glyph {
 
         if let Some(ref outline) = self.outline {
             writer.write_event(Event::Start(BytesStart::borrowed_name(b"outline")))?;
-            for component in &outline.components {
-                writer.write_event(component.to_event())?;
-            }
-
             for contour in &outline.contours {
                 contour.write_xml(&mut writer)?;
+            }
+
+            for component in &outline.components {
+                writer.write_event(component.to_event())?;
             }
             writer.write_event(Event::End(BytesEnd::borrowed(b"outline")))?;
         }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -20,6 +20,26 @@ fn parse() {
 }
 
 #[test]
+fn parse_v1_upgrade_anchors() {
+    let bytes = include_bytes!("../../testdata/glifv1.glif");
+    let glyph = parse_glyph(bytes).unwrap();
+    assert_eq!(
+        glyph.anchors,
+        Some(vec![
+            Anchor { name: Some("top".into()), x: 10.0, y: 10.0, color: None, identifier: None },
+            Anchor { name: Some("bottom".into()), x: 10.0, y: 20.0, color: None, identifier: None },
+            Anchor { name: Some("left".into()), x: 30.0, y: 20.0, color: None, identifier: None },
+            Anchor { name: Some("right".into()), x: 40.0, y: 20.0, color: None, identifier: None }
+        ])
+    );
+    assert_eq!(glyph.format, GlifVersion::V2);
+    assert_eq!(glyph.guidelines, None);
+    assert_eq!(glyph.image, None);
+    assert_eq!(glyph.lib, None);
+    assert_eq!(glyph.note, None);
+}
+
+#[test]
 fn curve_types() {
     let bytes = include_bytes!("../../testdata/mutatorSans/MutatorSansBoldWide.ufo/glyphs/D_.glif");
     let glyph = parse_glyph(bytes).unwrap();

--- a/testdata/glifv1.glif
+++ b/testdata/glifv1.glif
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="a" format="1">
+  <advance width="561"/>
+  <unicode hex="0061"/>
+  <outline>
+    <contour>
+      <point x="161" y="246" type="curve" smooth="yes"/>
+      <point x="161" y="179"/>
+      <point x="219" y="124"/>
+      <point x="292" y="124" type="curve" smooth="yes"/>
+      <point x="364" y="124"/>
+      <point x="422" y="179"/>
+      <point x="422" y="246" type="curve" smooth="yes"/>
+      <point x="422" y="313"/>
+      <point x="364" y="368"/>
+      <point x="292" y="368" type="curve" smooth="yes"/>
+      <point x="219" y="368"/>
+      <point x="161" y="313"/>
+    </contour>
+    <contour>
+      <point x="10" y="10" type="move" name="top"/>
+    </contour>
+    <contour>
+      <point x="10" y="20" type="move" name="bottom"/>
+    </contour>
+    <contour>
+      <point x="30" y="20" type="move" name="left"/>
+    </contour>
+    <contour>
+      <point x="40" y="20" type="move" name="right"/>
+    </contour>
+  </outline>
+</glyph>


### PR DESCRIPTION
This PR implements:
- A few miscellaneous fixes to make output more diff-less compared to the reference libraries.
- Ensure a glifs' note and lib elements are present once and that a v1 contour has no attributes.
- Loading and upconverting Glif v1 files, with single-point move-type contours being upgraded to anchors, as recommended in http://unifiedfontobject.org/versions/ufo3/glyphs/glif/#converting-implied-anchors-in-glif-1-to-glif-2-anchor-elements.