### PR TITLE
Handle object libs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
     NotCreatedHere,
     /// An error returned when trying to save an UFO in anything less than the latest version.
     DowngradeUnsupported,
+    /// An error returned when trying to save a Glyph that contains a `public.objectLibs`
+    /// lib key already (the key is automatically managed by Norad).
+    PreexistingPublicObjectLibsKey,
     IoError(IoError),
     ParseError(XmlError),
     Glif(GlifError),
@@ -127,6 +130,10 @@ impl std::fmt::Display for Error {
             Error::DowngradeUnsupported => {
                 write!(f, "Downgrading below UFO v3 is not currently supported.")
             }
+            Error::PreexistingPublicObjectLibsKey => write!(
+                f,
+                "The `public.objectLibs` lib key is managed by Norad and must not be set manually."
+            ),
             Error::IoError(e) => e.fmt(f),
             Error::ParseError(e) => e.fmt(f),
             Error::Glif(GlifError { path, position, kind }) => {

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -782,7 +782,7 @@ impl FontInfo {
     }
 
     /// Dump guideline libs into a Plist.
-    pub fn dump_object_libs(&self) -> Plist {
+    pub(crate) fn dump_object_libs(&self) -> Plist {
         let mut object_libs = Plist::default();
 
         if let Some(guidelines) = &self.guidelines {

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -333,7 +333,7 @@ impl FontInfo {
     pub fn from_file<P: AsRef<Path>>(
         path: P,
         format_version: FormatVersion,
-        lib: &mut Option<Plist>,
+        lib: Option<&mut Plist>,
     ) -> Result<Self, Error> {
         match format_version {
             FormatVersion::V3 => {

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -5,9 +5,10 @@ use serde::de::Deserializer;
 use serde::ser::{SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
 
+use crate::error::ErrorKind;
 use crate::shared_types::{
     Bitlist, Float, Guideline, Identifier, Integer, IntegerOrFloat, NonNegativeInteger,
-    NonNegativeIntegerOrFloat,
+    NonNegativeIntegerOrFloat, Plist,
 };
 use crate::{Error, FormatVersion};
 
@@ -332,11 +333,15 @@ impl FontInfo {
     pub fn from_file<P: AsRef<Path>>(
         path: P,
         format_version: FormatVersion,
+        lib: &mut Option<Plist>,
     ) -> Result<Self, Error> {
         match format_version {
             FormatVersion::V3 => {
-                let fontinfo: FontInfo = plist::from_file(path)?;
+                let mut fontinfo: FontInfo = plist::from_file(path)?;
                 fontinfo.validate()?;
+                if let Some(lib) = lib {
+                    fill_in_libs(&mut fontinfo, lib)?;
+                }
                 Ok(fontinfo)
             }
             FormatVersion::V2 => {
@@ -1170,6 +1175,33 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
             _ => Err(serde::de::Error::custom("unknown value for styleMapStyleName.")),
         }
     }
+}
+
+/// Move libs from the font lib's `public.objectLibs` key into the actual objects.
+/// They key will be removed from the font lib.
+fn fill_in_libs(fontinfo: &mut FontInfo, lib: &mut Plist) -> Result<(), Error> {
+    if let Some(object_libs) = lib.remove("public.objectLibs") {
+        let object_libs =
+            object_libs.into_dictionary().ok_or(Error::InvalidDataError(ErrorKind::BadLib))?;
+
+        'next_key: for (key, value) in object_libs.into_iter() {
+            let value =
+                value.into_dictionary().ok_or(Error::InvalidDataError(ErrorKind::BadLib))?;
+
+            if let Some(guidelines) = &mut fontinfo.guidelines {
+                for guideline in guidelines {
+                    if let Some(id) = guideline.identifier() {
+                        if id == &key {
+                            guideline.replace_lib(value);
+                            continue 'next_key;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -64,6 +64,11 @@ impl Glyph {
         if self.format != GlifVersion::V2 {
             return Err(Error::DowngradeUnsupported);
         }
+        if let Some(lib) = &self.lib {
+            if lib.contains_key("public.objectLibs") {
+                return Err(Error::PreexistingPublicObjectLibsKey);
+            }
+        }
         let data = self.encode_xml()?;
         std::fs::write(path, &data)?;
         Ok(())

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -85,7 +85,11 @@ impl<'names> GlifParser<'names> {
                 _other => return Err(err!(reader, ErrorKind::MissingCloseTag)),
             }
         }
-        Ok(self.builder.finish().map_err(|e| err!(reader, e))?)
+
+        let mut glyph = self.builder.finish().map_err(|e| err!(reader, e))?;
+        fill_in_libs(&mut glyph)?;
+
+        Ok(glyph)
     }
 
     fn parse_outline(
@@ -530,6 +534,73 @@ fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<GlyphBuilder, 
             _other => return Err(err!(reader, ErrorKind::WrongFirstElement)),
         }
     }
+}
+
+/// Move libs from the lib's `public.objectLibs` into the actual objects.
+/// They key will be removed from the glyph lib.
+fn fill_in_libs(glyph: &mut Glyph) -> Result<(), Error> {
+    if let Some(glyph_lib) = &mut glyph.lib {
+        if let Some(object_libs) = glyph_lib.remove("public.objectLibs") {
+            let object_libs = object_libs
+                .into_dictionary()
+                .ok_or(GlifErrorInternal::Spec { kind: ErrorKind::BadLib, position: 0 })?;
+
+            'next_key: for (key, value) in object_libs.into_iter() {
+                let value = value
+                    .into_dictionary()
+                    .ok_or(GlifErrorInternal::Spec { kind: ErrorKind::BadLib, position: 0 })?;
+
+                if let Some(anchors) = &mut glyph.anchors {
+                    for anchor in anchors {
+                        if let Some(id) = anchor.identifier() {
+                            if id == &key {
+                                anchor.replace_lib(value);
+                                continue 'next_key;
+                            }
+                        }
+                    }
+                }
+                if let Some(guidelines) = &mut glyph.guidelines {
+                    for guideline in guidelines {
+                        if let Some(id) = guideline.identifier() {
+                            if id == &key {
+                                guideline.replace_lib(value);
+                                continue 'next_key;
+                            }
+                        }
+                    }
+                }
+                if let Some(outline) = &mut glyph.outline {
+                    for contour in &mut outline.contours {
+                        if let Some(id) = contour.identifier() {
+                            if id == &key {
+                                contour.replace_lib(value);
+                                continue 'next_key;
+                            }
+                        }
+                        for point in &mut contour.points {
+                            if let Some(id) = point.identifier() {
+                                if id == &key {
+                                    point.replace_lib(value);
+                                    continue 'next_key;
+                                }
+                            }
+                        }
+                    }
+                    for component in &mut outline.components {
+                        if let Some(id) = component.identifier() {
+                            if id == &key {
+                                component.replace_lib(value);
+                                continue 'next_key;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 impl FromStr for GlifVersion {

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -88,7 +88,7 @@ impl<'names> GlifParser<'names> {
 
         let mut glyph = self.builder.finish().map_err(|e| err!(reader, e))?;
         // FIXME: Error returns the end of the byte stream as the location, which is misleading.
-        glyph.fill_in_libs().map_err(|e| err!(reader, e))?;
+        glyph.load_object_libs().map_err(|e| err!(reader, e))?;
 
         Ok(glyph)
     }

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -77,7 +77,7 @@ impl Glyph {
         // glyph.lib in-memory. If there are object libs to serialize, clone the
         // existing lib and insert them there for serialization, otherwise avoid
         // cloning and write out the original.
-        let object_libs = self.libs_to_object_libs();
+        let object_libs = self.dump_object_libs();
         if !object_libs.is_empty() {
             let mut new_lib = self.lib.clone().unwrap_or_else(|| Plist::new());
             new_lib.insert(PUBLIC_OBJECT_LIBS_KEY.into(), plist::Value::Dictionary(object_libs));

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -70,7 +70,20 @@ impl Glyph {
             }
         }
 
-        if let Some(lib) = self.lib.as_ref() {
+        // Object libs are treated specially. The UFO v3 format won't allow us
+        // to store them inline, so they have to be placed into the glyph's lib
+        // under the public.objectLibs parent key. To avoid mutation behind the
+        // client's back, object libs are written out but not stored in
+        // glyph.lib in-memory. If there are object libs to serialize, clone the
+        // existing lib and insert them there for serialization, otherwise avoid
+        // cloning and write out the original.
+        let object_libs = libs_to_object_libs(&self);
+        if !object_libs.is_empty() {
+            let mut new_lib =
+                if let Some(lib) = self.lib.as_ref() { lib.clone() } else { Plist::new() };
+            new_lib.insert("public.objectLibs".into(), plist::Value::Dictionary(object_libs));
+            write_lib_section(&new_lib, &mut writer)?;
+        } else if let Some(lib) = self.lib.as_ref() {
             if !lib.is_empty() {
                 write_lib_section(lib, &mut writer)?;
             }
@@ -82,6 +95,71 @@ impl Glyph {
 
         Ok(writer.into_inner().into_inner())
     }
+}
+
+fn libs_to_object_libs(glyph: &Glyph) -> Plist {
+    let mut object_libs = Plist::default();
+
+    if let Some(anchors) = &glyph.anchors {
+        for anchor in anchors {
+            if let Some(lib) = anchor.lib() {
+                let id = anchor.identifier();
+                debug_assert!(id.is_some());
+                object_libs.insert(
+                    String::from(id.as_ref().unwrap().as_str()),
+                    plist::Value::Dictionary(lib.clone()),
+                );
+            }
+        }
+    }
+
+    if let Some(guidelines) = &glyph.guidelines {
+        for guideline in guidelines {
+            if let Some(lib) = guideline.lib() {
+                let id = guideline.identifier();
+                debug_assert!(id.is_some());
+                object_libs.insert(
+                    String::from(id.as_ref().unwrap().as_str()),
+                    plist::Value::Dictionary(lib.clone()),
+                );
+            }
+        }
+    }
+
+    if let Some(outline) = &glyph.outline {
+        for contour in &outline.contours {
+            if let Some(lib) = contour.lib() {
+                let id = contour.identifier();
+                debug_assert!(id.is_some());
+                object_libs.insert(
+                    String::from(id.as_ref().unwrap().as_str()),
+                    plist::Value::Dictionary(lib.clone()),
+                );
+            }
+            for point in &contour.points {
+                if let Some(lib) = point.lib() {
+                    let id = point.identifier();
+                    debug_assert!(id.is_some());
+                    object_libs.insert(
+                        String::from(id.as_ref().unwrap().as_str()),
+                        plist::Value::Dictionary(lib.clone()),
+                    );
+                }
+            }
+        }
+        for component in &outline.components {
+            if let Some(lib) = component.lib() {
+                let id = component.identifier();
+                debug_assert!(id.is_some());
+                object_libs.insert(
+                    String::from(id.as_ref().unwrap().as_str()),
+                    plist::Value::Dictionary(lib.clone()),
+                );
+            }
+        }
+    }
+
+    object_libs
 }
 
 /// Writing out the embedded lib plist that a glif may have.

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -105,12 +105,12 @@ impl Layer {
     }
 
     /// Returns a mutable reference to the glyph with the given name, if it exists.
-    pub fn get_glyph_mut<K>(&mut self, glyph: &K) -> Option<&mut Arc<Glyph>>
+    pub fn get_glyph_mut<K>(&mut self, glyph: &K) -> Option<&mut Glyph>
     where
         GlyphName: Borrow<K>,
         K: Ord + ?Sized,
     {
-        self.glyphs.get_mut(glyph)
+        self.glyphs.get_mut(glyph).and_then(|g| Arc::get_mut(g))
     }
 
     /// Returns `true` if this layer contains a glyph with this name.

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -16,6 +16,8 @@ use druid::Data;
 use crate::error::ErrorKind;
 use crate::Error;
 
+pub static PUBLIC_OBJECT_LIBS_KEY: &str = "public.objectLibs";
+
 /// A Plist dictionary.
 pub type Plist = plist::Dictionary;
 

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -289,8 +289,8 @@ impl Ufo {
         // under the public.objectLibs parent key. To avoid mutation behind the
         // client's back, object libs are written out but not stored in
         // font.lib in-memory. If there are object libs to serialize, clone the
-        // existing lib and insert them there for serialization, otherwise avoid
-        // cloning and write out the original.
+        // existing lib and insert them there for serialization, otherwise write
+        // out the original.
         let object_libs = self
             .font_info
             .as_ref()

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -155,7 +155,7 @@ impl Ufo {
             let fontinfo_path = path.join(FONTINFO_FILE);
             let mut font_info = if fontinfo_path.exists() {
                 let font_info: FontInfo =
-                    FontInfo::from_file(fontinfo_path, meta.format_version, &mut lib)?;
+                    FontInfo::from_file(fontinfo_path, meta.format_version, lib.as_mut())?;
                 Some(font_info)
             } else {
                 None

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -363,7 +363,7 @@ impl Ufo {
 
     /// Returns a mutable reference to the glyph with the given name,
     /// IN THE DEFAULT LAYER, if it exists.
-    pub fn get_glyph_mut<K>(&mut self, key: &K) -> Option<&mut Arc<Glyph>>
+    pub fn get_glyph_mut<K>(&mut self, key: &K) -> Option<&mut Glyph>
     where
         GlyphName: Borrow<K>,
         K: Ord + ?Sized,

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -291,11 +291,8 @@ impl Ufo {
         // font.lib in-memory. If there are object libs to serialize, clone the
         // existing lib and insert them there for serialization, otherwise write
         // out the original.
-        let object_libs = self
-            .font_info
-            .as_ref()
-            .map(|f| f.libs_to_object_libs())
-            .unwrap_or_else(|| Plist::new());
+        let object_libs =
+            self.font_info.as_ref().map(|f| f.dump_object_libs()).unwrap_or_else(|| Plist::new());
         if !object_libs.is_empty() {
             let mut new_lib = self.lib.clone().unwrap_or_else(|| Plist::new());
             new_lib.insert(PUBLIC_OBJECT_LIBS_KEY.into(), plist::Value::Dictionary(object_libs));

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -18,6 +18,7 @@ use crate::fontinfo::FontInfo;
 use crate::glyph::{Glyph, GlyphName};
 use crate::layer::Layer;
 use crate::names::NameList;
+use crate::shared_types::Plist;
 use crate::upconversion;
 use crate::Error;
 
@@ -125,6 +126,10 @@ impl Ufo {
     /// a directory with the structure described in [v3 of the Unified Font Object][v3]
     /// spec.
     ///
+    /// NOTE: This will consume the `public.objectLibs` key in the global lib and in glyph
+    /// libs and assign object libs found therein to global guidelines and glyph objects
+    /// with the matching identifier, respectively.
+    ///
     /// [v3]: http://unifiedfontobject.org/versions/ufo3/
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Ufo, Error> {
         let path = path.as_ref();
@@ -135,14 +140,6 @@ impl Ufo {
             let meta_path = path.join(METAINFO_FILE);
             let mut meta: MetaInfo = plist::from_file(meta_path)?;
 
-            let fontinfo_path = path.join(FONTINFO_FILE);
-            let mut font_info = if fontinfo_path.exists() {
-                let font_info: FontInfo = FontInfo::from_file(fontinfo_path, meta.format_version)?;
-                Some(font_info)
-            } else {
-                None
-            };
-
             let lib_path = path.join(LIB_FILE);
             let mut lib = if lib_path.exists() {
                 // Value::as_dictionary(_mut) will only borrow the data, but we want to own it.
@@ -151,6 +148,15 @@ impl Ufo {
                     plist::Value::Dictionary(dict) => Some(dict),
                     _ => return Err(Error::ExpectedPlistDictionaryError),
                 }
+            } else {
+                None
+            };
+
+            let fontinfo_path = path.join(FONTINFO_FILE);
+            let mut font_info = if fontinfo_path.exists() {
+                let font_info: FontInfo =
+                    FontInfo::from_file(fontinfo_path, meta.format_version, &mut lib)?;
+                Some(font_info)
             } else {
                 None
             };
@@ -245,6 +251,9 @@ impl Ufo {
     /// This may fail; instead of saving directly to the target path, it is a good
     /// idea to save to a temporary location and then move that to the target path
     /// if the save is successful.
+    ///
+    /// This _will_ fail if either the global or any glyph lib contains the
+    /// `public.objectLibs` key, as object lib management is done automatically.
     pub fn save(&self, path: impl AsRef<Path>) -> Result<(), Error> {
         let path = path.as_ref();
         self.save_impl(path)
@@ -259,6 +268,12 @@ impl Ufo {
             return Err(Error::NotCreatedHere);
         }
 
+        if let Some(lib) = &self.lib {
+            if lib.contains_key("public.objectLibs") {
+                return Err(Error::PreexistingPublicObjectLibsKey);
+            }
+        }
+
         if path.exists() {
             fs::remove_dir_all(path)?;
         }
@@ -269,9 +284,23 @@ impl Ufo {
             plist::to_file_xml(path.join(FONTINFO_FILE), &font_info)?;
         }
 
-        if let Some(lib) = self.lib.as_ref() {
-            // XXX: Can this be done without cloning?
-            plist::Value::Dictionary(lib.clone()).to_file_xml(path.join(LIB_FILE))?;
+        // Object libs are treated specially. The UFO v3 format won't allow us
+        // to store them inline, so they have to be placed into the font's lib
+        // under the public.objectLibs parent key. To avoid mutation behind the
+        // client's back, object libs are written out but not stored in
+        // font.lib in-memory. If there are object libs to serialize, clone the
+        // existing lib and insert them there for serialization, otherwise avoid
+        // cloning and write out the original.
+        let object_libs = libs_to_object_libs(&self.font_info);
+        if !object_libs.is_empty() {
+            let mut new_lib =
+                if let Some(lib) = self.lib.as_ref() { lib.clone() } else { Plist::new() };
+            new_lib.insert("public.objectLibs".into(), plist::Value::Dictionary(object_libs));
+            plist::Value::Dictionary(new_lib).to_file_xml(path.join(LIB_FILE))?;
+        } else if let Some(lib) = self.lib.as_ref() {
+            if !lib.is_empty() {
+                plist::Value::Dictionary(lib.clone()).to_file_xml(path.join(LIB_FILE))?;
+            }
         }
 
         if let Some(groups) = self.groups.as_ref() {
@@ -417,6 +446,27 @@ fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidationError> {
     }
 
     Ok(())
+}
+
+fn libs_to_object_libs(fontinfo: &Option<FontInfo>) -> Plist {
+    let mut object_libs = Plist::default();
+
+    if let Some(fontinfo) = fontinfo {
+        if let Some(guidelines) = &fontinfo.guidelines {
+            for guideline in guidelines {
+                if let Some(lib) = guideline.lib() {
+                    let id = guideline.identifier();
+                    debug_assert!(id.is_some());
+                    object_libs.insert(
+                        String::from(id.as_ref().unwrap().as_str()),
+                        plist::Value::Dictionary(lib.clone()),
+                    );
+                }
+            }
+        }
+    }
+
+    object_libs
 }
 
 /// KerningSerializer is a crutch to serialize kerning values as integers if they are

--- a/testdata/identifiers.ufo/fontinfo.plist
+++ b/testdata/identifiers.ufo/fontinfo.plist
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>guidelines</key>
+    <array>
+      <dict>
+        <key>x</key>
+        <integer>100</integer>
+      </dict>
+      <dict>
+        <key>identifier</key>
+        <string>3f0f37d1-52d6-429c-aff4-3f81aed4abf0</string>
+        <key>y</key>
+        <integer>200</integer>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/testdata/identifiers.ufo/glyphs/component.glif
+++ b/testdata/identifiers.ufo/glyphs/component.glif
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="component" format="2">
+  <outline>
+  </outline>
+</glyph>

--- a/testdata/identifiers.ufo/glyphs/contents.plist
+++ b/testdata/identifiers.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>component</key>
+    <string>component.glif</string>
+    <key>test</key>
+    <string>test.glif</string>
+  </dict>
+</plist>

--- a/testdata/identifiers.ufo/glyphs/test.glif
+++ b/testdata/identifiers.ufo/glyphs/test.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="test" format="2">
+  <guideline x="300"/>
+  <guideline y="400" identifier="c76955c2-e9f2-4adf-8b51-1ae03da11dca"/>
+  <anchor x="1" y="2" name="top"/>
+  <anchor x="3" y="4" name="bottom" identifier="90b7eb80-e21a-4a79-a8c0-7634c25ddc18"/>
+  <outline>
+    <contour identifier="9bf0591d-6281-4c76-8c13-9ff3d93eec4f">
+      <point x="0" y="0" type="line"/>
+      <point x="100" y="200" type="line"/>
+      <point x="200" y="400" type="line"/>
+    </contour>
+    <contour>
+      <point x="1000" y="1000" type="line" identifier="f32ac0e8-4ec8-45f6-88b1-0e49390b8f5b"/>
+      <point x="1000" y="2000" type="line"/>
+      <point x="2000" y="4000" type="line" identifier="spare-id"/>
+    </contour>
+    <component base="component" identifier="a50e8ccd-2ba4-4279-a011-4c82a8075dd9"/>
+    <component base="component"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>90b7eb80-e21a-4a79-a8c0-7634c25ddc18</key>
+        <dict>
+          <key>com.test.anchorTool</key>
+          <true/>
+        </dict>
+        <key>9bf0591d-6281-4c76-8c13-9ff3d93eec4f</key>
+        <dict>
+          <key>com.test.foo</key>
+          <string>a</string>
+        </dict>
+        <key>a50e8ccd-2ba4-4279-a011-4c82a8075dd9</key>
+        <dict>
+          <key>com.test.foo</key>
+          <string>b</string>
+        </dict>
+        <key>c76955c2-e9f2-4adf-8b51-1ae03da11dca</key>
+        <dict>
+          <key>com.test.foo</key>
+          <integer>4321</integer>
+        </dict>
+        <key>f32ac0e8-4ec8-45f6-88b1-0e49390b8f5b</key>
+        <dict>
+          <key>com.test.foo</key>
+          <string>c</string>
+        </dict>
+        <key>ignore-me</key>
+        <dict>
+          <key>com.test.foo</key>
+          <string>d</string>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
+</glyph>

--- a/testdata/identifiers.ufo/layercontents.plist
+++ b/testdata/identifiers.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/testdata/identifiers.ufo/lib.plist
+++ b/testdata/identifiers.ufo/lib.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.objectLibs</key>
+    <dict>
+      <key>3f0f37d1-52d6-429c-aff4-3f81aed4abf0</key>
+      <dict>
+        <key>com.test.foo</key>
+        <integer>1234</integer>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/testdata/identifiers.ufo/metainfo.plist
+++ b/testdata/identifiers.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>org.linebender.norad</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -1,6 +1,6 @@
 //! Testing saving files.
 
-use norad::{FormatVersion, Glyph, Layer, Plist, Ufo};
+use norad::{FormatVersion, Glyph, Identifier, Layer, Plist, Ufo};
 
 #[test]
 fn save_default() {
@@ -69,4 +69,156 @@ fn save_fancy() {
         assert!(other.is_some(), "missing {}", &glyph.name);
         assert_eq!(&glyph, other.unwrap());
     }
+}
+
+#[test]
+fn roundtrip_object_libs() {
+    let ufo = Ufo::load("testdata/identifiers.ufo").unwrap();
+    assert_eq!(ufo.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+
+    let glyph = ufo.get_glyph("test").unwrap();
+    assert_eq!(glyph.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+
+    let dir = tempdir::TempDir::new("identifiers.ufo").unwrap();
+    ufo.save(&dir).unwrap();
+    assert_eq!(glyph.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+
+    let ufo2 = Ufo::load(&dir).unwrap();
+    assert_eq!(ufo2.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+
+    let font_guideline_second = &ufo2.font_info.as_ref().unwrap().guidelines.as_ref().unwrap()[1];
+    assert_eq!(
+        font_guideline_second.identifier(),
+        Some(&Identifier::new("3f0f37d1-52d6-429c-aff4-3f81aed4abf0").unwrap())
+    );
+    assert_eq!(
+        font_guideline_second
+            .lib()
+            .as_ref()
+            .unwrap()
+            .get("com.test.foo")
+            .unwrap()
+            .as_unsigned_integer()
+            .unwrap(),
+        1234
+    );
+
+    let glyph2 = ufo2.get_glyph("test").unwrap();
+    assert_eq!(glyph2.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+
+    let anchor_second = &glyph2.anchors.as_ref().unwrap()[1];
+    assert_eq!(
+        anchor_second.identifier(),
+        Some(&Identifier::new("90b7eb80-e21a-4a79-a8c0-7634c25ddc18").unwrap())
+    );
+    assert_eq!(
+        anchor_second
+            .lib()
+            .as_ref()
+            .unwrap()
+            .get("com.test.anchorTool")
+            .unwrap()
+            .as_boolean()
+            .unwrap(),
+        true
+    );
+
+    let guideline_second = &glyph2.guidelines.as_ref().unwrap()[1];
+    assert_eq!(
+        guideline_second.identifier(),
+        Some(&Identifier::new("c76955c2-e9f2-4adf-8b51-1ae03da11dca").unwrap())
+    );
+    assert_eq!(
+        guideline_second
+            .lib()
+            .as_ref()
+            .unwrap()
+            .get("com.test.foo")
+            .unwrap()
+            .as_unsigned_integer()
+            .unwrap(),
+        4321
+    );
+
+    let outline2 = glyph2.outline.as_ref().unwrap();
+    assert_eq!(
+        outline2.contours[0].identifier(),
+        Some(&Identifier::new("9bf0591d-6281-4c76-8c13-9ff3d93eec4f").unwrap())
+    );
+    assert_eq!(
+        outline2.contours[0]
+            .lib()
+            .as_ref()
+            .unwrap()
+            .get("com.test.foo")
+            .unwrap()
+            .as_string()
+            .unwrap(),
+        "a"
+    );
+
+    assert_eq!(
+        outline2.contours[1].points[0].identifier(),
+        Some(&Identifier::new("f32ac0e8-4ec8-45f6-88b1-0e49390b8f5b").unwrap())
+    );
+    assert_eq!(
+        outline2.contours[1].points[0]
+            .lib()
+            .as_ref()
+            .unwrap()
+            .get("com.test.foo")
+            .unwrap()
+            .as_string()
+            .unwrap(),
+        "c"
+    );
+    assert_eq!(
+        outline2.contours[1].points[2].identifier(),
+        Some(&Identifier::new("spare-id").unwrap())
+    );
+    assert!(outline2.contours[1].points[2].lib().is_none());
+
+    assert_eq!(
+        outline2.components[0].identifier(),
+        Some(&Identifier::new("a50e8ccd-2ba4-4279-a011-4c82a8075dd9").unwrap())
+    );
+    assert_eq!(
+        outline2.components[0]
+            .lib()
+            .as_ref()
+            .unwrap()
+            .get("com.test.foo")
+            .unwrap()
+            .as_string()
+            .unwrap(),
+        "b"
+    );
+}
+
+#[test]
+fn object_libs_reject_existing_key() {
+    let dir = tempdir::TempDir::new("test.ufo").unwrap();
+    let mut ufo = Ufo::new();
+
+    let mut test_lib = plist::Dictionary::new();
+    test_lib.insert("public.objectLibs".into(), plist::Value::Dictionary(plist::Dictionary::new()));
+
+    ufo.lib.replace(test_lib.clone());
+    assert!(ufo.save(&dir).is_err());
+    ufo.lib.as_mut().unwrap().remove("public.objectLibs".into());
+
+    let glyph = Glyph {
+        name: "test".into(),
+        format: norad::GlifVersion::V2,
+        advance: None,
+        anchors: None,
+        codepoints: None,
+        guidelines: None,
+        image: None,
+        lib: Some(test_lib),
+        note: None,
+        outline: None,
+    };
+    ufo.get_default_layer_mut().unwrap().insert_glyph(glyph);
+    assert!(ufo.save(&dir).is_err());
 }


### PR DESCRIPTION
Supersedes https://github.com/linebender/norad/pull/71.

Handle object libs by attaching libs directly to glyph objects and automatically handling `public.objectLibs` on loading and saving.