### PR TITLE
Add UfoDataRequest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "norad"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Colin Rofls <colin@cmyr.net>", "Nikolaus Waxweiler <madigens@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,4 +35,4 @@ pub use layer::Layer;
 pub use shared_types::{
     Color, Guideline, Identifier, IntegerOrFloat, Line, NonNegativeIntegerOrFloat,
 };
-pub use ufo::{FormatVersion, LayerInfo, MetaInfo, Ufo};
+pub use ufo::{FormatVersion, LayerInfo, MetaInfo, Ufo, UfoDataRequest};


### PR DESCRIPTION
This makes it so I can do this in MFEQ's Qmetadata:

```rust
fn main() {
    ..
    let ufo = Ufo::with_fields(UfoDataRequest::from_bool(false)).load_ufo(matches.value_of("UFO").unwrap());
    ..
}
```

That MFEQ module will never need all the glyph and kerning parsing this took does; so all it does is slow things down substantially, especially with the 125MB UFO for [TT2020 Style F](https://fontlibrary.org/fr/font/tt2020-style-f). I know Rust maintainers are rather picky, so if you don't like this idea, just let me know, I'm happy to maintain my own Norad version, I already maintain a personal `.glif` parser because I need Skia-friendly points.