### PR TITLE
Add sanity check for outlines, add point pen

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -79,9 +79,23 @@ pub enum ErrorKind {
     BadImage,
     BadIdentifier,
     UnexpectedDuplicate,
+    UnexpectedMove,
+    UnexpectedSmooth,
     UnexpectedElement,
     UnexpectedAttribute,
     UnexpectedEof,
+    UnexpectedPointAfterOffCurve,
+    TooManyOffCurves,
+    PenPathNotStarted,
+    TrailingOffCurves,
+    DuplicateIdentifier,
+    UnexpectedDrawing,
+    UnfinishedDrawing,
+    UnexpectedPointField,
+    UnexpectedComponentField,
+    UnexpectedAnchorField,
+    UnexpectedGuidelineField,
+    UnexpectedImageField,
 }
 
 impl std::fmt::Display for Error {
@@ -139,9 +153,35 @@ impl std::fmt::Display for ErrorKind {
             ErrorKind::BadImage => write!(f, "Bad image"),
             ErrorKind::BadIdentifier => write!(f, "Bad identifier"),
             ErrorKind::UnexpectedDuplicate => write!(f, "Unexpected duplicate"),
+            ErrorKind::UnexpectedMove => {
+                write!(f, "Unexpected move point, can only occur at start of contour")
+            }
+            ErrorKind::UnexpectedSmooth => {
+                write!(f, "Unexpected smooth attribute on an off-curve point")
+            }
             ErrorKind::UnexpectedElement => write!(f, "Unexpected element"),
             ErrorKind::UnexpectedAttribute => write!(f, "Unexpected attribute"),
             ErrorKind::UnexpectedEof => write!(f, "Unexpected EOF"),
+            ErrorKind::UnexpectedPointAfterOffCurve => {
+                write!(f, "An off-curve point must be followed by a curve or qcurve")
+            }
+            ErrorKind::TooManyOffCurves => {
+                write!(f, "At most two off-curve points can precede a curve")
+            }
+            ErrorKind::PenPathNotStarted => {
+                write!(f, "Must call begin_path() before calling add_point() or end_path()")
+            }
+            ErrorKind::TrailingOffCurves => {
+                write!(f, "Open contours must not have trailing off-curves")
+            }
+            ErrorKind::DuplicateIdentifier => write!(f, "Duplicate identifier"),
+            ErrorKind::UnexpectedDrawing => write!(f, "Unexpected drawing without an outline"),
+            ErrorKind::UnfinishedDrawing => write!(f, "Unfinished drawing, you must call end_path"),
+            ErrorKind::UnexpectedPointField => write!(f, "Unexpected point field"),
+            ErrorKind::UnexpectedComponentField => write!(f, "Unexpected component field "),
+            ErrorKind::UnexpectedAnchorField => write!(f, "Unexpected anchor field "),
+            ErrorKind::UnexpectedGuidelineField => write!(f, "Unexpected guideline field "),
+            ErrorKind::UnexpectedImageField => write!(f, "Unexpected image field "),
         }
     }
 }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -1,6 +1,7 @@
 //! Data related to individual glyphs.
 
 mod parse;
+pub mod pen;
 mod serialize;
 #[cfg(test)]
 mod tests;
@@ -19,7 +20,7 @@ use crate::shared_types::{Color, Guideline, Identifier, Line};
 pub type GlyphName = Arc<str>;
 
 //FIXME: actually load the 'lib' data
-type Plist = ();
+pub type Plist = ();
 
 /// A glyph, loaded from a [.glif file][glif].
 ///
@@ -155,10 +156,16 @@ pub struct Component {
     pub identifier: Option<Identifier>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Contour {
     pub identifier: Option<Identifier>,
     pub points: Vec<ContourPoint>,
+}
+
+impl Contour {
+    fn is_closed(&self) -> bool {
+        self.points.first().map_or(true, |v| v.typ != PointType::Move)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -1,7 +1,7 @@
 //! Data related to individual glyphs.
 
+pub mod builder;
 mod parse;
-pub mod pen;
 mod serialize;
 #[cfg(test)]
 mod tests;

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -101,7 +101,7 @@ impl<'names> GlifParser<'names> {
     ) -> Result<(), Error> {
         let mut identifier = None;
         for attr in data.attributes() {
-            if self.pen.format() == &GlifVersion::V1 {
+            if self.pen.get_format() == &GlifVersion::V1 {
                 return Err(err!(reader, ErrorKind::UnexpectedAttribute));
             }
             let attr = attr?;

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -464,7 +464,7 @@ fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<Pen, Error> {
                     }
                 }
                 if !name.is_empty() && format.is_some() {
-                    return Ok(Pen::new(name.into(), format.take().unwrap()));
+                    return Ok(Pen::new(name, format.take().unwrap()));
                 } else {
                     return Err(err!(reader, ErrorKind::WrongFirstElement));
                 }

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use super::*;
 use crate::error::{ErrorKind, GlifErrorInternal};
+use crate::glyph::pen::Pen;
 use crate::names::NameList;
 
 use quick_xml::{
@@ -26,7 +27,7 @@ macro_rules! err {
 type Error = GlifErrorInternal;
 
 pub(crate) struct GlifParser<'names> {
-    glyph: Glyph,
+    pen: Pen,
     /// Optional set of glyph names to be reused between glyphs.
     names: Option<&'names NameList>,
 }
@@ -37,8 +38,8 @@ impl<'names> GlifParser<'names> {
         let mut buf = Vec::new();
         reader.trim_text(true);
 
-        let glyph = start(&mut reader, &mut buf)?;
-        let this = GlifParser { glyph, names };
+        let pen = start(&mut reader, &mut buf)?;
+        let this = GlifParser { pen, names };
         this.parse_body(&mut reader, &mut buf)
     }
 
@@ -53,18 +54,9 @@ impl<'names> GlifParser<'names> {
                         "note" => self.parse_note(reader, buf)?,
                         "advance" => self.parse_advance(reader, start)?,
                         "unicode" => self.parse_unicode(reader, start)?,
-                        "anchor" => match &self.glyph.format {
-                            GlifVersion::V1 => return Err(err!(reader, ErrorKind::UnexpectedTag)),
-                            GlifVersion::V2 => self.parse_anchor(reader, start)?,
-                        },
-                        "guideline" => match &self.glyph.format {
-                            GlifVersion::V1 => return Err(err!(reader, ErrorKind::UnexpectedTag)),
-                            GlifVersion::V2 => self.parse_guideline(reader, start)?,
-                        },
-                        "image" => match &self.glyph.format {
-                            GlifVersion::V1 => return Err(err!(reader, ErrorKind::UnexpectedTag)),
-                            GlifVersion::V2 => self.parse_image(reader, start)?,
-                        },
+                        "anchor" => self.parse_anchor(reader, start)?,
+                        "guideline" => self.parse_guideline(reader, start)?,
+                        "image" => self.parse_image(reader, start)?,
                         _other => return Err(err!(reader, ErrorKind::UnexpectedTag)),
                     }
                 }
@@ -72,8 +64,7 @@ impl<'names> GlifParser<'names> {
                 _other => return Err(err!(reader, ErrorKind::MissingCloseTag)),
             }
         }
-        self.glyph.format = GlifVersion::V2;
-        Ok(self.glyph)
+        Ok(self.pen.finish().map_err(|e| err!(reader, e))?)
     }
 
     fn parse_outline(
@@ -81,11 +72,7 @@ impl<'names> GlifParser<'names> {
         reader: &mut Reader<&[u8]>,
         buf: &mut Vec<u8>,
     ) -> Result<(), Error> {
-        if self.glyph.outline.is_some() {
-            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
-        }
-
-        self.glyph.outline = Some(Outline { components: Vec::new(), contours: Vec::new() });
+        self.pen.outline().map_err(|e| err!(reader, e))?;
 
         loop {
             match reader.read_event(buf)? {
@@ -114,7 +101,7 @@ impl<'names> GlifParser<'names> {
     ) -> Result<(), Error> {
         let mut identifier = None;
         for attr in data.attributes() {
-            if self.glyph.format == GlifVersion::V1 {
+            if self.pen.format() == &GlifVersion::V1 {
                 return Err(err!(reader, ErrorKind::UnexpectedAttribute));
             }
             let attr = attr?;
@@ -127,35 +114,18 @@ impl<'names> GlifParser<'names> {
             }
         }
 
-        let mut points = Vec::new();
+        self.pen.begin_path(identifier).map_err(|e| err!(reader, e))?;
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"contour" => break,
                 Event::Empty(ref start) if start.name() == b"point" => {
-                    let point = self.parse_point(reader, start)?;
-                    points.push(point);
+                    self.parse_point(reader, start)?;
                 }
                 Event::Eof => return Err(err!(reader, ErrorKind::UnexpectedEof)),
                 _other => return Err(err!(reader, ErrorKind::UnexpectedElement)),
             }
         }
-
-        // In the Glif v1 spec, single-point contours that have a "move" type and a name should
-        // be treated as anchors and upgraded.
-        if contour_is_v1_anchor(&self.glyph.format, &points) {
-            let anchor_point = points.remove(0);
-            let anchor = Anchor {
-                name: anchor_point.name,
-                x: anchor_point.x,
-                y: anchor_point.y,
-                identifier: None,
-                color: None,
-            };
-
-            self.glyph.anchors.get_or_insert(Vec::new()).push(anchor);
-        } else {
-            self.glyph.outline.as_mut().unwrap().contours.push(Contour { identifier, points });
-        }
+        self.pen.end_path().map_err(|e| err!(reader, e))?;
 
         Ok(())
     }
@@ -201,16 +171,13 @@ impl<'names> GlifParser<'names> {
             return Err(err!(reader, ErrorKind::BadComponent));
         }
 
-        let component = Component { base: base.unwrap(), transform, identifier };
-        self.glyph.outline.as_mut().unwrap().components.push(component);
+        self.pen
+            .add_component(base.unwrap(), transform, identifier)
+            .map_err(|e| err!(reader, e))?;
         Ok(())
     }
 
     fn parse_lib(&mut self, reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<(), Error> {
-        if self.glyph.lib.is_some() {
-            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
-        }
-
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"lib" => break,
@@ -222,15 +189,13 @@ impl<'names> GlifParser<'names> {
     }
 
     fn parse_note(&mut self, reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<(), Error> {
-        if self.glyph.note.is_some() {
-            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
-        }
-
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"note" => break,
                 Event::Text(text) => {
-                    self.glyph.note = Some(text.unescape_and_decode(reader)?);
+                    self.pen
+                        .note(text.unescape_and_decode(reader)?)
+                        .map_err(|e| err!(reader, e))?;
                 }
                 Event::Eof => return Err(err!(reader, ErrorKind::UnexpectedEof)),
                 _other => (),
@@ -243,7 +208,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &Reader<&[u8]>,
         data: &BytesStart<'a>,
-    ) -> Result<ContourPoint, Error> {
+    ) -> Result<(), Error> {
         let mut name: Option<String> = None;
         let mut x: Option<f32> = None;
         let mut y: Option<f32> = None;
@@ -279,7 +244,11 @@ impl<'names> GlifParser<'names> {
         if x.is_none() || y.is_none() {
             return Err(err!(reader, ErrorKind::BadPoint));
         }
-        Ok(ContourPoint { x: x.unwrap(), y: y.unwrap(), typ, name, identifier, smooth })
+        self.pen
+            .add_point((x.unwrap(), y.unwrap()), typ, smooth, name, identifier)
+            .map_err(|e| err!(reader, e))?;
+
+        Ok(())
     }
 
     fn parse_advance<'a>(
@@ -287,25 +256,30 @@ impl<'names> GlifParser<'names> {
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
     ) -> Result<(), Error> {
-        if self.glyph.advance.is_some() {
-            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
-        }
-
-        let mut advance = Advance::default();
+        let mut width: f32 = 0.0;
+        let mut height: f32 = 0.0;
         for attr in data.attributes() {
             let attr = attr?;
-            if attr.key == b"width" || attr.key == b"height" {
-                let value = attr.unescaped_value()?;
-                let value = reader.decode(&value)?;
-                let value: f32 = value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?;
-                match attr.key {
-                    b"width" => advance.width = value,
-                    b"height" => advance.height = value,
-                    _ => unreachable!(),
-                };
+            match attr.key {
+                b"width" | b"height" => {
+                    let value = attr.unescaped_value()?;
+                    let value = reader.decode(&value)?;
+                    let value: f32 =
+                        value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?;
+                    match attr.key {
+                        b"width" => width = value,
+                        b"height" => height = value,
+                        _other => unreachable!(),
+                    };
+                }
+                _other => return Err(err!(reader, ErrorKind::UnexpectedAttribute)),
             }
         }
-        self.glyph.advance = Some(advance);
+        self.pen
+            .width(width)
+            .map_err(|e| err!(reader, e))?
+            .height(height)
+            .map_err(|e| err!(reader, e))?;
         Ok(())
     }
 
@@ -316,14 +290,17 @@ impl<'names> GlifParser<'names> {
     ) -> Result<(), Error> {
         for attr in data.attributes() {
             let attr = attr?;
-            if attr.key == b"hex" {
-                let value = attr.unescaped_value()?;
-                let value = reader.decode(&value)?;
-                let chr = u32::from_str_radix(&value, 16)
-                    .map_err(|_| value.to_string())
-                    .and_then(|n| char::try_from(n).map_err(|_| value.to_string()))
-                    .map_err(|_| err!(reader, ErrorKind::BadHexValue))?;
-                self.glyph.codepoints.get_or_insert(Vec::new()).push(chr);
+            match attr.key {
+                b"hex" => {
+                    let value = attr.unescaped_value()?;
+                    let value = reader.decode(&value)?;
+                    let chr = u32::from_str_radix(&value, 16)
+                        .map_err(|_| value.to_string())
+                        .and_then(|n| char::try_from(n).map_err(|_| value.to_string()))
+                        .map_err(|_| err!(reader, ErrorKind::BadHexValue))?;
+                    self.pen.unicode(chr);
+                }
+                _other => return Err(err!(reader, ErrorKind::UnexpectedAttribute)),
             }
         }
         Ok(())
@@ -365,8 +342,9 @@ impl<'names> GlifParser<'names> {
         if x.is_none() || y.is_none() {
             return Err(err!(reader, ErrorKind::BadAnchor));
         }
-        let anchors = self.glyph.anchors.get_or_insert(Vec::new());
-        anchors.push(Anchor { x: x.unwrap(), y: y.unwrap(), name, color, identifier });
+        self.pen
+            .anchor(Anchor { x: x.unwrap(), y: y.unwrap(), name, color, identifier })
+            .map_err(|e| err!(reader, e))?;
         Ok(())
     }
 
@@ -412,9 +390,9 @@ impl<'names> GlifParser<'names> {
             (Some(x), Some(y), Some(degrees)) => Line::Angle { x, y, degrees },
             _other => return Err(err!(reader, ErrorKind::BadGuideline)),
         };
-
-        let guideline = Guideline { line, name, color, identifier };
-        self.glyph.guidelines.get_or_insert(Vec::new()).push(guideline);
+        self.pen
+            .guideline(Guideline { line, name, color, identifier })
+            .map_err(|e| err!(reader, e))?;
 
         Ok(())
     }
@@ -424,10 +402,6 @@ impl<'names> GlifParser<'names> {
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
     ) -> Result<(), Error> {
-        if self.glyph.image.is_some() {
-            return Err(err!(reader, ErrorKind::UnexpectedDuplicate));
-        }
-
         let mut filename: Option<PathBuf> = None;
         let mut color: Option<Color> = None;
         let mut transform = AffineTransform::default();
@@ -455,14 +429,15 @@ impl<'names> GlifParser<'names> {
             return Err(err!(reader, ErrorKind::BadImage));
         }
 
-        let image = Image { file_name: filename.unwrap(), color, transform };
-        self.glyph.image = Some(image);
+        self.pen
+            .image(Image { file_name: filename.unwrap(), color, transform })
+            .map_err(|e| err!(reader, e))?;
 
         Ok(())
     }
 }
 
-fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<Glyph, Error> {
+fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<Pen, Error> {
     loop {
         match reader.read_event(buf)? {
             Event::Comment(_) => (),
@@ -472,40 +447,31 @@ fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<Glyph, Error> 
                 let mut format: Option<GlifVersion> = None;
                 for attr in start.attributes() {
                     let attr = attr?;
-                    if attr.key == b"name" {
-                        name = attr.unescape_and_decode_value(&reader)?;
-                    } else if attr.key == b"format" {
-                        let value = attr.unescaped_value()?;
-                        let value = reader.decode(&value)?;
-                        format = Some(
-                            value
-                                .parse()
-                                .map_err(|e: ErrorKind| e.to_error(reader.buffer_position()))?,
-                        );
+                    // XXX: support `formatMinor`
+                    match attr.key {
+                        b"name" => {
+                            name = attr.unescape_and_decode_value(&reader)?;
+                        }
+                        b"format" => {
+                            let value = attr.unescaped_value()?;
+                            let value = reader.decode(&value)?;
+                            format =
+                                Some(value.parse().map_err(|e: ErrorKind| {
+                                    e.to_error(reader.buffer_position())
+                                })?);
+                        }
+                        _other => return Err(err!(reader, ErrorKind::UnexpectedAttribute)),
                     }
                 }
                 if !name.is_empty() && format.is_some() {
-                    return Ok(Glyph::new(name.into(), format.take().unwrap()));
+                    return Ok(Pen::new(name.into(), format.take().unwrap()));
                 } else {
-                    eprintln!("name '{}', format {:?}", name, format);
                     return Err(err!(reader, ErrorKind::WrongFirstElement));
                 }
             }
-            other => {
-                eprintln!("breaking for {:?}", other);
-                break;
-            }
+            _other => return Err(err!(reader, ErrorKind::WrongFirstElement)),
         }
     }
-    Err(err!(reader, ErrorKind::WrongFirstElement))
-}
-
-/// Check if a contour is really an informal anchor according to the Glif v2 specification.
-fn contour_is_v1_anchor(format: &GlifVersion, points: &[ContourPoint]) -> bool {
-    *format == GlifVersion::V1
-        && points.len() == 1
-        && points[0].typ == PointType::Move
-        && points[0].name.is_some()
 }
 
 impl FromStr for GlifVersion {

--- a/src/glyph/pen.rs
+++ b/src/glyph/pen.rs
@@ -1,0 +1,671 @@
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+
+use crate::error::ErrorKind;
+use crate::glyph::{
+    Advance, AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph,
+    GlyphName, Guideline, Image, Outline, Plist, PointType,
+};
+use crate::shared_types::Identifier;
+
+/// A Pen is a consuming builder for [`Glyph`](../struct.Glyph.html)s.
+///
+/// It is different from fontTools' Pen concept, in that it is used to build the entire `Glyph`,
+/// not just the outlines and components, with built-in checking for conformity to the glif
+/// specification. It also upgrades all Glyphs to the highest supported version.
+///
+/// Specifically, the specification defines the following constraints:
+/// 1. If a "move" occurs, it must be the first point of a contour. ufoLib may allow straying from
+///    this for format 1, we don't.
+/// 2. The "smooth" attribute must not be set on off-curve points.
+/// 3. An off-curve point must be followed by a curve or qcurve.
+/// 4. A maximum of two offcurves can precede a curve.
+/// 5. All identifiers used in a `Glyph` must be unique within it.
+///
+/// Since Pen is also used by the Glif parser, additional constraints are baked into Pen to enforce
+/// constraints about how often a Glyph field or "element" can appear in a `.glif` file. For
+/// example, calling `outline()` twice results in an error.
+///
+/// # Example
+///
+/// ```
+/// use std::str::FromStr;
+///
+/// use norad::error::ErrorKind;
+/// use norad::{AffineTransform, Anchor, GlifVersion, Guideline, Identifier, Line, Pen, PointType};
+///
+/// fn main() -> Result<(), ErrorKind> {
+///     let mut pen = Pen::new("test".into(), GlifVersion::V2);
+///     pen.width(10.0)?
+///         .unicode('ä')
+///         .guideline(Guideline {
+///             line: Line::Horizontal(10.0),
+///             name: None,
+///             color: None,
+///             identifier: Some(Identifier::from_str("test1")?),
+///         })?
+///         .anchor(Anchor {
+///             x: 1.0,
+///             y: 2.0,
+///             name: Some("anchor1".into()),
+///             color: None,
+///             identifier: Some(Identifier::from_str("test3")?),
+///         })?
+///         .outline()?
+///         .begin_path(Some(Identifier::from_str("abc")?))?
+///         .add_point((173.0, 536.0), PointType::Line, false, None, None)?
+///         .add_point((85.0, 536.0), PointType::Line, false, None, None)?
+///         .add_point((85.0, 0.0), PointType::Line, false, None, None)?
+///         .add_point((173.0, 0.0), PointType::Line, false, None, Some(Identifier::from_str("def")?))?
+///         .end_path()?
+///         .add_component(
+///             "hallo".into(),
+///             AffineTransform::default(),
+///             Some(Identifier::from_str("xyz")?),
+///         )?;
+///     let glyph = pen.finish()?;
+///     Ok(())
+/// }
+/// ```
+#[derive(Debug)]
+pub struct Pen {
+    glyph: Glyph,
+    height: Option<f32>,
+    width: Option<f32>,
+    identifiers: HashSet<u64>, // All identifiers within a glyph must be unique.
+    scratch_contour: Option<Contour>,
+    number_of_offcurves: u32,
+}
+
+impl Pen {
+    /// Create a new Pen for a `Glyph` named `name`, using the format version `format` to interpret
+    /// commands.
+    pub fn new(name: GlyphName, format: GlifVersion) -> Self {
+        Self {
+            glyph: Glyph::new(name, format),
+            height: None,
+            width: None,
+            identifiers: HashSet::new(),
+            scratch_contour: None,
+            number_of_offcurves: 0,
+        }
+    }
+
+    /// Return the format version currently set.
+    pub fn format(&self) -> &GlifVersion {
+        &self.glyph.format
+    }
+
+    /// Set the glyph width.
+    ///
+    /// Errors when the function is called more than once.
+    pub fn width(&mut self, width: f32) -> Result<&mut Self, ErrorKind> {
+        if self.width.is_some() {
+            return Err(ErrorKind::UnexpectedDuplicate);
+        }
+        self.width.replace(width);
+        Ok(self)
+    }
+
+    /// Set the glyph height.
+    ///
+    /// Errors when the function is called more than once.
+    pub fn height(&mut self, height: f32) -> Result<&mut Self, ErrorKind> {
+        if self.height.is_some() {
+            return Err(ErrorKind::UnexpectedDuplicate);
+        }
+        self.height.replace(height);
+        Ok(self)
+    }
+
+    /// Add the Unicode value `char` to the `Glyph`'s Unicode values.
+    pub fn unicode(&mut self, unicode: char) -> &mut Self {
+        self.glyph.codepoints.get_or_insert(Vec::new()).push(unicode);
+        self
+    }
+
+    /// Add a note to the `Glyph`.
+    ///
+    /// Errors when the function is called more than once.
+    pub fn note(&mut self, note: String) -> Result<&mut Self, ErrorKind> {
+        if self.glyph.note.is_some() {
+            return Err(ErrorKind::UnexpectedDuplicate);
+        }
+        self.glyph.note.replace(note);
+        Ok(self)
+    }
+
+    /// Add a guideline to the `Glyph`. The optional identifier must be unique within the `Glyph`.
+    ///
+    /// Errors when format version 1 is set.
+    pub fn guideline(&mut self, guideline: Guideline) -> Result<&mut Self, ErrorKind> {
+        if &self.glyph.format == &GlifVersion::V1 {
+            return Err(ErrorKind::UnexpectedTag);
+        }
+        if let Some(identifier) = &guideline.identifier {
+            let identifier_hash = Self::hash_identifier(&identifier);
+            if !self.identifiers.insert(identifier_hash) {
+                return Err(ErrorKind::DuplicateIdentifier);
+            }
+        }
+        self.glyph.guidelines.get_or_insert(Vec::new()).push(guideline);
+        Ok(self)
+    }
+
+    /// Add an anchor to the `Glyph`.
+    ///
+    /// Errors when format version 1 is set or the optional identifier is not unique within the glyph.
+    pub fn anchor(&mut self, anchor: Anchor) -> Result<&mut Self, ErrorKind> {
+        if &self.glyph.format == &GlifVersion::V1 {
+            return Err(ErrorKind::UnexpectedTag);
+        }
+        if let Some(identifier) = &anchor.identifier {
+            let identifier_hash = Self::hash_identifier(&identifier);
+            if !self.identifiers.insert(identifier_hash) {
+                return Err(ErrorKind::DuplicateIdentifier);
+            }
+        }
+        self.glyph.anchors.get_or_insert(Vec::new()).push(anchor);
+        Ok(self)
+    }
+
+    /// Add an outline to the `Glyph`.
+    ///
+    /// Errors when the function is called more than once.
+    pub fn outline(&mut self) -> Result<&mut Self, ErrorKind> {
+        if self.glyph.outline.is_some() {
+            return Err(ErrorKind::UnexpectedDuplicate);
+        }
+        self.glyph.outline.replace(Outline::default());
+        Ok(self)
+    }
+
+    /// Add an image to the `Glyph`.
+    ///
+    /// Errors when format version 1 is set or the function is called more than once.
+    pub fn image(&mut self, image: Image) -> Result<&mut Self, ErrorKind> {
+        if &self.glyph.format == &GlifVersion::V1 {
+            return Err(ErrorKind::UnexpectedTag);
+        }
+        if self.glyph.image.is_some() {
+            return Err(ErrorKind::UnexpectedDuplicate);
+        }
+        self.glyph.image.replace(image);
+        Ok(self)
+    }
+
+    /// Add a lib to the `Glyph`.
+    ///
+    /// Errors when the function is called more than once.
+    pub fn lib(&mut self, lib: Plist) -> Result<&mut Self, ErrorKind> {
+        if self.glyph.lib.is_some() {
+            return Err(ErrorKind::UnexpectedDuplicate);
+        }
+        self.glyph.lib.replace(lib);
+        Ok(self)
+    }
+
+    /// Consume the pen and return the final `Glyph`.
+    ///
+    /// Errors when a path has been begun but not ended.
+    pub fn finish(mut self) -> Result<Glyph, ErrorKind> {
+        if self.scratch_contour.is_some() {
+            return Err(ErrorKind::UnfinishedDrawing);
+        }
+        if self.height.is_some() || self.width.is_some() {
+            self.glyph.advance = Some(Advance {
+                width: self.width.unwrap_or(0.0),
+                height: self.height.unwrap_or(0.0),
+            })
+        }
+
+        self.glyph.format = GlifVersion::V2;
+        Ok(self.glyph)
+    }
+
+    /// Start a new path to be added to the glyph with `end_path()`.
+    ///
+    /// Errors when:
+    /// 1. `outline()` wasn't called first.
+    /// 2. a path has been begun already but not ended yet.
+    /// 3. format version 1 is set but an identifier has been given.
+    /// 4. the identifier is not unique within the glyph.
+    pub fn begin_path(&mut self, identifier: Option<Identifier>) -> Result<&mut Self, ErrorKind> {
+        if self.glyph.outline.is_none() {
+            return Err(ErrorKind::UnexpectedDrawing);
+        }
+        if self.scratch_contour.is_some() {
+            return Err(ErrorKind::UnfinishedDrawing);
+        }
+        if &self.glyph.format == &GlifVersion::V1 && identifier.is_some() {
+            return Err(ErrorKind::UnexpectedAttribute);
+        }
+        if let Some(identifier) = &identifier {
+            let identifier_hash = Self::hash_identifier(&identifier);
+            if !self.identifiers.insert(identifier_hash) {
+                return Err(ErrorKind::DuplicateIdentifier);
+            }
+        }
+        self.scratch_contour.replace(Contour { identifier, points: Vec::new() });
+        Ok(self)
+    }
+
+    /// Add a point to the path begun by `begin_path()`.
+    ///
+    /// Errors when:
+    /// 1. `outline()` wasn't called first.
+    /// 2. `begin_path()` wasn't called first.
+    /// 3. format version 1 is set but an identifier has been given.
+    /// 4. the identifier is not unique within the glyph.
+    /// 5. the point is an off-curve with the smooth attribute set.
+    /// 6. the point sequence is forbidden by the specification.
+    pub fn add_point(
+        &mut self,
+        point: (f32, f32),
+        segment_type: PointType,
+        smooth: bool,
+        name: Option<String>,
+        identifier: Option<Identifier>,
+    ) -> Result<&mut Self, ErrorKind> {
+        if self.glyph.outline.is_none() {
+            return Err(ErrorKind::UnexpectedDrawing);
+        }
+        if &self.glyph.format == &GlifVersion::V1 && identifier.is_some() {
+            return Err(ErrorKind::UnexpectedAttribute);
+        }
+        if smooth && segment_type == PointType::OffCurve {
+            return Err(ErrorKind::UnexpectedSmooth);
+        }
+
+        let point =
+            ContourPoint { name, x: point.0, y: point.1, typ: segment_type, smooth, identifier };
+        match &mut self.scratch_contour {
+            Some(c) => {
+                match point.typ {
+                    PointType::Move => {
+                        if !c.points.is_empty() {
+                            return Err(ErrorKind::UnexpectedMove);
+                        }
+                    }
+                    PointType::Line => {
+                        if self.number_of_offcurves > 0 {
+                            return Err(ErrorKind::UnexpectedPointAfterOffCurve);
+                        }
+                    }
+                    PointType::OffCurve => self.number_of_offcurves += 1,
+                    PointType::QCurve => self.number_of_offcurves = 0,
+                    PointType::Curve => {
+                        if self.number_of_offcurves > 2 {
+                            return Err(ErrorKind::TooManyOffCurves);
+                        }
+                        self.number_of_offcurves = 0;
+                    }
+                }
+                if let Some(identifier) = &point.identifier {
+                    // TODO: test membership at fn start and insert() before push()?
+                    let identifier_hash = Self::hash_identifier(&identifier);
+                    if !self.identifiers.insert(identifier_hash) {
+                        return Err(ErrorKind::DuplicateIdentifier);
+                    }
+                }
+                c.points.push(point);
+                Ok(self)
+            }
+            None => Err(ErrorKind::PenPathNotStarted),
+        }
+    }
+
+    /// Add a point to the path begun by `begin_path()`.
+    ///
+    /// Errors when:
+    /// 1. `outline()` wasn't called first.
+    /// 2. `begin_path()` wasn't called first.
+    /// 3. the point sequence is forbidden by the specification.
+    ///
+    /// Discards path in case of error.
+    pub fn end_path(&mut self) -> Result<&mut Self, ErrorKind> {
+        if self.glyph.outline.is_none() {
+            return Err(ErrorKind::UnexpectedDrawing);
+        }
+
+        let contour = self.scratch_contour.take();
+        match contour {
+            Some(mut c) => {
+                // If using format version 1, check if we are actually looking at an implicit
+                // anchor and convert if so (leaving an empty outline if there is nothing else).
+                if Self::contour_is_v1_anchor(self.format(), &c.points) {
+                    let anchor_point = c.points.remove(0);
+                    let anchor = Anchor {
+                        name: anchor_point.name,
+                        x: anchor_point.x,
+                        y: anchor_point.y,
+                        identifier: None,
+                        color: None,
+                    };
+                    self.glyph.anchors.get_or_insert(Vec::new()).push(anchor);
+                    Ok(self)
+                // If ending a closed contour with off-curve points, wrap around and check
+                // from the beginning that we have a curve or qcurve following eventually.
+                } else {
+                    if self.number_of_offcurves > 0 {
+                        if c.is_closed() {
+                            for point in &c.points {
+                                match point.typ {
+                                    PointType::OffCurve => self.number_of_offcurves += 1,
+                                    PointType::QCurve => break,
+                                    PointType::Curve => {
+                                        if self.number_of_offcurves > 2 {
+                                            return Err(ErrorKind::TooManyOffCurves);
+                                        }
+                                        break;
+                                    }
+                                    PointType::Line => {
+                                        return Err(ErrorKind::UnexpectedPointAfterOffCurve);
+                                    }
+                                    PointType::Move => unreachable!(),
+                                }
+                            }
+                        } else {
+                            return Err(ErrorKind::TrailingOffCurves);
+                        }
+                    }
+                    self.number_of_offcurves = 0;
+                    self.glyph.outline.get_or_insert(Outline::default()).contours.push(c);
+                    Ok(self)
+                }
+            }
+            None => Err(ErrorKind::PenPathNotStarted),
+        }
+    }
+
+    /// Add a component to the glyph.
+    ///
+    /// Errors when:
+    /// 1. `outline()` wasn't called first.
+    /// 2. format version 1 is set but an identifier has been given.
+    /// 3. the identifier is not unique within the glyph.
+    pub fn add_component(
+        &mut self,
+        base: GlyphName,
+        transform: AffineTransform,
+        identifier: Option<Identifier>,
+    ) -> Result<&mut Self, ErrorKind> {
+        if self.glyph.outline.is_none() {
+            return Err(ErrorKind::UnexpectedDrawing);
+        }
+        if &self.glyph.format == &GlifVersion::V1 && identifier.is_some() {
+            return Err(ErrorKind::UnexpectedAttribute);
+        }
+        if let Some(identifier) = &identifier {
+            let identifier_hash = Self::hash_identifier(&identifier);
+            if !self.identifiers.insert(identifier_hash) {
+                return Err(ErrorKind::DuplicateIdentifier);
+            }
+        }
+        let component = Component { base, transform, identifier };
+        self.glyph.outline.get_or_insert(Outline::default()).components.push(component);
+        Ok(self)
+    }
+
+    /// Return the u64 hash value of an Identifier.
+    fn hash_identifier(identifier: &Identifier) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        identifier.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Check if a contour is really an informal anchor according to the Glif v2 specification.
+    fn contour_is_v1_anchor(format: &GlifVersion, points: &[ContourPoint]) -> bool {
+        *format == GlifVersion::V1
+            && points.len() == 1
+            && points[0].typ == PointType::Move
+            && points[0].name.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::glyph::Line;
+
+    #[test]
+    fn pen_one_line() -> Result<(), ErrorKind> {
+        let mut pen = Pen::new("test".into(), GlifVersion::V2);
+        pen.width(10.0)?
+            .height(20.0)?
+            .unicode('\u{2020}')
+            .unicode('\u{2021}')
+            .note("hello".into())?
+            .guideline(Guideline {
+                line: Line::Horizontal(10.0),
+                name: None,
+                color: None,
+                identifier: Some(Identifier::new("test1".into()).unwrap()),
+            })?
+            .guideline(Guideline {
+                line: Line::Vertical(20.0),
+                name: None,
+                color: None,
+                identifier: Some(Identifier::new("test2".into()).unwrap()),
+            })?
+            .anchor(Anchor {
+                x: 1.0,
+                y: 2.0,
+                name: Some("anchor1".into()),
+                color: None,
+                identifier: Some(Identifier::new("test3".into()).unwrap()),
+            })?
+            .anchor(Anchor {
+                x: 3.0,
+                y: 4.0,
+                name: Some("anchor2".into()),
+                color: None,
+                identifier: Some(Identifier::new("test4".into()).unwrap()),
+            })?
+            .outline()?
+            .begin_path(Some(Identifier::new("abc".into()).unwrap()))?
+            .add_point((173.0, 536.0), PointType::Line, false, None, None)?
+            .add_point((85.0, 536.0), PointType::Line, false, None, None)?
+            .add_point((85.0, 0.0), PointType::Line, false, None, None)?
+            .add_point((173.0, 0.0), PointType::Line, false, None, Some(Identifier::new("def".into()).unwrap()))?
+            .end_path()?
+            .add_component(
+                "hallo".into(),
+                AffineTransform::default(),
+                Some(Identifier::new("xyz".into()).unwrap()),
+            )?;
+        let glyph = pen.finish()?;
+
+        assert_eq!(
+            glyph,
+            Glyph {
+                name: "test".into(),
+                format: GlifVersion::V2,
+                advance: Some(Advance { height: 20.0, width: 10.0 }),
+                codepoints: Some(vec!['†', '‡']),
+                note: Some("hello".into()),
+                guidelines: Some(vec![
+                    Guideline {
+                        line: Line::Horizontal(10.0),
+                        name: None,
+                        color: None,
+                        identifier: Some(Identifier::new("test1".into()).unwrap()),
+                    },
+                    Guideline {
+                        line: Line::Vertical(20.0),
+                        name: None,
+                        color: None,
+                        identifier: Some(Identifier::new("test2".into()).unwrap()),
+                    },
+                ]),
+                anchors: Some(vec![
+                    Anchor {
+                        x: 1.0,
+                        y: 2.0,
+                        name: Some("anchor1".into()),
+                        color: None,
+                        identifier: Some(Identifier::new("test3".into()).unwrap()),
+                    },
+                    Anchor {
+                        x: 3.0,
+                        y: 4.0,
+                        name: Some("anchor2".into()),
+                        color: None,
+                        identifier: Some(Identifier::new("test4".into()).unwrap()),
+                    },
+                ]),
+                outline: Some(Outline {
+                    contours: vec![Contour {
+                        identifier: Some(Identifier::new("abc".into()).unwrap()),
+                        points: vec![
+                            ContourPoint {
+                                name: None,
+                                x: 173.0,
+                                y: 536.0,
+                                typ: PointType::Line,
+                                smooth: false,
+                                identifier: None,
+                            },
+                            ContourPoint {
+                                name: None,
+                                x: 85.0,
+                                y: 536.0,
+                                typ: PointType::Line,
+                                smooth: false,
+                                identifier: None,
+                            },
+                            ContourPoint {
+                                name: None,
+                                x: 85.0,
+                                y: 0.0,
+                                typ: PointType::Line,
+                                smooth: false,
+                                identifier: None,
+                            },
+                            ContourPoint {
+                                name: None,
+                                x: 173.0,
+                                y: 0.0,
+                                typ: PointType::Line,
+                                smooth: false,
+                                identifier: Some(Identifier::new("def".into()).unwrap()),
+                            },
+                        ],
+                    },],
+                    components: vec![Component {
+                        base: "hallo".into(),
+                        transform: AffineTransform {
+                            x_scale: 1.0,
+                            xy_scale: 0.0,
+                            yx_scale: 0.0,
+                            y_scale: 1.0,
+                            x_offset: 0.0,
+                            y_offset: 0.0,
+                        },
+                        identifier: Some(Identifier::new("xyz".into()).unwrap()),
+                    }]
+                }),
+                image: None,
+                lib: None,
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn pen_upgrade_v1_anchor() -> Result<(), ErrorKind> {
+        let mut pen = Pen::new("test".into(), GlifVersion::V1);
+        pen.outline()?
+            .begin_path(None)?
+            .add_point((173.0, 536.0), PointType::Move, false, Some("top".into()), None)?
+            .end_path()?;
+        let glyph = pen.finish()?;
+
+        assert_eq!(
+            glyph,
+            Glyph {
+                name: "test".into(),
+                format: GlifVersion::V2,
+                advance: None,
+                codepoints: None,
+                note: None,
+                guidelines: None,
+                anchors: Some(vec![Anchor {
+                    x: 173.0,
+                    y: 536.0,
+                    name: Some("top".into()),
+                    color: None,
+                    identifier: None,
+                }]),
+                outline: Some(Outline::default()),
+                image: None,
+                lib: None,
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "DuplicateIdentifier")]
+    fn pen_add_guidelines_duplicate_id() {
+        Pen::new("test".into(), GlifVersion::V2)
+            .guideline(Guideline {
+                line: Line::Horizontal(10.0),
+                name: None,
+                color: None,
+                identifier: Some(Identifier::new("test1".into()).unwrap()),
+            })
+            .unwrap()
+            .guideline(Guideline {
+                line: Line::Vertical(20.0),
+                name: None,
+                color: None,
+                identifier: Some(Identifier::new("test1".into()).unwrap()),
+            })
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "DuplicateIdentifier")]
+    fn pen_add_duplicate_id() {
+        Pen::new("test".into(), GlifVersion::V2)
+            .guideline(Guideline {
+                line: Line::Horizontal(10.0),
+                name: None,
+                color: None,
+                identifier: Some(Identifier::new("test1".into()).unwrap()),
+            })
+            .unwrap()
+            .anchor(Anchor {
+                x: 1.0,
+                y: 2.0,
+                name: None,
+                color: None,
+                identifier: Some(Identifier::new("test1".into()).unwrap()),
+            })
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "UnfinishedDrawing")]
+    fn pen_unfinished_drawing() {
+        let mut pen = Pen::new("test".into(), GlifVersion::V2);
+        pen.outline().unwrap().begin_path(Some(Identifier::new("abc".into()).unwrap())).unwrap();
+        let _glyph = pen.finish().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "UnfinishedDrawing")]
+    fn pen_unfinished_drawing2() {
+        let mut pen = Pen::new("test".into(), GlifVersion::V2);
+        pen.outline()
+            .unwrap()
+            .begin_path(Some(Identifier::new("abc".into()).unwrap()))
+            .unwrap()
+            .begin_path(None)
+            .unwrap();
+    }
+}

--- a/src/glyph/pen.rs
+++ b/src/glyph/pen.rs
@@ -316,7 +316,7 @@ impl Pen {
         }
     }
 
-    /// Add a point to the path begun by `begin_path()`.
+    /// Ends the path begun by `begin_path()` and adds the contour it to the glyph's outline.
     ///
     /// Errors when:
     /// 1. `outline()` wasn't called first.
@@ -371,7 +371,9 @@ impl Pen {
                         }
                     }
                     self.number_of_offcurves = 0;
-                    self.glyph.outline.get_or_insert(Outline::default()).contours.push(c);
+                    if c.points.len() > 0 {
+                        self.glyph.outline.get_or_insert(Outline::default()).contours.push(c);
+                    }
                     Ok(self)
                 }
             }

--- a/src/glyph/pen.rs
+++ b/src/glyph/pen.rs
@@ -93,7 +93,7 @@ impl Pen {
     }
 
     /// Return the format version currently set.
-    pub fn format(&self) -> &GlifVersion {
+    pub fn get_format(&self) -> &GlifVersion {
         &self.glyph.format
     }
 
@@ -334,7 +334,7 @@ impl Pen {
             Some(mut c) => {
                 // If using format version 1, check if we are actually looking at an implicit
                 // anchor and convert if so (leaving an empty outline if there is nothing else).
-                if Self::contour_is_v1_anchor(self.format(), &c.points) {
+                if Self::contour_is_v1_anchor(self.get_format(), &c.points) {
                     let anchor_point = c.points.remove(0);
                     let anchor = Anchor {
                         name: anchor_point.name,

--- a/src/glyph/pen.rs
+++ b/src/glyph/pen.rs
@@ -36,7 +36,7 @@ use crate::shared_types::Identifier;
 /// use norad::{AffineTransform, Anchor, GlifVersion, Guideline, Identifier, Line, Pen, PointType};
 ///
 /// fn main() -> Result<(), ErrorKind> {
-///     let mut pen = Pen::new("test".into(), GlifVersion::V2);
+///     let mut pen = Pen::new("test", GlifVersion::V2);
 ///     pen.width(10.0)?
 ///         .unicode('ä')
 ///         .guideline(Guideline {
@@ -81,9 +81,9 @@ pub struct Pen {
 impl Pen {
     /// Create a new Pen for a `Glyph` named `name`, using the format version `format` to interpret
     /// commands.
-    pub fn new(name: GlyphName, format: GlifVersion) -> Self {
+    pub fn new(name: impl Into<GlyphName>, format: GlifVersion) -> Self {
         Self {
-            glyph: Glyph::new(name, format),
+            glyph: Glyph::new(name.into(), format),
             height: None,
             width: None,
             identifiers: HashSet::new(),
@@ -431,7 +431,7 @@ mod tests {
 
     #[test]
     fn pen_one_line() -> Result<(), ErrorKind> {
-        let mut pen = Pen::new("test".into(), GlifVersion::V2);
+        let mut pen = Pen::new("test", GlifVersion::V2);
         pen.width(10.0)?
             .height(20.0)?
             .unicode('\u{2020}')
@@ -468,7 +468,13 @@ mod tests {
             .add_point((173.0, 536.0), PointType::Line, false, None, None)?
             .add_point((85.0, 536.0), PointType::Line, false, None, None)?
             .add_point((85.0, 0.0), PointType::Line, false, None, None)?
-            .add_point((173.0, 0.0), PointType::Line, false, None, Some(Identifier::new("def".into()).unwrap()))?
+            .add_point(
+                (173.0, 0.0),
+                PointType::Line,
+                false,
+                None,
+                Some(Identifier::new("def".into()).unwrap()),
+            )?
             .end_path()?
             .add_component(
                 "hallo".into(),
@@ -576,7 +582,7 @@ mod tests {
 
     #[test]
     fn pen_upgrade_v1_anchor() -> Result<(), ErrorKind> {
-        let mut pen = Pen::new("test".into(), GlifVersion::V1);
+        let mut pen = Pen::new("test", GlifVersion::V1);
         pen.outline()?
             .begin_path(None)?
             .add_point((173.0, 536.0), PointType::Move, false, Some("top".into()), None)?
@@ -611,7 +617,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "DuplicateIdentifier")]
     fn pen_add_guidelines_duplicate_id() {
-        Pen::new("test".into(), GlifVersion::V2)
+        Pen::new("test", GlifVersion::V2)
             .guideline(Guideline {
                 line: Line::Horizontal(10.0),
                 name: None,
@@ -631,7 +637,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "DuplicateIdentifier")]
     fn pen_add_duplicate_id() {
-        Pen::new("test".into(), GlifVersion::V2)
+        Pen::new("test", GlifVersion::V2)
             .guideline(Guideline {
                 line: Line::Horizontal(10.0),
                 name: None,
@@ -652,7 +658,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "UnfinishedDrawing")]
     fn pen_unfinished_drawing() {
-        let mut pen = Pen::new("test".into(), GlifVersion::V2);
+        let mut pen = Pen::new("test", GlifVersion::V2);
         pen.outline().unwrap().begin_path(Some(Identifier::new("abc".into()).unwrap())).unwrap();
         let _glyph = pen.finish().unwrap();
     }
@@ -660,7 +666,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "UnfinishedDrawing")]
     fn pen_unfinished_drawing2() {
-        let mut pen = Pen::new("test".into(), GlifVersion::V2);
+        let mut pen = Pen::new("test", GlifVersion::V2);
         pen.outline()
             .unwrap()
             .begin_path(Some(Identifier::new("abc".into()).unwrap()))

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -422,3 +422,31 @@ fn empty_outlines() {
     let test2 = parse_glyph(data2.as_bytes()).unwrap();
     assert_eq!(test2.outline.unwrap(), Outline::default());
 }
+
+#[test]
+fn empty_contours() {
+    let data1 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                </contour>
+                <contour identifier="aaa">
+                </contour>
+            </outline>
+        </glyph>
+        "#;
+    let data2 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour/>
+                <contour identifier="bbb"/>
+            </outline>
+        </glyph>
+        "#;
+    let test1 = parse_glyph(data1.as_bytes()).unwrap();
+    assert_eq!(test1.outline.unwrap(), Outline::default());
+    let test2 = parse_glyph(data2.as_bytes()).unwrap();
+    assert_eq!(test2.outline.unwrap(), Outline::default());
+}

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -160,3 +160,244 @@ fn druid_from_color() {
 //let glyph = parse_glyph(bytes).unwrap();
 //assert_eq!(glyph.width, Some(268.));
 //}
+
+#[test]
+#[should_panic(expected = "UnexpectedMove")]
+fn unexpected_move() {
+    let data = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="period" format="2">
+            <advance width="268"/>
+            <unicode hex="002E"/>
+            <outline>
+                <contour>
+                    <point x="237" y="152"/>
+                    <point x="193" y="187" type="move"/>
+                </contour>
+            </outline>
+        </glyph>
+"#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "UnexpectedSmooth")]
+fn unexpected_smooth() {
+    let data = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="period" format="2">
+            <advance width="268"/>
+            <unicode hex="002E"/>
+            <outline>
+                    <contour>
+                        <point x="193" y="187" smooth="yes"/>
+                    </contour>
+            </outline>
+        </glyph>
+  "#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+fn zero_to_two_offcurves_before_curve() {
+    let data1 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0" type="line"/>
+                    <point x="100" y="100" type="curve"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let data2 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0" type="line"/>
+                    <point x="50" y="50"/>
+                    <point x="100" y="100" type="curve"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let data3 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0" type="line"/>
+                    <point x="33" y="33"/>
+                    <point x="66" y="66"/>
+                    <point x="100" y="100" type="curve"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let data4 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="100" y="100" type="curve"/>
+                    <point x="0" y="0" type="line"/>
+                    <point x="33" y="33"/>
+                    <point x="66" y="66"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let _ = parse_glyph(data1.as_bytes()).unwrap();
+    let _ = parse_glyph(data2.as_bytes()).unwrap();
+    let _ = parse_glyph(data3.as_bytes()).unwrap();
+    let _ = parse_glyph(data4.as_bytes()).unwrap();
+}
+
+#[test]
+fn valid_offcurves() {
+    let data1 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let data2 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0"/>
+                    <point x="100" y="100"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let data3 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0"/>
+                    <point x="50" y="25"/>
+                    <point x="100" y="100"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let data4 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0"/>
+                    <point x="50" y="25" type="curve"/>
+                    <point x="100" y="100"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let _ = parse_glyph(data1.as_bytes()).unwrap();
+    let _ = parse_glyph(data2.as_bytes()).unwrap();
+    let _ = parse_glyph(data3.as_bytes()).unwrap();
+    let _ = parse_glyph(data4.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "TrailingOffCurves")]
+fn trailing_off_curves() {
+    let data = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0" type="move"/>
+                    <point x="50" y="25"/>
+                    <point x="100" y="100"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "TooManyOffCurves")]
+fn too_many_off_curves() {
+    let data = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="0" y="0" type="line"/>
+                    <point x="33" y="33"/>
+                    <point x="66" y="66"/>
+                    <point x="77" y="77"/>
+                    <point x="100" y="100" type="curve"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "UnexpectedPointAfterOffCurve")]
+fn unexpected_line_after_offcurve1() {
+    let data = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="1" y="1" type="line"/>
+                    <point x="33" y="33"/>
+                    <point x="0" y="0" type="line"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "UnexpectedPointAfterOffCurve")]
+fn unexpected_line_after_offcurve2() {
+    let data = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="301" y="714" type="line" smooth="yes"/>
+                    <point x="572" y="537" type="curve" smooth="yes"/>
+                    <point x="572" y="667"/>
+                    <point x="479" y="714"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "UnexpectedPointAfterOffCurve")]
+fn unexpected_line_after_offcurve3() {
+    let data = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+                <contour>
+                    <point x="479" y="714"/>
+                    <point x="301" y="714" type="line" smooth="yes"/>
+                    <point x="572" y="537" type="curve" smooth="yes"/>
+                    <point x="572" y="667"/>
+                </contour>
+            </outline>
+        </glyph>
+    "#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -401,3 +401,24 @@ fn unexpected_line_after_offcurve3() {
     "#;
     let _ = parse_glyph(data.as_bytes()).unwrap();
 }
+
+#[test]
+fn empty_outlines() {
+    let data1 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline>
+            </outline>
+        </glyph>
+        "#;
+    let data2 = r#"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <glyph name="test" format="2">
+            <outline/>
+        </glyph>
+        "#;
+    let test1 = parse_glyph(data1.as_bytes()).unwrap();
+    assert_eq!(test1.outline.unwrap(), Outline::default());
+    let test2 = parse_glyph(data2.as_bytes()).unwrap();
+    assert_eq!(test2.outline.unwrap(), Outline::default());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,10 @@ mod upconversion;
 
 pub use error::Error;
 pub use fontinfo::FontInfo;
-pub use glyph::{Glyph, GlyphName};
+pub use glyph::{
+    pen::Pen, Advance, AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion,
+    Glyph, GlyphName, Image, Outline, Plist, PointType,
+};
 pub use layer::Layer;
 pub use shared_types::{
     Color, Guideline, Identifier, IntegerOrFloat, Line, NonNegativeIntegerOrFloat,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ mod upconversion;
 pub use error::Error;
 pub use fontinfo::FontInfo;
 pub use glyph::{
-    pen::Pen, Advance, AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion,
-    Glyph, GlyphName, Image, Outline, Plist, PointType,
+    builder::GlyphBuilder, Advance, AffineTransform, Anchor, Component, Contour, ContourPoint,
+    GlifVersion, Glyph, GlyphName, Image, Outline, Plist, PointType,
 };
 pub use layer::Layer;
 pub use shared_types::{

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use serde::de;
 use serde::de::Deserializer;
+use serde::ser;
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Serialize};
 
@@ -177,7 +178,12 @@ impl Serialize for Guideline {
         let (x, y, angle) = match self.line {
             Line::Vertical(x) => (Some(x), None, None),
             Line::Horizontal(y) => (None, Some(y), None),
-            Line::Angle { x, y, degrees } => (Some(x), Some(y), Some(degrees)),
+            Line::Angle { x, y, degrees } => {
+                if !(0.0..=360.0).contains(&degrees) {
+                    return Err(ser::Error::custom("angle must be between 0 and 360 degrees."));
+                }
+                (Some(x), Some(y), Some(degrees))
+            }
         };
 
         let mut guideline = serializer.serialize_struct("RawGuideline", 6)?;

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -45,6 +45,7 @@ pub enum Line {
     Horizontal(f32),
     /// An angled line passing through `(x, y)` at `degrees` degrees counteer-clockwise
     /// to the horizontal.
+    // TODO: make a Degrees newtype that checks `0 <= degrees <= 360`.
     Angle { x: f32, y: f32, degrees: f32 },
 }
 


### PR DESCRIPTION
As detailed on https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#point.

I'm not quite sure about off-curves follows by a `move`, so I opened https://github.com/unified-font-object/ufo-spec/issues/148.

Also added a GlyphPointPen for programmatically drawing glyphs, like https://fonttools.readthedocs.io/en/latest/pens/pointPen.html.