### PR TITLE
Use enums to keep state

### DIFF
--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -382,7 +382,7 @@ impl OutlineBuilder {
         }
     }
 
-    /// Ends the path begun by [`Self::begin_path`] and adds the contour it to the glyph's outline, unless
+    /// Ends the path begun by [`Self::begin_path`] and adds the contour to the glyph's outline, unless
     /// it's empty.
     ///
     /// Errors when:


### PR DESCRIPTION
After reading https://hoverbear.org/blog/rust-state-machine-pattern/, I wanted to try and be a bit more clever about state management in `OutlineBuilder`.

I wonder if there should be a third state `Failure(ErrorKind)` that is sticky after an error happened? It would complicate the code somewhat though, I think. For example:

1. If `begin_path` fails, you can just carry on drawing the previously started contour. It doesn't change the state.
2. If `add_point` fails, it simply doesn't add what you were trying to add. It doesn't change the state.
3. If `end_path` fails, it just drops the contour you were trying to end. It doesn't change the state.
4. If `add_component` fails, it simply doesn't add the component you were trying to add. It doesn't change the state.
5. if `finish` fails, it simply won't return an outline to you. It doesn't change the state.

I think that's reasonably simple so we don't strictly need a `Failure` state?