### PR TITLE
Add bloatcmp to CI

### DIFF
--- a/.github/workflows/bloat.yml
+++ b/.github/workflows/bloat.yml
@@ -1,0 +1,100 @@
+on:
+  pull_request:
+  issue_comment:
+    types: [created, edited]
+name: bloat check
+
+jobs:
+  bloat_check:
+    runs-on: macOS-10.14
+    name: post binary size change info
+    # if it isn't an issue comment run every time, otherwise only run if the comment starts with '/bloat'
+    if: (!startsWith(github.eventName, 'issue_comment') || startsWith(github.event.comment.body, '/bloat'))
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: get revisions
+        id: get_revs
+        uses: cmyr/bloat-cmp/get-revs@v2
+        with:
+          command: /bloat
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: fetch refs
+        run: git fetch origin ${{ steps.get_revs.outputs.fetch }}
+        if: steps.get_revs.outputs.fetch != ''
+
+      - name: checkout base
+        uses: actions/checkout@v1
+        with:
+          ref: ${{ steps.get_revs.outputs.base }}
+
+      - name: setup stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: build base (release)
+        if: steps.get_revs.outputs.base != steps.get_revs.outputs.head
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --example=open_ufo
+
+      - name: build base (debug)
+        if: steps.get_revs.outputs.base != steps.get_revs.outputs.head
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --example=open_ufo
+
+      - name: get old sizes
+        if: steps.get_revs.outputs.base != steps.get_revs.outputs.head
+        id: old
+        uses: cmyr/bloat-cmp/get-sizes@v2
+        with:
+          paths: target/release/examples/open_ufo target/debug/examples/open_ufo
+
+      - name: checkout head
+        uses: actions/checkout@v1
+        with:
+          clean: false
+          ref: ${{ steps.get_revs.outputs.head }}
+
+      - name: build head (release)
+        if: steps.get_revs.outputs.base != steps.get_revs.outputs.head
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --example=open_ufo
+
+      - name: build head (debug)
+        if: steps.get_revs.outputs.base != steps.get_revs.outputs.head
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --example=open_ufo
+
+      - name: get new sizes
+        if: steps.get_revs.outputs.base != steps.get_revs.outputs.head
+        id: new
+        uses: cmyr/bloat-cmp/get-sizes@v2
+        with:
+          paths: target/release/examples/open_ufo target/debug/examples/open_ufo
+
+      - name: compare
+        if: steps.get_revs.outputs.base != steps.get_revs.outputs.head
+        id: bloatcmp
+        uses: cmyr/bloat-cmp/compare@v2
+        with:
+            old: ${{ steps.old.outputs.rawSizes }}
+            new: ${{ steps.new.outputs.rawSizes }}
+
+      - name: comment
+        if: steps.get_revs.outputs.base != steps.get_revs.outputs.head
+        uses: cmyr/bloat-cmp/post-comment@v2
+        with:
+          stats: ${{ steps.bloatcmp.outputs.stats }}
+          myToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a new action to CI that will compare the impact on binary size of new and old revisions.

I'd like to have this in place before I start working on the plist changes. 😁 