### PR TITLE
WIP: implement layerinfo loading

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ pub enum Error {
     ExpectedPlistDictionaryError,
     ExpectedPlistStringError,
     ExpectedPositiveValue,
-    TypeError(ErrorKind),
+    InvalidDataError(ErrorKind),
 }
 
 /// An error representing a failure to validate UFO groups.
@@ -149,7 +149,7 @@ impl std::fmt::Display for Error {
             Error::ExpectedPositiveValue => {
                 write!(f, "PositiveIntegerOrFloat expects a positive value.")
             }
-            Error::TypeError(e) => {
+            Error::InvalidDataError(e) => {
                 write!(f, "Type parsing error: '{}", e)
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,9 @@ pub enum Error {
     GroupsError(GroupsValidationError),
     GroupsUpconversionError(GroupsValidationError),
     ExpectedPlistDictionaryError,
+    ExpectedPlistStringError,
     ExpectedPositiveValue,
+    TypeError(ErrorKind),
 }
 
 /// An error representing a failure to validate UFO groups.
@@ -135,11 +137,21 @@ impl std::fmt::Display for Error {
             }
             Error::PlistError(e) => e.fmt(f),
             Error::FontInfoError => write!(f, "FontInfo contains invalid data"),
-            Error::FontInfoUpconversionError => write!(f, "FontInfo contains invalid data after upconversion"),
+            Error::FontInfoUpconversionError => {
+                write!(f, "FontInfo contains invalid data after upconversion")
+            }
             Error::GroupsError(ge) => ge.fmt(f),
-            Error::GroupsUpconversionError(ge) => write!(f, "Upconverting UFO v1 or v2 kerning data to v3 failed: {}", ge),
-            Error::ExpectedPlistDictionaryError => write!(f, "The files groups.plist, kerning.plist and lib.plist must contain plist dictionaries."),
-            Error::ExpectedPositiveValue => write!(f, "PositiveIntegerOrFloat expects a positive value."),
+            Error::GroupsUpconversionError(ge) => {
+                write!(f, "Upconverting UFO v1 or v2 kerning data to v3 failed: {}", ge)
+            }
+            Error::ExpectedPlistDictionaryError => write!(f, "Expected a Plist dictionary."),
+            Error::ExpectedPlistStringError => write!(f, "Expected a Plist string."),
+            Error::ExpectedPositiveValue => {
+                write!(f, "PositiveIntegerOrFloat expects a positive value.")
+            }
+            Error::TypeError(e) => {
+                write!(f, "Type parsing error: '{}", e)
+            }
         }
     }
 }

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -268,7 +268,8 @@ impl PointType {
 }
 
 impl Color {
-    fn to_rgba_string(&self) -> String {
+    pub fn to_rgba_string(&self) -> String {
+        // TODO: Check that all channels are 0.0..=1.0
         format!("{},{},{},{}", self.red, self.green, self.blue, self.alpha)
     }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -177,7 +177,9 @@ impl LayerInfo {
         let color_str = info_content.remove("color");
         if let Some(v) = color_str {
             match v.into_string() {
-                Some(s) => color.replace(Color::from_str(&s).map_err(|e| Error::TypeError(e))?),
+                Some(s) => {
+                    color.replace(Color::from_str(&s).map_err(|e| Error::InvalidDataError(e))?)
+                }
                 None => Err(Error::ExpectedPlistStringError)?,
             };
         };

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -84,7 +84,7 @@ impl Layer {
         fs::create_dir(&path)?;
         plist::to_file_xml(path.join(CONTENTS_FILE), &self.contents)?;
         // Avoid writing empty layerinfo.plist file.
-        if self.info.color.is_some() || self.info.lib.as_ref().map_or(false, |v| !v.is_empty()) {
+        if !self.info.is_empty() {
             self.info.to_file(&path)?;
         }
         for (name, glyph_path) in self.contents.iter() {
@@ -210,6 +210,10 @@ impl LayerInfo {
         plist::Value::Dictionary(dict).to_file_xml(path.join(LAYER_INFO_FILE))?;
 
         Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.color.is_none() && self.lib.as_ref().map_or(true, |v| v.is_empty())
     }
 }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -24,7 +24,7 @@ static LAYER_INFO_FILE: &str = "layerinfo.plist";
 pub struct Layer {
     pub(crate) glyphs: BTreeMap<GlyphName, Arc<Glyph>>,
     contents: BTreeMap<GlyphName, PathBuf>,
-    info: LayerInfoData,
+    info: LayerInfo,
 }
 
 impl Layer {
@@ -68,9 +68,9 @@ impl Layer {
 
         let layerinfo_path = path.join(LAYER_INFO_FILE);
         let info = if layerinfo_path.exists() {
-            LayerInfoData::from_file(&layerinfo_path)?
+            LayerInfo::from_file(&layerinfo_path)?
         } else {
-            LayerInfoData::default()
+            LayerInfo::default()
         };
 
         Ok(Layer { contents, glyphs, info })
@@ -158,7 +158,7 @@ impl Layer {
 ///
 /// [`layerinfo.plist`]: https://unifiedfontobject.org/versions/ufo3/glyphs/layerinfo.plist/
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct LayerInfoData {
+pub struct LayerInfo {
     pub color: Option<Color>,
     pub lib: Option<plist::Dictionary>,
 }
@@ -166,7 +166,7 @@ pub struct LayerInfoData {
 // Problem: layerinfo.plist contains a nested plist dictionary and the plist crate
 // cannot adequately handle that, as ser/de is not implemented for plist::Value.
 // Ser/de must be done manually...
-impl LayerInfoData {
+impl LayerInfo {
     fn from_file(path: &PathBuf) -> Result<Self, Error> {
         let mut info_content = plist::Value::from_file(path)
             .map_err(|e| Error::PlistError(e))?


### PR DESCRIPTION
Implement layerinfo.plist loading: https://unifiedfontobject.org/versions/ufo3/glyphs/layerinfo.plist/

It implements a new `LayerInfo` struct that is attached to every layer and carries data such as a layer color and a layer lib.