### PR TITLE
Consolidate Color methods to shared_types

### DIFF
--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -507,19 +507,6 @@ impl FromStr for GlifVersion {
     }
 }
 
-impl FromStr for Color {
-    type Err = ErrorKind;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut iter = s.split(',').map(|s| s.parse::<f32>().map_err(|_| ErrorKind::BadColor));
-        Ok(Color {
-            red: iter.next().ok_or(ErrorKind::BadColor).and_then(|r| r)?,
-            green: iter.next().ok_or(ErrorKind::BadColor).and_then(|r| r)?,
-            blue: iter.next().ok_or(ErrorKind::BadColor).and_then(|r| r)?,
-            alpha: iter.next().ok_or(ErrorKind::BadColor).and_then(|r| r)?,
-        })
-    }
-}
-
 impl FromStr for PointType {
     type Err = ErrorKind;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -62,23 +62,18 @@ impl FromStr for Color {
     type Err = ErrorKind;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let colors: Vec<f32> = s.split(',').map(|v| v.parse().unwrap()).collect();
-        if colors.len() != 4 {
-            return Err(ErrorKind::BadColor);
-        }
-
-        let red = colors[0];
-        let green = colors[1];
-        let blue = colors[2];
-        let alpha = colors[3];
-        if (0.0..=1.0).contains(&red)
-            && (0.0..=1.0).contains(&green)
-            && (0.0..=1.0).contains(&blue)
-            && (0.0..=1.0).contains(&alpha)
-        {
-            Ok(Color { red, green, blue, alpha })
-        } else {
+        let mut iter = s.split(',').map(|v| match v.parse::<f32>() {
+            Ok(val) if (0.0..=1.0).contains(&val) => Ok(val),
+            _ => Err(ErrorKind::BadColor),
+        });
+        let red = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        let green = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        let blue = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        let alpha = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        if iter.next().is_some() {
             Err(ErrorKind::BadColor)
+        } else {
+            Ok(Color { red, green, blue, alpha })
         }
     }
 }


### PR DESCRIPTION
I noticed that there is a `Color::from_str` already, but the one I wrote for serde is more anal.