### PR TITLE
Make kurbo a direct optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_derive = "1.0"
 serde_repr = "0.1"
 quick-xml = "0.20.0"
 rayon = { version = "1.3.0", optional = true }
+kurbo = { version = "0.8.0", optional = true }
 
 [dependencies.druid]
 #git = "https://github.com/xi-editor/druid.git"

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -630,10 +630,10 @@ pub struct Image {
     pub transform: AffineTransform,
 }
 
-#[cfg(feature = "druid")]
-impl From<AffineTransform> for druid::kurbo::Affine {
-    fn from(src: AffineTransform) -> druid::kurbo::Affine {
-        druid::kurbo::Affine::new([
+#[cfg(feature = "kurbo")]
+impl From<AffineTransform> for kurbo::Affine {
+    fn from(src: AffineTransform) -> kurbo::Affine {
+        kurbo::Affine::new([
             src.x_scale as f64,
             src.xy_scale as f64,
             src.yx_scale as f64,
@@ -644,9 +644,9 @@ impl From<AffineTransform> for druid::kurbo::Affine {
     }
 }
 
-#[cfg(feature = "druid")]
-impl From<druid::kurbo::Affine> for AffineTransform {
-    fn from(src: druid::kurbo::Affine) -> AffineTransform {
+#[cfg(feature = "kurbo")]
+impl From<kurbo::Affine> for AffineTransform {
+    fn from(src: kurbo::Affine) -> AffineTransform {
         let coeffs = src.as_coeffs();
         AffineTransform {
             x_scale: coeffs[0] as f32,


### PR DESCRIPTION
So I don't have to pull in druid to use kurbo converters.