### PR TITLE
Split OutlineBuilder from GlyphBuilder

### DIFF
--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1163,6 +1163,7 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 mod tests {
     use super::*;
     use serde_test::{assert_tokens, Token};
+    use std::str::FromStr;
 
     #[test]
     fn fontinfo() {
@@ -1237,7 +1238,7 @@ mod tests {
                     line: Line::Angle { x: 1.0, y: 2.0, degrees: 0.0 },
                     name: Some(" [locked]".to_string()),
                     color: Some(Color { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 }),
-                    identifier: Identifier::new("abc".to_string()).ok(),
+                    identifier: Some(Identifier::from_str("abc").unwrap()),
                 },
             ])
         );

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1163,7 +1163,6 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 mod tests {
     use super::*;
     use serde_test::{assert_tokens, Token};
-    use std::str::FromStr;
 
     #[test]
     fn fontinfo() {
@@ -1238,7 +1237,7 @@ mod tests {
                     line: Line::Angle { x: 1.0, y: 2.0, degrees: 0.0 },
                     name: Some(" [locked]".to_string()),
                     color: Some(Color { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 }),
-                    identifier: Some(Identifier::from_str("abc").unwrap()),
+                    identifier: Some(Identifier::new("abc").unwrap()),
                 },
             ])
         );

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -45,18 +45,18 @@ use crate::shared_types::Identifier;
 ///             line: Line::Horizontal(10.0),
 ///             name: None,
 ///             color: None,
-///             identifier: Some(Identifier::from_str("test1")?),
+///             identifier: Some(Identifier::new("test1")?),
 ///         })?
 ///         .anchor(Anchor {
 ///             x: 1.0,
 ///             y: 2.0,
 ///             name: Some("anchor1".into()),
 ///             color: None,
-///             identifier: Some(Identifier::from_str("test3")?),
+///             identifier: Some(Identifier::new("test3")?),
 ///         })?;
 ///     let mut outline_builder = OutlineBuilder::new();
 ///     outline_builder
-///         .begin_path(Some(Identifier::from_str("abc")?))?
+///         .begin_path(Some(Identifier::new("abc")?))?
 ///         .add_point((173.0, 536.0), PointType::Line, false, None, None)?
 ///         .add_point((85.0, 536.0), PointType::Line, false, None, None)?
 ///         .add_point((85.0, 0.0), PointType::Line, false, None, None)?
@@ -65,13 +65,13 @@ use crate::shared_types::Identifier;
 ///             PointType::Line,
 ///             false,
 ///             None,
-///             Some(Identifier::from_str("def")?),
+///             Some(Identifier::new("def")?),
 ///         )?
 ///         .end_path()?
 ///         .add_component(
 ///             "hallo".into(),
 ///             AffineTransform::default(),
-///             Some(Identifier::from_str("xyz")?),
+///             Some(Identifier::new("xyz")?),
 ///         )?;
 ///     let (outline, identifiers) = outline_builder.finish()?;
 ///     builder.outline(outline, identifiers)?;
@@ -446,7 +446,6 @@ fn insert_identifier(
 mod tests {
     use super::*;
     use crate::glyph::Line;
-    use std::str::FromStr;
 
     #[test]
     fn glyph_builder_basic() -> Result<(), ErrorKind> {
@@ -461,32 +460,32 @@ mod tests {
                 line: Line::Horizontal(10.0),
                 name: None,
                 color: None,
-                identifier: Some(Identifier::from_str("test1").unwrap()),
+                identifier: Some(Identifier::new("test1").unwrap()),
             })?
             .guideline(Guideline {
                 line: Line::Vertical(20.0),
                 name: None,
                 color: None,
-                identifier: Some(Identifier::from_str("test2").unwrap()),
+                identifier: Some(Identifier::new("test2").unwrap()),
             })?
             .anchor(Anchor {
                 x: 1.0,
                 y: 2.0,
                 name: Some("anchor1".into()),
                 color: None,
-                identifier: Some(Identifier::from_str("test3").unwrap()),
+                identifier: Some(Identifier::new("test3").unwrap()),
             })?
             .anchor(Anchor {
                 x: 3.0,
                 y: 4.0,
                 name: Some("anchor2".into()),
                 color: None,
-                identifier: Some(Identifier::from_str("test4").unwrap()),
+                identifier: Some(Identifier::new("test4").unwrap()),
             })?;
 
         let mut outline_builder = OutlineBuilder::new();
         outline_builder
-            .begin_path(Some(Identifier::from_str("abc").unwrap()))?
+            .begin_path(Some(Identifier::new("abc").unwrap()))?
             .add_point((173.0, 536.0), PointType::Line, false, None, None)?
             .add_point((85.0, 536.0), PointType::Line, false, None, None)?
             .add_point((85.0, 0.0), PointType::Line, false, None, None)?
@@ -495,13 +494,13 @@ mod tests {
                 PointType::Line,
                 false,
                 None,
-                Some(Identifier::from_str("def").unwrap()),
+                Some(Identifier::new("def").unwrap()),
             )?
             .end_path()?
             .add_component(
                 "hallo".into(),
                 AffineTransform::default(),
-                Some(Identifier::from_str("xyz").unwrap()),
+                Some(Identifier::new("xyz").unwrap()),
             )?;
         let (outline, identifiers) = outline_builder.finish()?;
         builder.outline(outline, identifiers)?;
@@ -520,13 +519,13 @@ mod tests {
                         line: Line::Horizontal(10.0),
                         name: None,
                         color: None,
-                        identifier: Some(Identifier::from_str("test1").unwrap()),
+                        identifier: Some(Identifier::new("test1").unwrap()),
                     },
                     Guideline {
                         line: Line::Vertical(20.0),
                         name: None,
                         color: None,
-                        identifier: Some(Identifier::from_str("test2").unwrap()),
+                        identifier: Some(Identifier::new("test2").unwrap()),
                     },
                 ]),
                 anchors: Some(vec![
@@ -535,19 +534,19 @@ mod tests {
                         y: 2.0,
                         name: Some("anchor1".into()),
                         color: None,
-                        identifier: Some(Identifier::from_str("test3").unwrap()),
+                        identifier: Some(Identifier::new("test3").unwrap()),
                     },
                     Anchor {
                         x: 3.0,
                         y: 4.0,
                         name: Some("anchor2".into()),
                         color: None,
-                        identifier: Some(Identifier::from_str("test4").unwrap()),
+                        identifier: Some(Identifier::new("test4").unwrap()),
                     },
                 ]),
                 outline: Some(Outline {
                     contours: vec![Contour {
-                        identifier: Some(Identifier::from_str("abc").unwrap()),
+                        identifier: Some(Identifier::new("abc").unwrap()),
                         points: vec![
                             ContourPoint {
                                 name: None,
@@ -579,7 +578,7 @@ mod tests {
                                 y: 0.0,
                                 typ: PointType::Line,
                                 smooth: false,
-                                identifier: Some(Identifier::from_str("def").unwrap()),
+                                identifier: Some(Identifier::new("def").unwrap()),
                             },
                         ],
                     },],
@@ -593,7 +592,7 @@ mod tests {
                             x_offset: 0.0,
                             y_offset: 0.0,
                         },
-                        identifier: Some(Identifier::from_str("xyz").unwrap()),
+                        identifier: Some(Identifier::new("xyz").unwrap()),
                     }]
                 }),
                 image: None,
@@ -650,14 +649,14 @@ mod tests {
                 line: Line::Horizontal(10.0),
                 name: None,
                 color: None,
-                identifier: Some(Identifier::from_str("test1").unwrap()),
+                identifier: Some(Identifier::new("test1").unwrap()),
             })
             .unwrap()
             .guideline(Guideline {
                 line: Line::Vertical(20.0),
                 name: None,
                 color: None,
-                identifier: Some(Identifier::from_str("test1").unwrap()),
+                identifier: Some(Identifier::new("test1").unwrap()),
             })
             .unwrap();
     }
@@ -670,7 +669,7 @@ mod tests {
                 line: Line::Horizontal(10.0),
                 name: None,
                 color: None,
-                identifier: Some(Identifier::from_str("test1").unwrap()),
+                identifier: Some(Identifier::new("test1").unwrap()),
             })
             .unwrap()
             .anchor(Anchor {
@@ -678,7 +677,7 @@ mod tests {
                 y: 2.0,
                 name: None,
                 color: None,
-                identifier: Some(Identifier::from_str("test1").unwrap()),
+                identifier: Some(Identifier::new("test1").unwrap()),
             })
             .unwrap();
     }
@@ -687,7 +686,7 @@ mod tests {
     #[should_panic(expected = "UnfinishedDrawing")]
     fn outline_builder_unfinished_drawing() {
         let mut outline_builder = OutlineBuilder::new();
-        outline_builder.begin_path(Some(Identifier::from_str("abc").unwrap())).unwrap();
+        outline_builder.begin_path(Some(Identifier::new("abc").unwrap())).unwrap();
         outline_builder.finish().unwrap();
     }
 
@@ -695,7 +694,7 @@ mod tests {
     #[should_panic(expected = "UnfinishedDrawing")]
     fn outline_builder_unfinished_drawing2() {
         OutlineBuilder::new()
-            .begin_path(Some(Identifier::from_str("abc").unwrap()))
+            .begin_path(Some(Identifier::new("abc").unwrap()))
             .unwrap()
             .begin_path(None)
             .unwrap();

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -1,11 +1,12 @@
 use std::borrow::Borrow;
+use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::str::FromStr;
 
 use super::*;
 use crate::error::{ErrorKind, GlifErrorInternal};
-use crate::glyph::builder::GlyphBuilder;
+use crate::glyph::builder::{GlyphBuilder, OutlineBuilder};
 use crate::names::NameList;
 
 use quick_xml::{
@@ -62,7 +63,9 @@ impl<'names> GlifParser<'names> {
                     match tag_name.borrow() {
                         "outline" => {
                             // ufoLib parses `<outline/>` as an empty outline.
-                            self.builder.outline().map_err(|e| err!(reader, e))?;
+                            self.builder
+                                .outline(Outline::default(), HashSet::new())
+                                .map_err(|e| err!(reader, e))?;
                         }
                         "advance" => self.parse_advance(reader, start)?,
                         "unicode" => self.parse_unicode(reader, start)?,
@@ -84,7 +87,7 @@ impl<'names> GlifParser<'names> {
         reader: &mut Reader<&[u8]>,
         buf: &mut Vec<u8>,
     ) -> Result<(), Error> {
-        self.builder.outline().map_err(|e| err!(reader, e))?;
+        let mut outline_builder = OutlineBuilder::new();
 
         loop {
             match reader.read_event(buf)? {
@@ -92,7 +95,9 @@ impl<'names> GlifParser<'names> {
                     let tag_name = reader.decode(&start.name())?;
                     let mut new_buf = Vec::new(); // borrowck :/
                     match tag_name.borrow() {
-                        "contour" => self.parse_contour(start, reader, &mut new_buf)?,
+                        "contour" => {
+                            self.parse_contour(start, reader, &mut new_buf, &mut outline_builder)?
+                        }
                         _other => return Err(err!(reader, ErrorKind::UnexpectedTag)),
                     }
                 }
@@ -102,7 +107,7 @@ impl<'names> GlifParser<'names> {
                         // Skip empty contours as meaningless.
                         // https://github.com/unified-font-object/ufo-spec/issues/150
                         "contour" => (),
-                        "component" => self.parse_component(reader, start)?,
+                        "component" => self.parse_component(reader, start, &mut outline_builder)?,
                         _other => return Err(err!(reader, ErrorKind::UnexpectedTag)),
                     }
                 }
@@ -111,6 +116,10 @@ impl<'names> GlifParser<'names> {
                 _other => return Err(err!(reader, ErrorKind::UnexpectedElement)),
             }
         }
+
+        let (outline, identifiers) = outline_builder.finish().map_err(|e| err!(reader, e))?;
+        self.builder.outline(outline, identifiers).map_err(|e| err!(reader, e))?;
+
         Ok(())
     }
 
@@ -119,6 +128,7 @@ impl<'names> GlifParser<'names> {
         data: BytesStart,
         reader: &mut Reader<&[u8]>,
         buf: &mut Vec<u8>,
+        outline_builder: &mut OutlineBuilder,
     ) -> Result<(), Error> {
         let mut identifier = None;
         for attr in data.attributes() {
@@ -135,18 +145,18 @@ impl<'names> GlifParser<'names> {
             }
         }
 
-        self.builder.begin_path(identifier).map_err(|e| err!(reader, e))?;
+        outline_builder.begin_path(identifier).map_err(|e| err!(reader, e))?;
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"contour" => break,
                 Event::Empty(ref start) if start.name() == b"point" => {
-                    self.parse_point(reader, start)?;
+                    self.parse_point(reader, start, outline_builder)?;
                 }
                 Event::Eof => return Err(err!(reader, ErrorKind::UnexpectedEof)),
                 _other => return Err(err!(reader, ErrorKind::UnexpectedElement)),
             }
         }
-        self.builder.end_path().map_err(|e| err!(reader, e))?;
+        outline_builder.end_path().map_err(|e| err!(reader, e))?;
 
         Ok(())
     }
@@ -155,6 +165,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &mut Reader<&[u8]>,
         start: BytesStart,
+        outline_builder: &mut OutlineBuilder,
     ) -> Result<(), Error> {
         let mut base: Option<GlyphName> = None;
         let mut identifier: Option<Identifier> = None;
@@ -192,7 +203,7 @@ impl<'names> GlifParser<'names> {
             return Err(err!(reader, ErrorKind::BadComponent));
         }
 
-        self.builder
+        outline_builder
             .add_component(base.unwrap(), transform, identifier)
             .map_err(|e| err!(reader, e))?;
         Ok(())
@@ -229,6 +240,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &Reader<&[u8]>,
         data: &BytesStart<'a>,
+        outline_builder: &mut OutlineBuilder,
     ) -> Result<(), Error> {
         let mut name: Option<String> = None;
         let mut x: Option<f32> = None;
@@ -265,7 +277,7 @@ impl<'names> GlifParser<'names> {
         if x.is_none() || y.is_none() {
             return Err(err!(reader, ErrorKind::BadPoint));
         }
-        self.builder
+        outline_builder
             .add_point((x.unwrap(), y.unwrap()), typ, smooth, name, identifier)
             .map_err(|e| err!(reader, e))?;
 

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use super::*;
 use crate::error::{ErrorKind, GlifErrorInternal};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ mod upconversion;
 pub use error::Error;
 pub use fontinfo::FontInfo;
 pub use glyph::{
-    builder::GlyphBuilder, Advance, AffineTransform, Anchor, Component, Contour, ContourPoint,
-    GlifVersion, Glyph, GlyphName, Image, Outline, Plist, PointType,
+    builder::GlyphBuilder, builder::OutlineBuilder, Advance, AffineTransform, Anchor, Component,
+    Contour, ContourPoint, GlifVersion, Glyph, GlyphName, Image, Outline, Plist, PointType,
 };
 pub use layer::Layer;
 pub use shared_types::{

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -23,7 +23,7 @@ use crate::Error;
 /// Identifiers are specified as a string between one and 100 characters long.
 /// All characters must be in the printable ASCII range, 0x20 to 0x7E.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
-pub struct Identifier(Arc<String>);
+pub struct Identifier(Arc<str>);
 
 /// A guideline associated with a glyph.
 #[derive(Debug, Clone, PartialEq)]
@@ -67,9 +67,10 @@ impl Identifier {
     ///
     /// A valid identifier must have between 0 and 100 characters, and each
     /// character must be in the printable ASCII range, 0x20 to 0x7E.
-    pub fn new(s: String) -> Result<Self, ErrorKind> {
-        if is_valid_identifier(&s) {
-            Ok(Identifier(s.into()))
+    pub fn new(s: impl Into<Arc<str>>) -> Result<Self, ErrorKind> {
+        let string = s.into();
+        if is_valid_identifier(&string) {
+            Ok(Identifier(string))
         } else {
             Err(ErrorKind::BadIdentifier)
         }
@@ -91,11 +92,7 @@ impl Identifier {
 impl FromStr for Identifier {
     type Err = ErrorKind;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if is_valid_identifier(s) {
-            Ok(Identifier(s.to_owned().into()))
-        } else {
-            Err(ErrorKind::BadIdentifier)
-        }
+        Identifier::new(s)
     }
 }
 
@@ -150,7 +147,7 @@ struct RawGuideline {
     identifier: Option<Identifier>,
 }
 
-fn is_valid_identifier(s: &str) -> bool {
+fn is_valid_identifier(s: &Arc<str>) -> bool {
     s.len() <= 100 && s.bytes().all(|b| (0x20..=0x7E).contains(&b))
 }
 
@@ -173,11 +170,7 @@ impl<'de> Deserialize<'de> for Identifier {
         D: Deserializer<'de>,
     {
         let string = String::deserialize(deserializer)?;
-        if is_valid_identifier(&string) {
-            Ok(Identifier(string.into()))
-        } else {
-            Err(de::Error::custom("Identifier must be at most 100 characters long and contain only ASCII characters in the range 0x20 to 0x7E."))
-        }
+        Identifier::new(string).map_err(|_| de::Error::custom("Identifier must be at most 100 characters long and contain only ASCII characters in the range 0x20 to 0x7E."))
     }
 }
 
@@ -443,11 +436,11 @@ mod tests {
     #[test]
     fn identifier_parsing() {
         let valid_chars = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
-        assert!(Identifier::from_str(valid_chars).is_ok());
+        assert!(Identifier::new(valid_chars).is_ok());
 
-        let i2 = Identifier::from_str("0aAä");
+        let i2 = Identifier::new("0aAä");
         assert!(i2.is_err());
-        let i3 = Identifier::from_str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let i3 = Identifier::new("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         assert!(i3.is_err());
     }
 
@@ -457,7 +450,7 @@ mod tests {
             line: Line::Angle { x: 10.0, y: 20.0, degrees: 360.0 },
             name: Some("hello".to_string()),
             color: Some(Color { red: 0.0, green: 0.5, blue: 0.0, alpha: 0.5 }),
-            identifier: Some(Identifier::from_str("abcABC123").unwrap()),
+            identifier: Some(Identifier::new("abcABC123").unwrap()),
         };
         assert_tokens(
             &g1,


### PR DESCRIPTION
This complicates the process slightly because now there's a hand-off between both builders, but is conceptually nicer. I think.