### PR TITLE
Protect various objects' identifier and lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 
 [dependencies]
 plist = "1.0.1"
+uuid = { version = "0.8", features = ["v4"] }
 serde = { version =  "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_repr = "0.1"

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -658,7 +658,7 @@ impl FontInfo {
         if let Some(guidelines) = &self.guidelines {
             let mut identifiers: HashSet<Identifier> = HashSet::new();
             for guideline in guidelines {
-                if let Some(id) = &guideline.identifier {
+                if let Some(id) = &guideline.get_identifier() {
                     if !identifiers.insert(id.clone()) {
                         return Err(Error::FontInfoError);
                     }
@@ -1229,30 +1229,22 @@ mod tests {
         assert_eq!(
             font_info.guidelines,
             Some(vec![
-                Guideline {
-                    line: Line::Angle { x: 82.0, y: 720.0, degrees: 90.0 },
-                    name: None,
-                    color: None,
-                    identifier: None
-                },
-                Guideline {
-                    line: Line::Vertical(372.0),
-                    name: None,
-                    color: None,
-                    identifier: None
-                },
-                Guideline {
-                    line: Line::Horizontal(123.0),
-                    name: None,
-                    color: None,
-                    identifier: None
-                },
-                Guideline {
-                    line: Line::Angle { x: 1.0, y: 2.0, degrees: 0.0 },
-                    name: Some(" [locked]".to_string()),
-                    color: Some(Color { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 }),
-                    identifier: Some(Identifier::new("abc").unwrap()),
-                },
+                Guideline::new(
+                    Line::Angle { x: 82.0, y: 720.0, degrees: 90.0 },
+                    None,
+                    None,
+                    None,
+                    None
+                ),
+                Guideline::new(Line::Vertical(372.0), None, None, None, None),
+                Guideline::new(Line::Horizontal(123.0), None, None, None, None),
+                Guideline::new(
+                    Line::Angle { x: 1.0, y: 2.0, degrees: 0.0 },
+                    Some(" [locked]".to_string()),
+                    Some(Color { red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0 }),
+                    Some(Identifier::new("abc").unwrap()),
+                    None
+                ),
             ])
         );
         assert_eq!(
@@ -1402,34 +1394,38 @@ mod tests {
         assert!(fi.validate().is_ok());
 
         fi.guidelines.replace(vec![
-            Guideline {
-                line: Line::Horizontal(10.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test1").unwrap()),
-            },
-            Guideline {
-                line: Line::Vertical(20.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test2").unwrap()),
-            },
+            Guideline::new(
+                Line::Horizontal(10.0),
+                None,
+                None,
+                Some(Identifier::new("test1").unwrap()),
+                None,
+            ),
+            Guideline::new(
+                Line::Vertical(20.0),
+                None,
+                None,
+                Some(Identifier::new("test2").unwrap()),
+                None,
+            ),
         ]);
         assert!(fi.validate().is_ok());
 
         fi.guidelines.replace(vec![
-            Guideline {
-                line: Line::Horizontal(10.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test1").unwrap()),
-            },
-            Guideline {
-                line: Line::Vertical(20.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test1").unwrap()),
-            },
+            Guideline::new(
+                Line::Horizontal(10.0),
+                None,
+                None,
+                Some(Identifier::new("test1").unwrap()),
+                None,
+            ),
+            Guideline::new(
+                Line::Vertical(20.0),
+                None,
+                None,
+                Some(Identifier::new("test1").unwrap()),
+                None,
+            ),
         ]);
         assert!(fi.validate().is_err());
     }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -658,7 +658,7 @@ impl FontInfo {
         if let Some(guidelines) = &self.guidelines {
             let mut identifiers: HashSet<Identifier> = HashSet::new();
             for guideline in guidelines {
-                if let Some(id) = &guideline.get_identifier() {
+                if let Some(id) = guideline.identifier() {
                     if !identifiers.insert(id.clone()) {
                         return Err(Error::FontInfoError);
                     }

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -41,19 +41,21 @@ use crate::shared_types::{Identifier, Plist};
 ///     builder
 ///         .width(10.0)?
 ///         .unicode('ä')
-///         .guideline(Guideline {
-///             line: Line::Horizontal(10.0),
-///             name: None,
-///             color: None,
-///             identifier: Some(Identifier::new("test1")?),
-///         })?
-///         .anchor(Anchor {
-///             x: 1.0,
-///             y: 2.0,
-///             name: Some("anchor1".into()),
-///             color: None,
-///             identifier: Some(Identifier::new("test3")?),
-///         })?;
+///         .guideline(Guideline::new(
+///             Line::Horizontal(10.0),
+///             None,
+///             None,
+///             Some(Identifier::new("test1")?),
+///             None,
+///         ))?
+///         .anchor(Anchor::new(
+///             1.0,
+///             2.0,
+///             Some("anchor1".into()),
+///             None,
+///             Some(Identifier::new("test3")?),
+///             None,
+///         ))?;
 ///     let mut outline_builder = OutlineBuilder::new();
 ///     outline_builder
 ///         .begin_path(Some(Identifier::new("abc")?))?
@@ -150,7 +152,7 @@ impl GlyphBuilder {
         if &self.glyph.format == &GlifVersion::V1 {
             return Err(ErrorKind::UnexpectedTag);
         }
-        insert_identifier(&mut self.identifiers, guideline.identifier.clone())?;
+        insert_identifier(&mut self.identifiers, guideline.get_identifier().clone())?;
         self.glyph.guidelines.get_or_insert(Vec::new()).push(guideline);
         Ok(self)
     }
@@ -196,13 +198,14 @@ impl GlyphBuilder {
                     && c.points[0].name.is_some()
                 {
                     let anchor_point = c.points.remove(0);
-                    let anchor = Anchor {
-                        name: anchor_point.name,
-                        x: anchor_point.x,
-                        y: anchor_point.y,
-                        identifier: None,
-                        color: None,
-                    };
+                    let anchor = Anchor::new(
+                        anchor_point.x,
+                        anchor_point.y,
+                        anchor_point.name,
+                        None,
+                        None,
+                        None,
+                    );
                     self.glyph.anchors.get_or_insert(Vec::new()).push(anchor);
                 }
             }
@@ -296,7 +299,7 @@ impl OutlineBuilder {
             return Err(ErrorKind::UnfinishedDrawing);
         }
         insert_identifier(&mut self.identifiers, identifier.clone())?;
-        self.scratch_contour.replace(Contour { identifier, points: Vec::new() });
+        self.scratch_contour.replace(Contour::new(Vec::new(), identifier, None));
         Ok(self)
     }
 
@@ -320,7 +323,7 @@ impl OutlineBuilder {
         }
 
         let point =
-            ContourPoint { name, x: point.0, y: point.1, typ: segment_type, smooth, identifier };
+            ContourPoint::new(point.0, point.1, segment_type, smooth, name, identifier, None);
 
         match &mut self.scratch_contour {
             Some(c) => {
@@ -413,7 +416,7 @@ impl OutlineBuilder {
         identifier: Option<Identifier>,
     ) -> Result<&mut Self, ErrorKind> {
         insert_identifier(&mut self.identifiers, identifier.clone())?;
-        self.outline.components.push(Component { base, transform, identifier });
+        self.outline.components.push(Component::new(base, transform, identifier, None));
         Ok(self)
     }
 
@@ -456,32 +459,36 @@ mod tests {
             .unicode('\u{2020}')
             .unicode('\u{2021}')
             .note("hello".into())?
-            .guideline(Guideline {
-                line: Line::Horizontal(10.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test1").unwrap()),
-            })?
-            .guideline(Guideline {
-                line: Line::Vertical(20.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test2").unwrap()),
-            })?
-            .anchor(Anchor {
-                x: 1.0,
-                y: 2.0,
-                name: Some("anchor1".into()),
-                color: None,
-                identifier: Some(Identifier::new("test3").unwrap()),
-            })?
-            .anchor(Anchor {
-                x: 3.0,
-                y: 4.0,
-                name: Some("anchor2".into()),
-                color: None,
-                identifier: Some(Identifier::new("test4").unwrap()),
-            })?;
+            .guideline(Guideline::new(
+                Line::Horizontal(10.0),
+                None,
+                None,
+                Some(Identifier::new("test1").unwrap()),
+                None,
+            ))?
+            .guideline(Guideline::new(
+                Line::Vertical(20.0),
+                None,
+                None,
+                Some(Identifier::new("test2").unwrap()),
+                None,
+            ))?
+            .anchor(Anchor::new(
+                1.0,
+                2.0,
+                Some("anchor1".into()),
+                None,
+                Some(Identifier::new("test3").unwrap()),
+                None,
+            ))?
+            .anchor(Anchor::new(
+                3.0,
+                4.0,
+                Some("anchor2".into()),
+                None,
+                Some(Identifier::new("test4").unwrap()),
+                None,
+            ))?;
 
         let mut outline_builder = OutlineBuilder::new();
         outline_builder
@@ -515,76 +522,77 @@ mod tests {
                 codepoints: Some(vec!['†', '‡']),
                 note: Some("hello".into()),
                 guidelines: Some(vec![
-                    Guideline {
-                        line: Line::Horizontal(10.0),
-                        name: None,
-                        color: None,
-                        identifier: Some(Identifier::new("test1").unwrap()),
-                    },
-                    Guideline {
-                        line: Line::Vertical(20.0),
-                        name: None,
-                        color: None,
-                        identifier: Some(Identifier::new("test2").unwrap()),
-                    },
+                    Guideline::new(
+                        Line::Horizontal(10.0),
+                        None,
+                        None,
+                        Some(Identifier::new("test1").unwrap()),
+                        None,
+                    ),
+                    Guideline::new(
+                        Line::Vertical(20.0),
+                        None,
+                        None,
+                        Some(Identifier::new("test2").unwrap()),
+                        None,
+                    ),
                 ]),
                 anchors: Some(vec![
-                    Anchor {
-                        x: 1.0,
-                        y: 2.0,
-                        name: Some("anchor1".into()),
-                        color: None,
-                        identifier: Some(Identifier::new("test3").unwrap()),
-                    },
-                    Anchor {
-                        x: 3.0,
-                        y: 4.0,
-                        name: Some("anchor2".into()),
-                        color: None,
-                        identifier: Some(Identifier::new("test4").unwrap()),
-                    },
+                    Anchor::new(
+                        1.0,
+                        2.0,
+                        Some("anchor1".into()),
+                        None,
+                        Some(Identifier::new("test3").unwrap()),
+                        None
+                    ),
+                    Anchor::new(
+                        3.0,
+                        4.0,
+                        Some("anchor2".into()),
+                        None,
+                        Some(Identifier::new("test4").unwrap()),
+                        None
+                    ),
                 ]),
                 outline: Some(Outline {
-                    contours: vec![Contour {
-                        identifier: Some(Identifier::new("abc").unwrap()),
-                        points: vec![
-                            ContourPoint {
-                                name: None,
-                                x: 173.0,
-                                y: 536.0,
-                                typ: PointType::Line,
-                                smooth: false,
-                                identifier: None,
-                            },
-                            ContourPoint {
-                                name: None,
-                                x: 85.0,
-                                y: 536.0,
-                                typ: PointType::Line,
-                                smooth: false,
-                                identifier: None,
-                            },
-                            ContourPoint {
-                                name: None,
-                                x: 85.0,
-                                y: 0.0,
-                                typ: PointType::Line,
-                                smooth: false,
-                                identifier: None,
-                            },
-                            ContourPoint {
-                                name: None,
-                                x: 173.0,
-                                y: 0.0,
-                                typ: PointType::Line,
-                                smooth: false,
-                                identifier: Some(Identifier::new("def").unwrap()),
-                            },
+                    contours: vec![Contour::new(
+                        vec![
+                            ContourPoint::new(
+                                173.0,
+                                536.0,
+                                PointType::Line,
+                                false,
+                                None,
+                                None,
+                                None,
+                            ),
+                            ContourPoint::new(
+                                85.0,
+                                536.0,
+                                PointType::Line,
+                                false,
+                                None,
+                                None,
+                                None,
+                            ),
+                            ContourPoint::new(85.0, 0.0, PointType::Line, false, None, None, None),
+                            ContourPoint::new(
+                                173.0,
+                                0.0,
+                                PointType::Line,
+                                false,
+                                None,
+                                Some(Identifier::new("def").unwrap()),
+                                None,
+                            ),
                         ],
-                    },],
-                    components: vec![Component {
-                        base: "hallo".into(),
-                        transform: AffineTransform {
+                        Some(Identifier::new("abc").unwrap()),
+                        None,
+                    )],
+                    components: vec![Component::new(
+                        "hallo".into(),
+                        AffineTransform {
                             x_scale: 1.0,
                             xy_scale: 0.0,
                             yx_scale: 0.0,
@@ -592,8 +600,9 @@ mod tests {
                             x_offset: 0.0,
                             y_offset: 0.0,
                         },
-                        identifier: Some(Identifier::new("xyz").unwrap()),
-                    }]
+                        Some(Identifier::new("xyz").unwrap()),
+                        None,
+                    )]
                 }),
                 image: None,
                 lib: None,
@@ -625,13 +634,14 @@ mod tests {
                 codepoints: None,
                 note: None,
                 guidelines: None,
-                anchors: Some(vec![Anchor {
-                    x: 173.0,
-                    y: 536.0,
-                    name: Some("top".into()),
-                    color: None,
-                    identifier: None,
-                }]),
+                anchors: Some(vec![Anchor::new(
+                    173.0,
+                    536.0,
+                    Some("top".into()),
+                    None,
+                    None,
+                    None
+                )]),
                 outline: Some(Outline::default()),
                 image: None,
                 lib: None,
@@ -645,19 +655,21 @@ mod tests {
     #[should_panic(expected = "DuplicateIdentifier")]
     fn glyph_builder_add_guidelines_duplicate_id() {
         GlyphBuilder::new("test", GlifVersion::V2)
-            .guideline(Guideline {
-                line: Line::Horizontal(10.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test1").unwrap()),
-            })
+            .guideline(Guideline::new(
+                Line::Horizontal(10.0),
+                None,
+                None,
+                Some(Identifier::new("test1").unwrap()),
+                None,
+            ))
             .unwrap()
-            .guideline(Guideline {
-                line: Line::Vertical(20.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test1").unwrap()),
-            })
+            .guideline(Guideline::new(
+                Line::Vertical(20.0),
+                None,
+                None,
+                Some(Identifier::new("test1").unwrap()),
+                None,
+            ))
             .unwrap();
     }
 
@@ -665,20 +677,22 @@ mod tests {
     #[should_panic(expected = "DuplicateIdentifier")]
     fn glyph_builder_add_duplicate_id() {
         GlyphBuilder::new("test", GlifVersion::V2)
-            .guideline(Guideline {
-                line: Line::Horizontal(10.0),
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test1").unwrap()),
-            })
+            .guideline(Guideline::new(
+                Line::Horizontal(10.0),
+                None,
+                None,
+                Some(Identifier::new("test1").unwrap()),
+                None,
+            ))
             .unwrap()
-            .anchor(Anchor {
-                x: 1.0,
-                y: 2.0,
-                name: None,
-                color: None,
-                identifier: Some(Identifier::new("test1").unwrap()),
-            })
+            .anchor(Anchor::new(
+                1.0,
+                2.0,
+                None,
+                None,
+                Some(Identifier::new("test1").unwrap()),
+                None,
+            ))
             .unwrap();
     }
 

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -3,9 +3,9 @@ use std::collections::HashSet;
 use crate::error::ErrorKind;
 use crate::glyph::{
     Advance, AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph,
-    GlyphName, Guideline, Image, Outline, Plist, PointType,
+    GlyphName, Guideline, Image, Outline, PointType,
 };
-use crate::shared_types::Identifier;
+use crate::shared_types::{Identifier, Plist};
 
 /// A GlyphBuilder is a consuming builder for [`crate::glyph::Glyph`].
 ///

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -152,7 +152,7 @@ impl GlyphBuilder {
         if &self.glyph.format == &GlifVersion::V1 {
             return Err(ErrorKind::UnexpectedTag);
         }
-        insert_identifier(&mut self.identifiers, guideline.get_identifier().clone())?;
+        insert_identifier(&mut self.identifiers, guideline.identifier().cloned())?;
         self.glyph.guidelines.get_or_insert(Vec::new()).push(guideline);
         Ok(self)
     }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -14,13 +14,10 @@ use druid::{Data, Lens};
 
 use crate::error::{Error, GlifError, GlifErrorInternal};
 use crate::names::NameList;
-use crate::shared_types::{Color, Guideline, Identifier, Line};
+use crate::shared_types::{Color, Guideline, Identifier, Line, Plist};
 
 /// The name of a glyph.
 pub type GlyphName = Arc<str>;
-
-/// A Plist dictionary.
-pub type Plist = plist::Dictionary;
 
 /// A glyph, loaded from a [.glif file][glif].
 ///

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -246,13 +246,13 @@ impl Anchor {
     }
 
     /// Returns an immutable reference to the anchor's lib.
-    pub fn get_lib(&self) -> &Option<Plist> {
-        &self.lib
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
     }
 
     /// Returns a mutable reference to the anchor's lib.
-    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
-        &mut self.lib
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
@@ -270,8 +270,8 @@ impl Anchor {
     }
 
     /// Returns an immutable reference to the anchor's identifier.
-    pub fn get_identifier(&self) -> &Option<Identifier> {
-        &self.identifier
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
     }
 
     /// Replaces the actual identifier by the identifier given in parameter,
@@ -291,13 +291,13 @@ impl Contour {
     }
 
     /// Returns an immutable reference to the contour's lib.
-    pub fn get_lib(&self) -> &Option<Plist> {
-        &self.lib
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
     }
 
     /// Returns a mutable reference to the contour's lib.
-    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
-        &mut self.lib
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
@@ -315,8 +315,8 @@ impl Contour {
     }
 
     /// Returns an immutable reference to the contour's identifier.
-    pub fn get_identifier(&self) -> &Option<Identifier> {
-        &self.identifier
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
     }
 
     /// Replaces the actual identifier by the identifier given in parameter,
@@ -340,13 +340,13 @@ impl ContourPoint {
     }
 
     /// Returns an immutable reference to the contour's lib.
-    pub fn get_lib(&self) -> &Option<Plist> {
-        &self.lib
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
     }
 
     /// Returns a mutable reference to the contour's lib.
-    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
-        &mut self.lib
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
@@ -364,8 +364,8 @@ impl ContourPoint {
     }
 
     /// Returns an immutable reference to the contour's identifier.
-    pub fn get_identifier(&self) -> &Option<Identifier> {
-        &self.identifier
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
     }
 
     /// Replaces the actual identifier by the identifier given in parameter,
@@ -386,13 +386,13 @@ impl Component {
     }
 
     /// Returns an immutable reference to the component's lib.
-    pub fn get_lib(&self) -> &Option<Plist> {
-        &self.lib
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
     }
 
     /// Returns a mutable reference to the component's lib.
-    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
-        &mut self.lib
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
@@ -410,8 +410,8 @@ impl Component {
     }
 
     /// Returns an immutable reference to the component's identifier.
-    pub fn get_identifier(&self) -> &Option<Identifier> {
-        &self.identifier
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
     }
 
     /// Replaces the actual identifier by the identifier given in parameter,

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -135,7 +135,11 @@ pub struct Anchor {
     /// An arbitrary name for the anchor.
     pub name: Option<String>,
     pub color: Option<Color>,
-    pub identifier: Option<Identifier>,
+    /// Unique identifier for the anchor within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The anchor's lib for arbitary data.
+    lib: Option<Plist>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -150,13 +154,21 @@ pub struct Component {
     /// The name of the base glyph.
     pub base: GlyphName,
     pub transform: AffineTransform,
-    pub identifier: Option<Identifier>,
+    /// Unique identifier for the component within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The component's lib for arbitary data.
+    lib: Option<Plist>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Contour {
-    pub identifier: Option<Identifier>,
     pub points: Vec<ContourPoint>,
+    /// Unique identifier for the contour within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The contour's lib for arbitary data.
+    lib: Option<Plist>,
 }
 
 impl Contour {
@@ -167,12 +179,16 @@ impl Contour {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ContourPoint {
-    pub name: Option<String>,
     pub x: f32,
     pub y: f32,
     pub typ: PointType,
     pub smooth: bool,
-    pub identifier: Option<Identifier>,
+    pub name: Option<String>,
+    /// Unique identifier for the point within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The point's lib for arbitary data.
+    lib: Option<Plist>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -215,6 +231,194 @@ pub struct AffineTransform {
     pub y_scale: f32,
     pub x_offset: f32,
     pub y_offset: f32,
+}
+
+impl Anchor {
+    pub fn new(
+        x: f32,
+        y: f32,
+        name: Option<String>,
+        color: Option<Color>,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        Self { x, y, name, color, identifier, lib }
+    }
+
+    /// Returns an immutable reference to the anchor's lib.
+    pub fn get_lib(&self) -> &Option<Plist> {
+        &self.lib
+    }
+
+    /// Returns a mutable reference to the anchor's lib.
+    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
+        &mut self.lib
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the anchor, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the anchor's identifier.
+    pub fn get_identifier(&self) -> &Option<Identifier> {
+        &self.identifier
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}
+
+impl Contour {
+    pub fn new(
+        points: Vec<ContourPoint>,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        Self { points, identifier, lib }
+    }
+
+    /// Returns an immutable reference to the contour's lib.
+    pub fn get_lib(&self) -> &Option<Plist> {
+        &self.lib
+    }
+
+    /// Returns a mutable reference to the contour's lib.
+    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
+        &mut self.lib
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the contour, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the contour's identifier.
+    pub fn get_identifier(&self) -> &Option<Identifier> {
+        &self.identifier
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}
+
+impl ContourPoint {
+    pub fn new(
+        x: f32,
+        y: f32,
+        typ: PointType,
+        smooth: bool,
+        name: Option<String>,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        Self { x, y, typ, smooth, name, identifier, lib }
+    }
+
+    /// Returns an immutable reference to the contour's lib.
+    pub fn get_lib(&self) -> &Option<Plist> {
+        &self.lib
+    }
+
+    /// Returns a mutable reference to the contour's lib.
+    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
+        &mut self.lib
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the contour, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the contour's identifier.
+    pub fn get_identifier(&self) -> &Option<Identifier> {
+        &self.identifier
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}
+
+impl Component {
+    pub fn new(
+        base: GlyphName,
+        transform: AffineTransform,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        Self { base, transform, identifier, lib }
+    }
+
+    /// Returns an immutable reference to the component's lib.
+    pub fn get_lib(&self) -> &Option<Plist> {
+        &self.lib
+    }
+
+    /// Returns a mutable reference to the component's lib.
+    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
+        &mut self.lib
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the component, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the component's identifier.
+    pub fn get_identifier(&self) -> &Option<Identifier> {
+        &self.identifier
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
 }
 
 impl AffineTransform {

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -396,7 +396,7 @@ impl<'names> GlifParser<'names> {
             return Err(err!(reader, ErrorKind::BadAnchor));
         }
         self.builder
-            .anchor(Anchor { x: x.unwrap(), y: y.unwrap(), name, color, identifier })
+            .anchor(Anchor::new(x.unwrap(), y.unwrap(), name, color, identifier, None))
             .map_err(|e| err!(reader, e))?;
         Ok(())
     }
@@ -449,7 +449,7 @@ impl<'names> GlifParser<'names> {
             _other => return Err(err!(reader, ErrorKind::BadGuideline)),
         };
         self.builder
-            .guideline(Guideline { line, name, color, identifier })
+            .guideline(Guideline::new(line, name, color, identifier, None))
             .map_err(|e| err!(reader, e))?;
 
         Ok(())

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -169,7 +169,7 @@ impl Guideline {
             start.push_attribute(("color", color.to_rgba_string().as_str()));
         }
 
-        if let Some(id) = &self.identifier {
+        if let Some(id) = &self.get_identifier() {
             start.push_attribute(("identifier", id.as_str()));
         }
         Event::Empty(start)

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -169,7 +169,7 @@ impl Guideline {
             start.push_attribute(("color", color.to_rgba_string().as_str()));
         }
 
-        if let Some(id) = &self.get_identifier() {
+        if let Some(id) = &self.identifier() {
             start.push_attribute(("identifier", id.as_str()));
         }
         Event::Empty(start)

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -26,10 +26,10 @@ fn parse_v1_upgrade_anchors() {
     assert_eq!(
         glyph.anchors,
         Some(vec![
-            Anchor { name: Some("top".into()), x: 10.0, y: 10.0, color: None, identifier: None },
-            Anchor { name: Some("bottom".into()), x: 10.0, y: 20.0, color: None, identifier: None },
-            Anchor { name: Some("left".into()), x: 30.0, y: 20.0, color: None, identifier: None },
-            Anchor { name: Some("right".into()), x: 40.0, y: 20.0, color: None, identifier: None }
+            Anchor::new(10.0, 10.0, Some("top".into()), None, None, None),
+            Anchor::new(10.0, 20.0, Some("bottom".into()), None, None, None),
+            Anchor::new(30.0, 20.0, Some("left".into()), None, None, None),
+            Anchor::new(40.0, 20.0, Some("right".into()), None, None, None),
         ])
     );
     assert_eq!(glyph.format, GlifVersion::V2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,10 @@ pub use error::Error;
 pub use fontinfo::FontInfo;
 pub use glyph::{
     builder::GlyphBuilder, builder::OutlineBuilder, Advance, AffineTransform, Anchor, Component,
-    Contour, ContourPoint, GlifVersion, Glyph, GlyphName, Image, Outline, Plist, PointType,
+    Contour, ContourPoint, GlifVersion, Glyph, GlyphName, Image, Outline, PointType,
 };
 pub use layer::Layer;
 pub use shared_types::{
-    Color, Guideline, Identifier, IntegerOrFloat, Line, NonNegativeIntegerOrFloat,
+    Color, Guideline, Identifier, IntegerOrFloat, Line, NonNegativeIntegerOrFloat, Plist,
 };
 pub use ufo::{FormatVersion, LayerInfo, MetaInfo, Ufo};

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -78,13 +78,13 @@ impl Guideline {
     }
 
     /// Returns an immutable reference to the Guideline's lib.
-    pub fn get_lib(&self) -> &Option<Plist> {
-        &self.lib
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
     }
 
     /// Returns a mutable reference to the Guideline's lib.
-    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
-        &mut self.lib
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
@@ -102,8 +102,8 @@ impl Guideline {
     }
 
     /// Returns an immutable reference to the Guideline's identifier.
-    pub fn get_identifier(&self) -> &Option<Identifier> {
-        &self.identifier
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
     }
 
     /// Replaces the actual identifier by the identifier given in parameter,

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -16,6 +16,9 @@ use druid::Data;
 use crate::error::ErrorKind;
 use crate::Error;
 
+/// A Plist dictionary.
+pub type Plist = plist::Dictionary;
+
 /// Identifiers are optional attributes of several objects in the UFO.
 /// These identifiers are required to be unique within certain contexts
 /// as defined on a per object basis throughout this specification.

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -36,9 +36,11 @@ pub struct Guideline {
     pub name: Option<String>,
     /// The color of the line.
     pub color: Option<Color>,
-    /// Unique identifier for the guideline. This attribute is not required
-    /// and should only be added to guidelines as needed.
-    pub identifier: Option<Identifier>,
+    /// Unique identifier for the guideline within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The guideline's lib for arbitary data.
+    lib: Option<Plist>,
 }
 
 /// An infinite line.
@@ -64,6 +66,53 @@ pub struct Color {
     pub alpha: f32,
 }
 
+impl Guideline {
+    pub fn new(
+        line: Line,
+        name: Option<String>,
+        color: Option<Color>,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        Self { line, name, color, identifier, lib }
+    }
+
+    /// Returns an immutable reference to the Guideline's lib.
+    pub fn get_lib(&self) -> &Option<Plist> {
+        &self.lib
+    }
+
+    /// Returns a mutable reference to the Guideline's lib.
+    pub fn get_lib_mut(&mut self) -> &mut Option<Plist> {
+        &mut self.lib
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the Guideline, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the Guideline's identifier.
+    pub fn get_identifier(&self) -> &Option<Identifier> {
+        &self.identifier
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}
+
 impl Identifier {
     /// Create a new `Identifier` from a `String`, if it is valid.
     ///
@@ -78,9 +127,19 @@ impl Identifier {
         }
     }
 
+    pub fn from_uuidv4() -> Self {
+        Self::new(uuid::Uuid::new_v4().to_string()).unwrap()
+    }
+
     /// Return the raw identifier, as a `&str`.
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl PartialEq<String> for Identifier {
+    fn eq(&self, other: &String) -> bool {
+        *self.0 == *other
     }
 }
 
@@ -233,12 +292,7 @@ impl<'de> Deserialize<'de> for Guideline {
             }
         };
 
-        Ok(Guideline {
-            line,
-            name: guideline.name,
-            color: guideline.color,
-            identifier: guideline.identifier,
-        })
+        Ok(Guideline::new(line, guideline.name, guideline.color, guideline.identifier, None))
     }
 }
 
@@ -441,12 +495,13 @@ mod tests {
 
     #[test]
     fn guideline_parsing() {
-        let g1 = Guideline {
-            line: Line::Angle { x: 10.0, y: 20.0, degrees: 360.0 },
-            name: Some("hello".to_string()),
-            color: Some(Color { red: 0.0, green: 0.5, blue: 0.0, alpha: 0.5 }),
-            identifier: Some(Identifier::new("abcABC123").unwrap()),
-        };
+        let g1 = Guideline::new(
+            Line::Angle { x: 10.0, y: 20.0, degrees: 360.0 },
+            Some("hello".to_string()),
+            Some(Color { red: 0.0, green: 0.5, blue: 0.0, alpha: 0.5 }),
+            Some(Identifier::new("abcABC123").unwrap()),
+            None,
+        );
         assert_tokens(
             &g1,
             &[


### PR DESCRIPTION
In preparation of adding object libs handling.

This de-pubs `lib` and `identifier` and adds some getters and setters so we can make sure that

1. Having a lib ensures that we also have an identifier
2. The identifier cannot be removed while a lib is present.

Here, we set a UUID v4 identifier if none exists on `replace`ing the lib. Use UUID because we can generate one and be reasonably sure that we probably don't introduce a duplicate, saving us a lengthy check. No support for removing the identifier because the spec says an id should not be removed without reason and I haven't had a need yet.