### PR TITLE
Simplify Glyph

### DIFF
--- a/examples/normalize.rs
+++ b/examples/normalize.rs
@@ -20,7 +20,7 @@ fn main() {
 
         // Prune the foreground layer's lib.
         let default_layer = ufo.get_default_layer_mut().unwrap();
-        default_layer.info.lib.retain(|k, &mut _| {
+        default_layer.lib.retain(|k, &mut _| {
             k.starts_with("public.") || k.starts_with("com.schriftgestaltung.layerId")
         });
 

--- a/examples/normalize.rs
+++ b/examples/normalize.rs
@@ -20,36 +20,30 @@ fn main() {
 
         // Prune the foreground layer's lib.
         let default_layer = ufo.get_default_layer_mut().unwrap();
-        default_layer.info.lib.as_mut().and_then(|lib| {
-            Some(lib.retain(|k, &mut _| {
-                k.starts_with("public.") || k.starts_with("com.schriftgestaltung.layerId")
-            }))
+        default_layer.info.lib.retain(|k, &mut _| {
+            k.starts_with("public.") || k.starts_with("com.schriftgestaltung.layerId")
         });
 
         // Prune all glyphs' libs.
         for glyph in default_layer.iter_contents_mut() {
-            glyph.lib.as_mut().and_then(|lib| {
-                Some(lib.retain(|k, &mut _| {
-                    (k.starts_with("public.")
-                        || k.starts_with("com.schriftgestaltung.")
-                        || k == "com.schriftgestaltung.componentsAlignment")
-                        && k != "public.markColor"
-                }))
+            glyph.lib.retain(|k, &mut _| {
+                (k.starts_with("public.")
+                    || k.starts_with("com.schriftgestaltung.")
+                    || k == "com.schriftgestaltung.componentsAlignment")
+                    && k != "public.markColor"
             });
         }
 
         // Prune the UFO lib.
-        ufo.lib.as_mut().and_then(|lib| {
-            Some(lib.retain(|k, &mut _| {
-                k.starts_with("public.")
-                    || k.starts_with("com.github.googlei18n.ufo2ft.")
-                    || k == "com.schriftgestaltung.appVersion"
-                    || k == "com.schriftgestaltung.fontMasterID"
-                    || k == "com.schriftgestaltung.customParameter.GSFont.disablesLastChange"
-                    || k == "com.schriftgestaltung.customParameter.GSFontMaster.paramArea"
-                    || k == "com.schriftgestaltung.customParameter.GSFontMaster.paramDepth"
-                    || k == "com.schriftgestaltung.customParameter.GSFontMaster.paramOver"
-            }))
+        ufo.lib.retain(|k, &mut _| {
+            k.starts_with("public.")
+                || k.starts_with("com.github.googlei18n.ufo2ft.")
+                || k == "com.schriftgestaltung.appVersion"
+                || k == "com.schriftgestaltung.fontMasterID"
+                || k == "com.schriftgestaltung.customParameter.GSFont.disablesLastChange"
+                || k == "com.schriftgestaltung.customParameter.GSFontMaster.paramArea"
+                || k == "com.schriftgestaltung.customParameter.GSFontMaster.paramDepth"
+                || k == "com.schriftgestaltung.customParameter.GSFontMaster.paramOver"
         });
 
         ufo.meta.creator = "org.linebender.norad".to_string();

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -333,15 +333,13 @@ impl FontInfo {
     pub fn from_file<P: AsRef<Path>>(
         path: P,
         format_version: FormatVersion,
-        lib: Option<&mut Plist>,
+        lib: &mut Plist,
     ) -> Result<Self, Error> {
         match format_version {
             FormatVersion::V3 => {
                 let mut fontinfo: FontInfo = plist::from_file(path)?;
                 fontinfo.validate()?;
-                if let Some(lib) = lib {
-                    fontinfo.load_object_libs(lib)?;
-                }
+                fontinfo.load_object_libs(lib)?;
                 Ok(fontinfo)
             }
             FormatVersion::V2 => {

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -87,6 +87,7 @@ pub struct GlyphBuilder {
     height: Option<f32>,
     width: Option<f32>,
     outline: Option<Outline>,
+    lib: Option<Plist>,
     identifiers: HashSet<Identifier>, // All identifiers within a glyph must be unique.
 }
 
@@ -99,6 +100,7 @@ impl GlyphBuilder {
             height: None,
             width: None,
             outline: None,
+            lib: None,
             identifiers: HashSet::new(),
         }
     }
@@ -238,10 +240,10 @@ impl GlyphBuilder {
     ///
     /// Errors when the function is called more than once.
     pub fn lib(&mut self, lib: Plist) -> Result<&mut Self, ErrorKind> {
-        if self.glyph.lib.is_some() {
+        if self.lib.is_some() {
             return Err(ErrorKind::UnexpectedDuplicate);
         }
-        self.glyph.lib.replace(lib);
+        self.lib.replace(lib);
         Ok(self)
     }
 
@@ -258,6 +260,9 @@ impl GlyphBuilder {
         if let Some(outline) = &mut self.outline {
             self.glyph.components.append(&mut outline.components);
             self.glyph.contours.append(&mut outline.contours);
+        }
+        if let Some(lib) = self.lib {
+            self.glyph.lib = lib;
         }
 
         self.glyph.format = GlifVersion::V2;
@@ -629,7 +634,7 @@ mod tests {
                     None,
                 )],
                 image: None,
-                lib: None,
+                lib: Plist::new(),
             }
         );
 
@@ -663,7 +668,7 @@ mod tests {
                 components: Vec::new(),
                 contours: Vec::new(),
                 image: None,
-                lib: None,
+                lib: Plist::new(),
             }
         );
 

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -7,6 +7,10 @@ use crate::glyph::{
 };
 use crate::shared_types::{Identifier, Plist};
 
+// NOTE: The builders are private to the crate until we have a real-world use-case for making
+// them public. Then, we need to think about maybe doing without a GlyphBuilder at all (check
+// for elements occuring once in parse.rs) and only keeping OutlineBuilder.
+
 /// A GlyphBuilder is a consuming builder for [`crate::glyph::Glyph`].
 ///
 /// It is different from fontTools' Pen concept, in that it is used to build the entire `Glyph`,
@@ -27,7 +31,7 @@ use crate::shared_types::{Identifier, Plist};
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// use std::str::FromStr;
 ///
 /// use norad::error::ErrorKind;
@@ -82,7 +86,7 @@ use crate::shared_types::{Identifier, Plist};
 /// }
 /// ```
 #[derive(Debug)]
-pub struct GlyphBuilder {
+pub(crate) struct GlyphBuilder {
     glyph: Glyph,
     height: Option<f32>,
     width: Option<f32>,
@@ -276,16 +280,16 @@ impl GlyphBuilder {
 ///
 /// [fontTools point pen]: https://fonttools.readthedocs.io/en/latest/pens/basePen.html
 #[derive(Debug, Default)]
-pub struct OutlineBuilder {
+pub(crate) struct OutlineBuilder {
     identifiers: HashSet<Identifier>,
     outline: Outline,
     scratch_state: OutlineBuilderState,
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct Outline {
-    pub components: Vec<Component>,
-    pub contours: Vec<Contour>,
+pub(crate) struct Outline {
+    components: Vec<Component>,
+    contours: Vec<Contour>,
 }
 
 #[derive(Debug)]

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use super::*;
 use crate::error::{ErrorKind, GlifErrorInternal};
-use crate::glyph::builder::{GlyphBuilder, OutlineBuilder};
+use crate::glyph::builder::{GlyphBuilder, Outline, OutlineBuilder};
 use crate::names::NameList;
 
 use quick_xml::{

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -76,11 +76,11 @@ impl Glyph {
         // cloning and write out the original.
         let object_libs = self.dump_object_libs();
         if !object_libs.is_empty() {
-            let mut new_lib = self.lib.clone().unwrap_or_else(Plist::new);
+            let mut new_lib = self.lib.clone();
             new_lib.insert(PUBLIC_OBJECT_LIBS_KEY.into(), plist::Value::Dictionary(object_libs));
             write_lib_section(&new_lib, &mut writer)?;
-        } else if let Some(lib) = self.lib.as_ref().filter(|lib| !lib.is_empty()) {
-            write_lib_section(lib, &mut writer)?;
+        } else if !self.lib.is_empty() {
+            write_lib_section(&self.lib, &mut writer)?;
         }
 
         writer.write_event(Event::End(BytesEnd::borrowed(b"glyph")))?;

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -35,7 +35,7 @@ fn parse_v1_upgrade_anchors() {
     assert_eq!(glyph.format, GlifVersion::V2);
     assert_eq!(glyph.guidelines, vec![]);
     assert_eq!(glyph.image, None);
-    assert_eq!(glyph.lib, None);
+    assert_eq!(glyph.lib, Plist::new());
     assert_eq!(glyph.note, None);
 }
 

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -25,15 +25,15 @@ fn parse_v1_upgrade_anchors() {
     let glyph = parse_glyph(bytes).unwrap();
     assert_eq!(
         glyph.anchors,
-        Some(vec![
+        vec![
             Anchor::new(10.0, 10.0, Some("top".into()), None, None, None),
             Anchor::new(10.0, 20.0, Some("bottom".into()), None, None, None),
             Anchor::new(30.0, 20.0, Some("left".into()), None, None, None),
             Anchor::new(40.0, 20.0, Some("right".into()), None, None, None),
-        ])
+        ]
     );
     assert_eq!(glyph.format, GlifVersion::V2);
-    assert_eq!(glyph.guidelines, None);
+    assert_eq!(glyph.guidelines, vec![]);
     assert_eq!(glyph.image, None);
     assert_eq!(glyph.lib, None);
     assert_eq!(glyph.note, None);
@@ -43,22 +43,21 @@ fn parse_v1_upgrade_anchors() {
 fn curve_types() {
     let bytes = include_bytes!("../../testdata/mutatorSans/MutatorSansBoldWide.ufo/glyphs/D_.glif");
     let glyph = parse_glyph(bytes).unwrap();
-    let outline = glyph.outline.as_ref().unwrap();
-    assert_eq!(outline.contours.len(), 2);
-    assert_eq!(outline.contours[1].points[0].typ, PointType::Line);
-    assert_eq!(outline.contours[1].points[0].smooth, false);
-    assert_eq!(outline.contours[1].points[1].smooth, true);
-    assert_eq!(outline.contours[1].points[2].typ, PointType::OffCurve);
-    assert_eq!(outline.contours[1].points[4].typ, PointType::Curve);
+    assert_eq!(glyph.contours.len(), 2);
+    assert_eq!(glyph.contours[1].points[0].typ, PointType::Line);
+    assert_eq!(glyph.contours[1].points[0].smooth, false);
+    assert_eq!(glyph.contours[1].points[1].smooth, true);
+    assert_eq!(glyph.contours[1].points[2].typ, PointType::OffCurve);
+    assert_eq!(glyph.contours[1].points[4].typ, PointType::Curve);
 }
 
 #[test]
 fn guidelines() {
     let bytes = include_bytes!("../../testdata/Blinker_one.glif");
     let glyph = parse_glyph(bytes).unwrap();
-    assert_eq!(glyph.guidelines.as_ref().map(Vec::len), Some(8));
-    assert_eq!(glyph.outline.as_ref().map(|o| o.contours.len()), Some(2));
-    assert_eq!(glyph.advance, Some(Advance { width: 364., height: 0. }));
+    assert_eq!(glyph.guidelines.len(), 8);
+    assert_eq!(glyph.contours.len(), 2);
+    assert_eq!(glyph.width, 364.);
 }
 
 #[test]
@@ -98,10 +97,12 @@ fn save() {
     let glyph2 = parse_glyph(buf.as_slice()).expect("re-parse failed");
     assert_eq!(glyph.name, glyph2.name);
     assert_eq!(glyph.format, glyph2.format);
-    assert_eq!(glyph.advance, glyph2.advance);
+    assert_eq!(glyph.height, glyph2.height);
+    assert_eq!(glyph.width, glyph2.width);
     assert_eq!(glyph.codepoints, glyph2.codepoints);
     assert_eq!(glyph.note, glyph2.note);
-    assert_eq!(glyph.outline, glyph2.outline);
+    assert_eq!(glyph.components, glyph2.components);
+    assert_eq!(glyph.contours, glyph2.contours);
     assert_eq!(glyph.image, glyph2.image);
     assert_eq!(glyph.anchors, glyph2.anchors);
     assert_eq!(glyph.guidelines, glyph2.guidelines);
@@ -418,9 +419,11 @@ fn empty_outlines() {
         </glyph>
         "#;
     let test1 = parse_glyph(data1.as_bytes()).unwrap();
-    assert_eq!(test1.outline.unwrap(), Outline::default());
+    assert_eq!(test1.components, vec![]);
+    assert_eq!(test1.contours, vec![]);
     let test2 = parse_glyph(data2.as_bytes()).unwrap();
-    assert_eq!(test2.outline.unwrap(), Outline::default());
+    assert_eq!(test2.components, vec![]);
+    assert_eq!(test2.contours, vec![]);
 }
 
 #[test]
@@ -446,7 +449,9 @@ fn empty_contours() {
         </glyph>
         "#;
     let test1 = parse_glyph(data1.as_bytes()).unwrap();
-    assert_eq!(test1.outline.unwrap(), Outline::default());
+    assert_eq!(test1.components, vec![]);
+    assert_eq!(test1.contours, vec![]);
     let test2 = parse_glyph(data2.as_bytes()).unwrap();
-    assert_eq!(test2.outline.unwrap(), Outline::default());
+    assert_eq!(test2.components, vec![]);
+    assert_eq!(test2.contours, vec![]);
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -223,7 +223,6 @@ impl LayerInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::glyph::Advance;
     use std::path::Path;
 
     #[test]
@@ -247,9 +246,9 @@ mod tests {
             "curve"
         );
         let glyph = layer.get_glyph("A").expect("failed to load glyph 'A'");
-        assert_eq!(glyph.advance, Some(Advance { width: 1290., height: 0. }));
-        assert_eq!(glyph.codepoints.as_ref().map(Vec::len), Some(1));
-        assert_eq!(glyph.codepoints.as_ref().unwrap()[0], 'A');
+        assert_eq!(glyph.height, 0.);
+        assert_eq!(glyph.width, 1290.);
+        assert_eq!(glyph.codepoints, vec!['A']);
     }
 
     #[test]
@@ -321,9 +320,9 @@ mod tests {
         let layer_path = "testdata/mutatorSans/MutatorSansBoldWide.ufo/glyphs";
         let mut layer = Layer::load(layer_path).unwrap();
         let mut glyph = Glyph::new_named("A");
-        glyph.advance = Some(Advance { height: 69., width: 0. });
+        glyph.width = 69.;
         layer.insert_glyph(glyph);
         let glyph = layer.get_glyph("A").expect("failed to load glyph 'A'");
-        assert_eq!(glyph.advance, Some(Advance { height: 69., width: 0. }));
+        assert_eq!(glyph.width, 69.);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ mod upconversion;
 pub use error::Error;
 pub use fontinfo::FontInfo;
 pub use glyph::{
-    builder::GlyphBuilder, builder::OutlineBuilder, AffineTransform, Anchor, Component, Contour,
-    ContourPoint, GlifVersion, Glyph, GlyphName, Image, PointType,
+    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,
+    Image, PointType,
 };
 pub use layer::Layer;
 pub use shared_types::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ mod upconversion;
 pub use error::Error;
 pub use fontinfo::FontInfo;
 pub use glyph::{
-    builder::GlyphBuilder, builder::OutlineBuilder, Advance, AffineTransform, Anchor, Component,
-    Contour, ContourPoint, GlifVersion, Glyph, GlyphName, Image, Outline, PointType,
+    builder::GlyphBuilder, builder::OutlineBuilder, AffineTransform, Anchor, Component, Contour,
+    ContourPoint, GlifVersion, Glyph, GlyphName, Image, PointType,
 };
 pub use layer::Layer;
 pub use shared_types::{

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -146,7 +146,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
         v_stems: Option<Vec<IntegerOrFloat>>,
     }
 
-    // Reead lib.plist again because it is easier than pulling out the data manually.
+    // Read lib.plist again because it is easier than pulling out the data manually.
     let lib_data: LibData = plist::from_file(lib_path)?;
 
     // Convert features.

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -23,7 +23,7 @@ fn save_default() {
 fn save_new_file() {
     let mut my_ufo = Ufo::new();
     let mut my_glyph = Glyph::new_named("A");
-    my_glyph.codepoints = Some(vec!['A']);
+    my_glyph.codepoints = vec!['A'];
     my_glyph.note = Some("I did a glyph!".into());
     let mut plist = Plist::new();
     plist.insert("my-cool-key".into(), plist::Value::Integer(420_u32.into()));
@@ -41,7 +41,7 @@ fn save_new_file() {
     let loaded = Ufo::load(dir).unwrap();
     assert!(loaded.get_default_layer().unwrap().get_glyph("A").is_some());
     let glyph = loaded.get_default_layer().unwrap().get_glyph("A").unwrap();
-    assert_eq!(glyph.codepoints.as_ref(), Some(&vec!['A']));
+    assert_eq!(glyph.codepoints, vec!['A']);
     let lib_val = glyph
         .lib
         .as_ref()
@@ -106,7 +106,7 @@ fn roundtrip_object_libs() {
     let glyph2 = ufo2.get_glyph("test").unwrap();
     assert_eq!(glyph2.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
 
-    let anchor_second = &glyph2.anchors.as_ref().unwrap()[1];
+    let anchor_second = &glyph2.anchors[1];
     assert_eq!(
         anchor_second.identifier(),
         Some(&Identifier::new("90b7eb80-e21a-4a79-a8c0-7634c25ddc18").unwrap())
@@ -123,13 +123,12 @@ fn roundtrip_object_libs() {
         true
     );
 
-    let guideline_second = &glyph2.guidelines.as_ref().unwrap()[1];
     assert_eq!(
-        guideline_second.identifier(),
+        glyph2.guidelines[1].identifier(),
         Some(&Identifier::new("c76955c2-e9f2-4adf-8b51-1ae03da11dca").unwrap())
     );
     assert_eq!(
-        guideline_second
+        glyph2.guidelines[1]
             .lib()
             .as_ref()
             .unwrap()
@@ -140,29 +139,21 @@ fn roundtrip_object_libs() {
         4321
     );
 
-    let outline2 = glyph2.outline.as_ref().unwrap();
     assert_eq!(
-        outline2.contours[0].identifier(),
+        glyph.contours[0].identifier(),
         Some(&Identifier::new("9bf0591d-6281-4c76-8c13-9ff3d93eec4f").unwrap())
     );
     assert_eq!(
-        outline2.contours[0]
-            .lib()
-            .as_ref()
-            .unwrap()
-            .get("com.test.foo")
-            .unwrap()
-            .as_string()
-            .unwrap(),
+        glyph.contours[0].lib().as_ref().unwrap().get("com.test.foo").unwrap().as_string().unwrap(),
         "a"
     );
 
     assert_eq!(
-        outline2.contours[1].points[0].identifier(),
+        glyph.contours[1].points[0].identifier(),
         Some(&Identifier::new("f32ac0e8-4ec8-45f6-88b1-0e49390b8f5b").unwrap())
     );
     assert_eq!(
-        outline2.contours[1].points[0]
+        glyph.contours[1].points[0]
             .lib()
             .as_ref()
             .unwrap()
@@ -173,17 +164,17 @@ fn roundtrip_object_libs() {
         "c"
     );
     assert_eq!(
-        outline2.contours[1].points[2].identifier(),
+        glyph.contours[1].points[2].identifier(),
         Some(&Identifier::new("spare-id").unwrap())
     );
-    assert!(outline2.contours[1].points[2].lib().is_none());
+    assert!(glyph.contours[1].points[2].lib().is_none());
 
     assert_eq!(
-        outline2.components[0].identifier(),
+        glyph.components[0].identifier(),
         Some(&Identifier::new("a50e8ccd-2ba4-4279-a011-4c82a8075dd9").unwrap())
     );
     assert_eq!(
-        outline2.components[0]
+        glyph.components[0]
             .lib()
             .as_ref()
             .unwrap()
@@ -210,14 +201,16 @@ fn object_libs_reject_existing_key() {
     let glyph = Glyph {
         name: "test".into(),
         format: norad::GlifVersion::V2,
-        advance: None,
-        anchors: None,
-        codepoints: None,
-        guidelines: None,
+        height: 0.,
+        width: 0.,
+        anchors: vec![],
+        codepoints: vec![],
+        guidelines: vec![],
         image: None,
         lib: Some(test_lib),
         note: None,
-        outline: None,
+        components: vec![],
+        contours: vec![],
     };
     ufo.get_default_layer_mut().unwrap().insert_glyph(glyph);
     assert!(ufo.save(&dir).is_err());

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -27,7 +27,7 @@ fn save_new_file() {
     my_glyph.note = Some("I did a glyph!".into());
     let mut plist = Plist::new();
     plist.insert("my-cool-key".into(), plist::Value::Integer(420_u32.into()));
-    my_glyph.lib = Some(plist);
+    my_glyph.lib = plist;
     my_ufo.get_default_layer_mut().unwrap().insert_glyph(my_glyph);
 
     let dir = tempdir::TempDir::new("Test.ufo").unwrap();
@@ -42,10 +42,7 @@ fn save_new_file() {
     assert!(loaded.get_default_layer().unwrap().get_glyph("A").is_some());
     let glyph = loaded.get_default_layer().unwrap().get_glyph("A").unwrap();
     assert_eq!(glyph.codepoints, vec!['A']);
-    let lib_val = glyph
-        .lib
-        .as_ref()
-        .and_then(|lib| lib.get("my-cool-key").and_then(|val| val.as_unsigned_integer()));
+    let lib_val = glyph.lib.get("my-cool-key").and_then(|val| val.as_unsigned_integer());
     assert_eq!(lib_val, Some(420));
 }
 
@@ -74,17 +71,17 @@ fn save_fancy() {
 #[test]
 fn roundtrip_object_libs() {
     let ufo = Ufo::load("testdata/identifiers.ufo").unwrap();
-    assert_eq!(ufo.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+    assert_eq!(ufo.lib.contains_key("public.objectLibs"), false);
 
     let glyph = ufo.get_glyph("test").unwrap();
-    assert_eq!(glyph.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+    assert_eq!(glyph.lib.contains_key("public.objectLibs"), false);
 
     let dir = tempdir::TempDir::new("identifiers.ufo").unwrap();
     ufo.save(&dir).unwrap();
-    assert_eq!(glyph.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+    assert_eq!(glyph.lib.contains_key("public.objectLibs"), false);
 
     let ufo2 = Ufo::load(&dir).unwrap();
-    assert_eq!(ufo2.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+    assert_eq!(ufo2.lib.contains_key("public.objectLibs"), false);
 
     let font_guideline_second = &ufo2.font_info.as_ref().unwrap().guidelines.as_ref().unwrap()[1];
     assert_eq!(
@@ -104,7 +101,7 @@ fn roundtrip_object_libs() {
     );
 
     let glyph2 = ufo2.get_glyph("test").unwrap();
-    assert_eq!(glyph2.lib.as_ref().unwrap().contains_key("public.objectLibs"), false);
+    assert_eq!(glyph2.lib.contains_key("public.objectLibs"), false);
 
     let anchor_second = &glyph2.anchors[1];
     assert_eq!(
@@ -194,9 +191,9 @@ fn object_libs_reject_existing_key() {
     let mut test_lib = plist::Dictionary::new();
     test_lib.insert("public.objectLibs".into(), plist::Value::Dictionary(plist::Dictionary::new()));
 
-    ufo.lib.replace(test_lib.clone());
+    ufo.lib = test_lib.clone();
     assert!(ufo.save(&dir).is_err());
-    ufo.lib.as_mut().unwrap().remove("public.objectLibs".into());
+    ufo.lib.remove("public.objectLibs".into());
 
     let glyph = Glyph {
         name: "test".into(),
@@ -207,7 +204,7 @@ fn object_libs_reject_existing_key() {
         codepoints: vec![],
         guidelines: vec![],
         image: None,
-        lib: Some(test_lib),
+        lib: test_lib,
         note: None,
         components: vec![],
         contours: vec![],


### PR DESCRIPTION
Closes https://github.com/linebender/norad/issues/92.

I'm keeping `Outline` around for only-once checking. Maybe... I can cut down the builders again and get the only-once logic back into the glif parser...