### PR TITLE
Move stuff around

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,89 @@
+use std::str::FromStr;
+
+#[cfg(feature = "druid")]
+use druid::Data;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error::ErrorKind;
+
+/// A color.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "druid", derive(Data))]
+pub struct Color {
+    pub red: f32,
+    pub green: f32,
+    pub blue: f32,
+    pub alpha: f32,
+}
+
+impl FromStr for Color {
+    type Err = ErrorKind;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut iter = s.split(',').map(|v| match v.parse::<f32>() {
+            Ok(val) if (0.0..=1.0).contains(&val) => Ok(val),
+            _ => Err(ErrorKind::BadColor),
+        });
+        let red = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        let green = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        let blue = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        let alpha = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        if iter.next().is_some() {
+            Err(ErrorKind::BadColor)
+        } else {
+            Ok(Color { red, green, blue, alpha })
+        }
+    }
+}
+
+impl Serialize for Color {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let color_string = format!("{},{},{},{}", self.red, self.green, self.blue, self.alpha);
+        serializer.serialize_str(&color_string)
+    }
+}
+
+impl<'de> Deserialize<'de> for Color {
+    fn deserialize<D>(deserializer: D) -> Result<Color, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        Color::from_str(&string).map_err(|_| serde::de::Error::custom("Malformed color string."))
+    }
+}
+
+#[cfg(feature = "druid")]
+impl From<druid::piet::Color> for Color {
+    fn from(src: druid::piet::Color) -> Color {
+        let rgba = src.as_rgba_u32();
+        let r = ((rgba >> 24) & 0xff) as f32 / 255.0;
+        let g = ((rgba >> 16) & 0xff) as f32 / 255.0;
+        let b = ((rgba >> 8) & 0xff) as f32 / 255.0;
+        let a = (rgba & 0xff) as f32 / 255.0;
+        assert!((0.0..=1.0).contains(&b), "b: {}, raw {}", b, (rgba & (0xff << 8)));
+
+        Color {
+            red: r.max(0.0).min(1.0),
+            green: g.max(0.0).min(1.0),
+            blue: b.max(0.0).min(1.0),
+            alpha: a.max(0.0).min(1.0),
+        }
+    }
+}
+
+#[cfg(feature = "druid")]
+impl From<Color> for druid::piet::Color {
+    fn from(src: Color) -> druid::piet::Color {
+        druid::piet::Color::rgba(
+            src.red.into(),
+            src.green.into(),
+            src.blue.into(),
+            src.alpha.into(),
+        )
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use plist::Error as PlistError;
 use quick_xml::Error as XmlError;
 
-use crate::GlyphName;
+use crate::names::GlyphName;
 
 /// Errors that occur while working with font objects.
 #[derive(Debug)]

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -7,9 +7,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ErrorKind;
 use crate::guideline::Guideline;
+use crate::identifier::Identifier;
 use crate::shared_types::{
-    Bitlist, Float, Identifier, Integer, IntegerOrFloat, NonNegativeInteger,
-    NonNegativeIntegerOrFloat, Plist, PUBLIC_OBJECT_LIBS_KEY,
+    Bitlist, Float, Integer, IntegerOrFloat, NonNegativeInteger, NonNegativeIntegerOrFloat, Plist,
+    PUBLIC_OBJECT_LIBS_KEY,
 };
 use crate::{Error, FormatVersion};
 
@@ -1217,9 +1218,12 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::guideline::Line;
     use serde_test::{assert_tokens, Token};
+
+    use crate::guideline::Line;
+    use crate::identifier::Identifier;
+
+    use super::*;
 
     #[test]
     fn fontinfo() {
@@ -1233,7 +1237,7 @@ mod tests {
 
     #[test]
     fn fontinfo2() {
-        use crate::shared_types::{Color, Identifier};
+        use crate::shared_types::Color;
 
         let path = "testdata/fontinfotest.ufo/fontinfo.plist";
         let font_info: FontInfo = plist::from_file(path).expect("failed to load fontinfo");

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1237,7 +1237,7 @@ mod tests {
 
     #[test]
     fn fontinfo2() {
-        use crate::shared_types::Color;
+        use crate::color::Color;
 
         let path = "testdata/fontinfotest.ufo/fontinfo.plist";
         let font_info: FontInfo = plist::from_file(path).expect("failed to load fontinfo");

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -6,8 +6,9 @@ use serde::ser::{SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
 
 use crate::error::ErrorKind;
+use crate::guideline::Guideline;
 use crate::shared_types::{
-    Bitlist, Float, Guideline, Identifier, Integer, IntegerOrFloat, NonNegativeInteger,
+    Bitlist, Float, Identifier, Integer, IntegerOrFloat, NonNegativeInteger,
     NonNegativeIntegerOrFloat, Plist, PUBLIC_OBJECT_LIBS_KEY,
 };
 use crate::{Error, FormatVersion};
@@ -1217,7 +1218,7 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shared_types::Line;
+    use crate::guideline::Line;
     use serde_test::{assert_tokens, Token};
 
     #[test]
@@ -1232,7 +1233,7 @@ mod tests {
 
     #[test]
     fn fontinfo2() {
-        use crate::shared_types::{Color, Identifier, Line};
+        use crate::shared_types::{Color, Identifier};
 
         let path = "testdata/fontinfotest.ufo/fontinfo.plist";
         let font_info: FontInfo = plist::from_file(path).expect("failed to load fontinfo");

--- a/src/glyph/affinetransform.rs
+++ b/src/glyph/affinetransform.rs
@@ -1,0 +1,63 @@
+#[cfg(feature = "druid")]
+use druid::Data;
+
+/// Taken together in order, these fields represent an affine transformation matrix.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "druid", derive(Data))]
+pub struct AffineTransform {
+    pub x_scale: f32,
+    pub xy_scale: f32,
+    pub yx_scale: f32,
+    pub y_scale: f32,
+    pub x_offset: f32,
+    pub y_offset: f32,
+}
+
+impl AffineTransform {
+    ///  [1 0 0 1 0 0]; the identity transformation.
+    fn identity() -> Self {
+        AffineTransform {
+            x_scale: 1.0,
+            xy_scale: 0.,
+            yx_scale: 0.,
+            y_scale: 1.0,
+            x_offset: 0.,
+            y_offset: 0.,
+        }
+    }
+}
+
+impl Default for AffineTransform {
+    fn default() -> Self {
+        Self::identity()
+    }
+}
+
+#[cfg(feature = "kurbo")]
+impl From<AffineTransform> for kurbo::Affine {
+    fn from(src: AffineTransform) -> kurbo::Affine {
+        kurbo::Affine::new([
+            src.x_scale as f64,
+            src.xy_scale as f64,
+            src.yx_scale as f64,
+            src.y_scale as f64,
+            src.x_offset as f64,
+            src.y_offset as f64,
+        ])
+    }
+}
+
+#[cfg(feature = "kurbo")]
+impl From<kurbo::Affine> for AffineTransform {
+    fn from(src: kurbo::Affine) -> AffineTransform {
+        let coeffs = src.as_coeffs();
+        AffineTransform {
+            x_scale: coeffs[0] as f32,
+            xy_scale: coeffs[1] as f32,
+            yx_scale: coeffs[2] as f32,
+            y_scale: coeffs[3] as f32,
+            x_offset: coeffs[4] as f32,
+            y_offset: coeffs[5] as f32,
+        }
+    }
+}

--- a/src/glyph/anchor.rs
+++ b/src/glyph/anchor.rs
@@ -1,0 +1,70 @@
+use crate::{Color, Identifier, Plist};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Anchor {
+    pub x: f32,
+    pub y: f32,
+    /// An arbitrary name for the anchor.
+    pub name: Option<String>,
+    pub color: Option<Color>,
+    /// Unique identifier for the anchor within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The anchor's lib for arbitary data.
+    lib: Option<Plist>,
+}
+
+impl Anchor {
+    pub fn new(
+        x: f32,
+        y: f32,
+        name: Option<String>,
+        color: Option<Color>,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        let mut this = Self { x, y, name, color, identifier: None, lib: None };
+        if let Some(id) = identifier {
+            this.replace_identifier(id);
+        }
+        if let Some(lib) = lib {
+            this.replace_lib(lib);
+        }
+        this
+    }
+
+    /// Returns an immutable reference to the anchor's lib.
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
+    }
+
+    /// Returns a mutable reference to the anchor's lib.
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the anchor, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the anchor's identifier.
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -6,7 +6,8 @@ use crate::glyph::{
     Image, PointType,
 };
 use crate::guideline::Guideline;
-use crate::shared_types::{Identifier, Plist};
+use crate::identifier::Identifier;
+use crate::shared_types::Plist;
 
 // NOTE: The builders are private to the crate until we have a real-world use-case for making
 // them public. Then, we need to think about maybe doing without a GlyphBuilder at all (check

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 
 use crate::error::ErrorKind;
+use crate::glyph::component::Component;
 use crate::glyph::{
-    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, PointType,
+    AffineTransform, Anchor, Contour, ContourPoint, GlifVersion, Glyph, Image, PointType,
 };
 use crate::guideline::Guideline;
 use crate::identifier::Identifier;

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -2,11 +2,11 @@ use std::collections::HashSet;
 
 use crate::error::ErrorKind;
 use crate::glyph::{
-    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,
-    Image, PointType,
+    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, PointType,
 };
 use crate::guideline::Guideline;
 use crate::identifier::Identifier;
+use crate::names::GlyphName;
 use crate::shared_types::Plist;
 
 // NOTE: The builders are private to the crate until we have a real-world use-case for making
@@ -499,8 +499,9 @@ fn insert_identifier(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::glyph::Line;
+
+    use super::*;
 
     #[test]
     fn glyph_builder_basic() -> Result<(), ErrorKind> {

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -174,7 +174,7 @@ impl GlyphBuilder {
         if self.glyph.format == GlifVersion::V1 {
             return Err(ErrorKind::UnexpectedTag);
         }
-        insert_identifier(&mut self.identifiers, anchor.identifier.clone())?;
+        insert_identifier(&mut self.identifiers, anchor.identifier().cloned())?;
         self.glyph.anchors.push(anchor);
         Ok(self)
     }

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -1,14 +1,11 @@
 use std::collections::HashSet;
 
 use crate::error::ErrorKind;
-use crate::glyph::component::Component;
-use crate::glyph::{
-    AffineTransform, Anchor, Contour, ContourPoint, GlifVersion, Glyph, Image, PointType,
+
+use crate::{
+    AffineTransform, Anchor, Component, Contour, GlifVersion, Glyph, GlyphName, Guideline,
+    Identifier, Image, Plist, Point, PointType,
 };
-use crate::guideline::Guideline;
-use crate::identifier::Identifier;
-use crate::names::GlyphName;
-use crate::shared_types::Plist;
 
 // NOTE: The builders are private to the crate until we have a real-world use-case for making
 // them public. Then, we need to think about maybe doing without a GlyphBuilder at all (check
@@ -392,7 +389,7 @@ impl OutlineBuilder {
                     }
                 }
                 insert_identifier(&mut self.identifiers, identifier.clone()).unwrap();
-                scratch_contour.points.push(ContourPoint::new(
+                scratch_contour.points.push(Point::new(
                     x,
                     y,
                     segment_type,
@@ -612,10 +609,10 @@ mod tests {
                 ],
                 contours: vec![Contour::new(
                     vec![
-                        ContourPoint::new(173.0, 536.0, PointType::Line, false, None, None, None,),
-                        ContourPoint::new(85.0, 536.0, PointType::Line, false, None, None, None,),
-                        ContourPoint::new(85.0, 0.0, PointType::Line, false, None, None, None),
-                        ContourPoint::new(
+                        Point::new(173.0, 536.0, PointType::Line, false, None, None, None,),
+                        Point::new(85.0, 536.0, PointType::Line, false, None, None, None,),
+                        Point::new(85.0, 0.0, PointType::Line, false, None, None, None),
+                        Point::new(
                             173.0,
                             0.0,
                             PointType::Line,

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -3,8 +3,9 @@ use std::collections::HashSet;
 use crate::error::ErrorKind;
 use crate::glyph::{
     AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,
-    Guideline, Image, PointType,
+    Image, PointType,
 };
+use crate::guideline::Guideline;
 use crate::shared_types::{Identifier, Plist};
 
 // NOTE: The builders are private to the crate until we have a real-world use-case for making

--- a/src/glyph/component.rs
+++ b/src/glyph/component.rs
@@ -1,0 +1,67 @@
+use crate::{AffineTransform, GlyphName, Identifier, Plist};
+
+/// Another glyph inserted as part of the outline.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Component {
+    /// The name of the base glyph.
+    pub base: GlyphName,
+    pub transform: AffineTransform,
+    /// Unique identifier for the component within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The component's lib for arbitary data.
+    lib: Option<Plist>,
+}
+
+impl Component {
+    pub fn new(
+        base: GlyphName,
+        transform: AffineTransform,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        let mut this = Self { base, transform, identifier: None, lib: None };
+        if let Some(id) = identifier {
+            this.replace_identifier(id);
+        }
+        if let Some(lib) = lib {
+            this.replace_lib(lib);
+        }
+        this
+    }
+
+    /// Returns an immutable reference to the component's lib.
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
+    }
+
+    /// Returns a mutable reference to the component's lib.
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the component, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the component's identifier.
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}

--- a/src/glyph/contour.rs
+++ b/src/glyph/contour.rs
@@ -1,0 +1,63 @@
+use crate::{Identifier, Plist, Point, PointType};
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Contour {
+    pub points: Vec<Point>,
+    /// Unique identifier for the contour within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The contour's lib for arbitary data.
+    lib: Option<Plist>,
+}
+
+impl Contour {
+    pub fn new(points: Vec<Point>, identifier: Option<Identifier>, lib: Option<Plist>) -> Self {
+        let mut this = Self { points, identifier: None, lib: None };
+        if let Some(id) = identifier {
+            this.replace_identifier(id);
+        }
+        if let Some(lib) = lib {
+            this.replace_lib(lib);
+        }
+        this
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.points.first().map_or(true, |v| v.typ != PointType::Move)
+    }
+
+    /// Returns an immutable reference to the contour's lib.
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
+    }
+
+    /// Returns a mutable reference to the contour's lib.
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the contour, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the contour's identifier.
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}

--- a/src/glyph/image.rs
+++ b/src/glyph/image.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+use crate::{AffineTransform, Color};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Image {
+    /// Not an absolute / relative path, but the name of the image file.
+    pub file_name: PathBuf,
+    pub color: Option<Color>,
+    pub transform: AffineTransform,
+}

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -1,22 +1,23 @@
 //! Data related to individual glyphs.
 
-pub mod builder;
-mod parse;
-mod serialize;
-#[cfg(test)]
-mod tests;
-
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 #[cfg(feature = "druid")]
 use druid::{Data, Lens};
 
+use crate::color::Color;
 use crate::error::{Error, ErrorKind, GlifError, GlifErrorInternal};
 use crate::guideline::{Guideline, Line};
 use crate::identifier::Identifier;
 use crate::names::NameList;
-use crate::shared_types::{Color, Plist, PUBLIC_OBJECT_LIBS_KEY};
+use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
+
+pub mod builder;
+mod parse;
+mod serialize;
+#[cfg(test)]
+mod tests;
 
 /// The name of a glyph.
 pub type GlyphName = Arc<str>;
@@ -621,36 +622,5 @@ impl From<kurbo::Affine> for AffineTransform {
             x_offset: coeffs[4] as f32,
             y_offset: coeffs[5] as f32,
         }
-    }
-}
-
-#[cfg(feature = "druid")]
-impl From<druid::piet::Color> for Color {
-    fn from(src: druid::piet::Color) -> Color {
-        let rgba = src.as_rgba_u32();
-        let r = ((rgba >> 24) & 0xff) as f32 / 255.0;
-        let g = ((rgba >> 16) & 0xff) as f32 / 255.0;
-        let b = ((rgba >> 8) & 0xff) as f32 / 255.0;
-        let a = (rgba & 0xff) as f32 / 255.0;
-        assert!((0.0..=1.0).contains(&b), "b: {}, raw {}", b, (rgba & (0xff << 8)));
-
-        Color {
-            red: r.max(0.0).min(1.0),
-            green: g.max(0.0).min(1.0),
-            blue: b.max(0.0).min(1.0),
-            alpha: a.max(0.0).min(1.0),
-        }
-    }
-}
-
-#[cfg(feature = "druid")]
-impl From<Color> for druid::piet::Color {
-    fn from(src: Color) -> druid::piet::Color {
-        druid::piet::Color::rgba(
-            src.red.into(),
-            src.green.into(),
-            src.blue.into(),
-            src.alpha.into(),
-        )
     }
 }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -13,8 +13,9 @@ use std::sync::Arc;
 use druid::{Data, Lens};
 
 use crate::error::{Error, ErrorKind, GlifError, GlifErrorInternal};
+use crate::guideline::{Guideline, Line};
 use crate::names::NameList;
-use crate::shared_types::{Color, Guideline, Identifier, Line, Plist, PUBLIC_OBJECT_LIBS_KEY};
+use crate::shared_types::{Color, Identifier, Plist, PUBLIC_OBJECT_LIBS_KEY};
 
 /// The name of a glyph.
 pub type GlyphName = Arc<str>;

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use druid::{Data, Lens};
 
 pub use anchor::Anchor;
+pub use component::Component;
 
 use crate::color::Color;
 use crate::error::{Error, ErrorKind, GlifError, GlifErrorInternal};
@@ -16,6 +17,7 @@ use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
 
 pub mod anchor;
 pub mod builder;
+pub mod component;
 mod parse;
 mod serialize;
 #[cfg(test)]
@@ -211,19 +213,6 @@ pub enum GlifVersion {
     V2 = 2,
 }
 
-/// Another glyph inserted as part of the outline.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Component {
-    /// The name of the base glyph.
-    pub base: GlyphName,
-    pub transform: AffineTransform,
-    /// Unique identifier for the component within the glyph. This attribute is only required
-    /// when a lib is present and should otherwise only be added as needed.
-    identifier: Option<Identifier>,
-    /// The component's lib for arbitary data.
-    lib: Option<Plist>,
-}
-
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Contour {
     pub points: Vec<ContourPoint>,
@@ -393,59 +382,6 @@ impl ContourPoint {
     }
 
     /// Returns an immutable reference to the contour's identifier.
-    pub fn identifier(&self) -> Option<&Identifier> {
-        self.identifier.as_ref()
-    }
-
-    /// Replaces the actual identifier by the identifier given in parameter,
-    /// returning the old identifier if present.
-    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
-        self.identifier.replace(id)
-    }
-}
-
-impl Component {
-    pub fn new(
-        base: GlyphName,
-        transform: AffineTransform,
-        identifier: Option<Identifier>,
-        lib: Option<Plist>,
-    ) -> Self {
-        let mut this = Self { base, transform, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
-    }
-
-    /// Returns an immutable reference to the component's lib.
-    pub fn lib(&self) -> Option<&Plist> {
-        self.lib.as_ref()
-    }
-
-    /// Returns a mutable reference to the component's lib.
-    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
-        self.lib.as_mut()
-    }
-
-    /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
-    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
-        self.lib.replace(lib)
-    }
-
-    /// Takes the lib out of the component, leaving a None in its place.
-    pub fn take_lib(&mut self) -> Option<Plist> {
-        self.lib.take()
-    }
-
-    /// Returns an immutable reference to the component's identifier.
     pub fn identifier(&self) -> Option<&Identifier> {
         self.identifier.as_ref()
     }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "druid")]
 use druid::{Data, Lens};
 
+pub use anchor::Anchor;
+
 use crate::color::Color;
 use crate::error::{Error, ErrorKind, GlifError, GlifErrorInternal};
 use crate::guideline::{Guideline, Line};
@@ -12,6 +14,7 @@ use crate::identifier::Identifier;
 use crate::names::{GlyphName, NameList};
 use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
 
+pub mod anchor;
 pub mod builder;
 mod parse;
 mod serialize;
@@ -208,20 +211,6 @@ pub enum GlifVersion {
     V2 = 2,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct Anchor {
-    pub x: f32,
-    pub y: f32,
-    /// An arbitrary name for the anchor.
-    pub name: Option<String>,
-    pub color: Option<Color>,
-    /// Unique identifier for the anchor within the glyph. This attribute is only required
-    /// when a lib is present and should otherwise only be added as needed.
-    identifier: Option<Identifier>,
-    /// The anchor's lib for arbitary data.
-    lib: Option<Plist>,
-}
-
 /// Another glyph inserted as part of the outline.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Component {
@@ -305,61 +294,6 @@ pub struct AffineTransform {
     pub y_scale: f32,
     pub x_offset: f32,
     pub y_offset: f32,
-}
-
-impl Anchor {
-    pub fn new(
-        x: f32,
-        y: f32,
-        name: Option<String>,
-        color: Option<Color>,
-        identifier: Option<Identifier>,
-        lib: Option<Plist>,
-    ) -> Self {
-        let mut this = Self { x, y, name, color, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
-    }
-
-    /// Returns an immutable reference to the anchor's lib.
-    pub fn lib(&self) -> Option<&Plist> {
-        self.lib.as_ref()
-    }
-
-    /// Returns a mutable reference to the anchor's lib.
-    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
-        self.lib.as_mut()
-    }
-
-    /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
-    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
-        self.lib.replace(lib)
-    }
-
-    /// Takes the lib out of the anchor, leaving a None in its place.
-    pub fn take_lib(&mut self) -> Option<Plist> {
-        self.lib.take()
-    }
-
-    /// Returns an immutable reference to the anchor's identifier.
-    pub fn identifier(&self) -> Option<&Identifier> {
-        self.identifier.as_ref()
-    }
-
-    /// Replaces the actual identifier by the identifier given in parameter,
-    /// returning the old identifier if present.
-    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
-        self.identifier.replace(id)
-    }
 }
 
 impl Contour {

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -1,7 +1,6 @@
 //! Data related to individual glyphs.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 #[cfg(feature = "druid")]
 use druid::{Data, Lens};
@@ -10,7 +9,7 @@ use crate::color::Color;
 use crate::error::{Error, ErrorKind, GlifError, GlifErrorInternal};
 use crate::guideline::{Guideline, Line};
 use crate::identifier::Identifier;
-use crate::names::NameList;
+use crate::names::{GlyphName, NameList};
 use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
 
 pub mod builder;
@@ -18,9 +17,6 @@ mod parse;
 mod serialize;
 #[cfg(test)]
 mod tests;
-
-/// The name of a glyph.
-pub type GlyphName = Arc<str>;
 
 /// A glyph, loaded from a [.glif file][glif].
 ///

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -14,8 +14,9 @@ use druid::{Data, Lens};
 
 use crate::error::{Error, ErrorKind, GlifError, GlifErrorInternal};
 use crate::guideline::{Guideline, Line};
+use crate::identifier::Identifier;
 use crate::names::NameList;
-use crate::shared_types::{Color, Identifier, Plist, PUBLIC_OBJECT_LIBS_KEY};
+use crate::shared_types::{Color, Plist, PUBLIC_OBJECT_LIBS_KEY};
 
 /// The name of a glyph.
 pub type GlyphName = Arc<str>;

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -5,15 +5,17 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use super::*;
-use crate::error::{ErrorKind, GlifErrorInternal};
-use crate::glyph::builder::{GlyphBuilder, Outline, OutlineBuilder};
-use crate::names::NameList;
-
 use quick_xml::{
     events::{BytesStart, Event},
     Reader,
 };
+
+use crate::error::{ErrorKind, GlifErrorInternal};
+use crate::glyph::builder::{GlyphBuilder, Outline, OutlineBuilder};
+use crate::names::NameList;
+use crate::PointType;
+
+use super::*;
 
 #[cfg(test)]
 pub(crate) fn parse_glyph(xml: &[u8]) -> Result<Glyph, GlifErrorInternal> {

--- a/src/glyph/point.rs
+++ b/src/glyph/point.rs
@@ -1,0 +1,101 @@
+use crate::{Identifier, Plist};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Point {
+    pub x: f32,
+    pub y: f32,
+    pub typ: PointType,
+    pub smooth: bool,
+    pub name: Option<String>,
+    /// Unique identifier for the point within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The point's lib for arbitary data.
+    lib: Option<Plist>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PointType {
+    /// A point of this type must be the first in a contour. The reverse is not true:
+    /// a contour does not necessarily start with a move point. When a contour
+    /// does start with a move point, it signifies the beginning of an open contour.
+    /// A closed contour does not start with a move and is defined as a cyclic
+    /// list of points, with no predominant start point. There is always a next
+    /// point and a previous point. For this purpose the list of points can be
+    /// seen as endless in both directions. The actual list of points can be
+    /// rotated arbitrarily (by removing the first N points and appending
+    /// them at the end) while still describing the same outline.
+    Move,
+    /// Draw a straight line from the previous point to this point.
+    /// The previous point must be a move, a line, a curve or a qcurve.
+    /// It must not be an offcurve.
+    Line,
+    /// This point is part of a curve segment that goes up to the next point
+    /// that is either a curve or a qcurve.
+    OffCurve,
+    /// Draw a cubic bezier curve from the last non-offcurve point to this point.
+    /// The number of offcurve points can be zero, one or two.
+    /// If the number of offcurve points is zero, a straight line is drawn.
+    /// If it is one, a quadratic curve is drawn.
+    /// If it is two, a regular cubic bezier is drawn.
+    Curve,
+    /// Similar to curve, but uses quadratic curves, using the TrueType
+    /// “implied on-curve points” principle.
+    QCurve,
+}
+
+impl Point {
+    pub fn new(
+        x: f32,
+        y: f32,
+        typ: PointType,
+        smooth: bool,
+        name: Option<String>,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        let mut this = Self { x, y, typ, smooth, name, identifier: None, lib: None };
+        if let Some(id) = identifier {
+            this.replace_identifier(id);
+        }
+        if let Some(lib) = lib {
+            this.replace_lib(lib);
+        }
+        this
+    }
+
+    /// Returns an immutable reference to the contour's lib.
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
+    }
+
+    /// Returns a mutable reference to the contour's lib.
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the contour, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the contour's identifier.
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -7,16 +7,13 @@ use quick_xml::{
     Error as XmlError, Writer,
 };
 
-use crate::color::Color;
 use crate::error::{GlifWriteError, WriteError};
-use crate::glyph::anchor::Anchor;
-use crate::glyph::component::Component;
-use crate::guideline::{Guideline, Line};
-
-use super::{
-    AffineTransform, Contour, ContourPoint, GlifVersion, Glyph, Image, Plist, PointType,
-    PUBLIC_OBJECT_LIBS_KEY,
+use crate::{
+    AffineTransform, Anchor, Color, Component, Contour, GlifVersion, Glyph, Guideline, Image, Line,
+    Plist, Point, PointType,
 };
+
+use super::PUBLIC_OBJECT_LIBS_KEY;
 
 impl Glyph {
     pub fn encode_xml(&self) -> Result<Vec<u8>, GlifWriteError> {
@@ -213,7 +210,7 @@ impl Contour {
     fn write_xml<T: Write>(&self, writer: &mut Writer<T>) -> Result<(), XmlError> {
         let mut start = BytesStart::borrowed_name(b"contour");
 
-        if let Some(id) = &self.identifier {
+        if let Some(id) = &self.identifier() {
             start.push_attribute(("identifier", id.as_str()));
         }
 
@@ -227,7 +224,7 @@ impl Contour {
     }
 }
 
-impl ContourPoint {
+impl Point {
     fn to_event(&self) -> Event {
         let mut start = BytesStart::borrowed_name(b"point");
 
@@ -247,7 +244,7 @@ impl ContourPoint {
             start.push_attribute(("name", name.as_str()));
         }
 
-        if let Some(id) = &self.identifier {
+        if let Some(id) = &self.identifier() {
             start.push_attribute(("identifier", id.as_str()));
         }
         Event::Empty(start)

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -7,13 +7,14 @@ use quick_xml::{
     Error as XmlError, Writer,
 };
 
-use super::{
-    AffineTransform, Anchor, Color, Component, Contour, ContourPoint, GlifVersion, Glyph, Image,
-    Plist, PointType, PUBLIC_OBJECT_LIBS_KEY,
-};
-
+use crate::color::Color;
 use crate::error::{GlifWriteError, WriteError};
 use crate::guideline::{Guideline, Line};
+
+use super::{
+    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, Plist,
+    PointType, PUBLIC_OBJECT_LIBS_KEY,
+};
 
 impl Glyph {
     pub fn encode_xml(&self) -> Result<Vec<u8>, GlifWriteError> {

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -8,11 +8,12 @@ use quick_xml::{
 };
 
 use super::{
-    AffineTransform, Anchor, Color, Component, Contour, ContourPoint, GlifVersion, Glyph,
-    Guideline, Image, Line, Plist, PointType, PUBLIC_OBJECT_LIBS_KEY,
+    AffineTransform, Anchor, Color, Component, Contour, ContourPoint, GlifVersion, Glyph, Image,
+    Plist, PointType, PUBLIC_OBJECT_LIBS_KEY,
 };
 
 use crate::error::{GlifWriteError, WriteError};
+use crate::guideline::{Guideline, Line};
 
 impl Glyph {
     pub fn encode_xml(&self) -> Result<Vec<u8>, GlifWriteError> {

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -9,11 +9,12 @@ use quick_xml::{
 
 use crate::color::Color;
 use crate::error::{GlifWriteError, WriteError};
+use crate::glyph::anchor::Anchor;
 use crate::guideline::{Guideline, Line};
 
 use super::{
-    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, Plist,
-    PointType, PUBLIC_OBJECT_LIBS_KEY,
+    AffineTransform, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, Plist, PointType,
+    PUBLIC_OBJECT_LIBS_KEY,
 };
 
 impl Glyph {
@@ -182,7 +183,7 @@ impl Anchor {
         start.push_attribute(("x", self.x.to_string().as_str()));
         start.push_attribute(("y", self.y.to_string().as_str()));
 
-        if let Some(id) = &self.identifier {
+        if let Some(id) = &self.identifier().cloned() {
             start.push_attribute(("identifier", id.as_str()));
         }
 

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -10,10 +10,11 @@ use quick_xml::{
 use crate::color::Color;
 use crate::error::{GlifWriteError, WriteError};
 use crate::glyph::anchor::Anchor;
+use crate::glyph::component::Component;
 use crate::guideline::{Guideline, Line};
 
 use super::{
-    AffineTransform, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, Plist, PointType,
+    AffineTransform, Contour, ContourPoint, GlifVersion, Glyph, Image, Plist, PointType,
     PUBLIC_OBJECT_LIBS_KEY,
 };
 
@@ -201,7 +202,7 @@ impl Component {
 
         write_transform_attributes(&mut start, &self.transform);
 
-        if let Some(id) = &self.identifier {
+        if let Some(id) = &self.identifier() {
             start.push_attribute(("identifier", id.as_str()));
         }
         Event::Empty(start)

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -1,6 +1,9 @@
+use std::path::PathBuf;
+
+use crate::PointType;
+
 use super::parse::parse_glyph;
 use super::*;
-use std::path::PathBuf;
 
 #[test]
 fn transform() {

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -2,8 +2,9 @@ use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use serde::{de, ser};
 
+use crate::color::Color;
 use crate::identifier::Identifier;
-use crate::shared_types::{Color, Plist};
+use crate::shared_types::Plist;
 
 /// A guideline associated with a glyph.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -2,7 +2,8 @@ use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use serde::{de, ser};
 
-use crate::shared_types::{Color, Identifier, Plist};
+use crate::identifier::Identifier;
+use crate::shared_types::{Color, Plist};
 
 /// A guideline associated with a glyph.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -1,0 +1,167 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+use serde::{de, ser};
+
+use crate::shared_types::{Color, Identifier, Plist};
+
+/// A guideline associated with a glyph.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Guideline {
+    /// The line itself.
+    pub line: Line,
+    /// An arbitrary name for the guideline.
+    pub name: Option<String>,
+    /// The color of the line.
+    pub color: Option<Color>,
+    /// Unique identifier for the guideline within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The guideline's lib for arbitary data.
+    lib: Option<Plist>,
+}
+
+/// An infinite line.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Line {
+    /// A vertical line, passing through a given `x` coordinate.
+    Vertical(f32),
+    /// A horizontal line, passing through a given `y` coordinate.
+    Horizontal(f32),
+    /// An angled line passing through `(x, y)` at `degrees` degrees counteer-clockwise
+    /// to the horizontal.
+    // TODO: make a Degrees newtype that checks `0 <= degrees <= 360`.
+    Angle { x: f32, y: f32, degrees: f32 },
+}
+
+impl Guideline {
+    pub fn new(
+        line: Line,
+        name: Option<String>,
+        color: Option<Color>,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        let mut this = Self { line, name, color, identifier: None, lib: None };
+        if let Some(id) = identifier {
+            this.replace_identifier(id);
+        }
+        if let Some(lib) = lib {
+            this.replace_lib(lib);
+        }
+        this
+    }
+
+    /// Returns an immutable reference to the Guideline's lib.
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
+    }
+
+    /// Returns a mutable reference to the Guideline's lib.
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the Guideline, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the Guideline's identifier.
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawGuideline {
+    x: Option<f32>,
+    y: Option<f32>,
+    angle: Option<f32>,
+    name: Option<String>,
+    color: Option<Color>,
+    identifier: Option<Identifier>,
+}
+
+impl Serialize for Guideline {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let (x, y, angle) = match self.line {
+            Line::Vertical(x) => (Some(x), None, None),
+            Line::Horizontal(y) => (None, Some(y), None),
+            Line::Angle { x, y, degrees } => {
+                if !(0.0..=360.0).contains(&degrees) {
+                    return Err(ser::Error::custom("angle must be between 0 and 360 degrees."));
+                }
+                (Some(x), Some(y), Some(degrees))
+            }
+        };
+
+        let mut guideline = serializer.serialize_struct("RawGuideline", 6)?;
+        guideline.serialize_field("x", &x)?;
+        guideline.serialize_field("y", &y)?;
+        guideline.serialize_field("angle", &angle)?;
+        guideline.serialize_field("name", &self.name)?;
+        guideline.serialize_field("color", &self.color)?;
+        guideline.serialize_field("identifier", &self.identifier)?;
+        guideline.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Guideline {
+    fn deserialize<D>(deserializer: D) -> Result<Guideline, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let guideline = RawGuideline::deserialize(deserializer)?;
+
+        let x = guideline.x;
+        let y = guideline.y;
+        let angle = guideline.angle;
+
+        let line = match (x, y, angle) {
+            // Valid data:
+            (Some(x), None, None) => Line::Vertical(x),
+            (None, Some(y), None) => Line::Horizontal(y),
+            (Some(x), Some(y), Some(degrees)) => {
+                if !(0.0..=360.0).contains(&degrees) {
+                    return Err(de::Error::custom("angle must be between 0 and 360 degrees."));
+                }
+                Line::Angle { x, y, degrees }
+            }
+            // Invalid data:
+            (None, None, _) => {
+                return Err(de::Error::custom("x or y must be present in a guideline."))
+            }
+            (None, Some(_), Some(_)) | (Some(_), None, Some(_)) => {
+                return Err(de::Error::custom(
+                    "angle must only be specified when both x and y are specified.",
+                ))
+            }
+            (Some(_), Some(_), None) => {
+                return Err(de::Error::custom(
+                    "angle must be specified when both x and y are specified.",
+                ))
+            }
+        };
+
+        Ok(Guideline::new(line, guideline.name, guideline.color, guideline.identifier, None))
+    }
+}

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -1,0 +1,79 @@
+use std::hash::Hash;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error::ErrorKind;
+
+/// Identifiers are optional attributes of several objects in the UFO.
+/// These identifiers are required to be unique within certain contexts
+/// as defined on a per object basis throughout this specification.
+/// Identifiers are specified as a string between one and 100 characters long.
+/// All characters must be in the printable ASCII range, 0x20 to 0x7E.
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub struct Identifier(Arc<str>);
+
+impl Identifier {
+    /// Create a new `Identifier` from a `String`, if it is valid.
+    ///
+    /// A valid identifier must have between 0 and 100 characters, and each
+    /// character must be in the printable ASCII range, 0x20 to 0x7E.
+    pub fn new(s: impl Into<Arc<str>>) -> Result<Self, ErrorKind> {
+        let string = s.into();
+        if is_valid_identifier(&string) {
+            Ok(Identifier(string))
+        } else {
+            Err(ErrorKind::BadIdentifier)
+        }
+    }
+
+    pub fn from_uuidv4() -> Self {
+        Self::new(uuid::Uuid::new_v4().to_string()).unwrap()
+    }
+
+    /// Return the raw identifier, as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PartialEq<String> for Identifier {
+    fn eq(&self, other: &String) -> bool {
+        *self.0 == *other
+    }
+}
+
+impl FromStr for Identifier {
+    type Err = ErrorKind;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Identifier::new(s)
+    }
+}
+
+fn is_valid_identifier(s: &Arc<str>) -> bool {
+    s.len() <= 100 && s.bytes().all(|b| (0x20..=0x7E).contains(&b))
+}
+
+impl Serialize for Identifier {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        debug_assert!(
+            is_valid_identifier(&self.0),
+            "all identifiers are validated on construction"
+        );
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Identifier {
+    fn deserialize<D>(deserializer: D) -> Result<Identifier, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let string = String::deserialize(deserializer)?;
+        Identifier::new(string).map_err(|_| de::Error::custom("Identifier must be at most 100 characters long and contain only ASCII characters in the range 0x20 to 0x7E."))
+    }
+}

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -8,9 +8,9 @@ use std::sync::Arc;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
+use crate::color::Color;
 use crate::glyph::GlyphName;
 use crate::names::NameList;
-use crate::shared_types::Color;
 use crate::{Error, Glyph, Plist};
 
 static CONTENTS_FILE: &str = "contents.plist";

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use rayon::prelude::*;
 
 use crate::color::Color;
-use crate::glyph::GlyphName;
+use crate::names::GlyphName;
 use crate::names::NameList;
 use crate::{Error, Glyph, Plist};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,13 @@ extern crate serde_repr;
 pub use color::Color;
 pub use error::Error;
 pub use fontinfo::FontInfo;
-pub use glyph::{
-    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, PointType,
-};
+pub use glyph::affinetransform::AffineTransform;
+pub use glyph::anchor::Anchor;
+pub use glyph::component::Component;
+pub use glyph::contour::Contour;
+pub use glyph::image::Image;
+pub use glyph::point::{Point, PointType};
+pub use glyph::{GlifVersion, Glyph};
 pub use guideline::{Guideline, Line};
 pub use identifier::Identifier;
 pub use layer::Layer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod error;
 pub mod fontinfo;
 pub mod glyph;
 mod guideline;
+mod identifier;
 mod layer;
 mod names;
 mod shared_types;
@@ -36,6 +37,7 @@ pub use glyph::{
     Image, PointType,
 };
 pub use guideline::{Guideline, Line};
+pub use identifier::Identifier;
 pub use layer::Layer;
-pub use shared_types::{Color, Identifier, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
+pub use shared_types::{Color, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
 pub use ufo::{DataRequest, FormatVersion, LayerInfo, MetaInfo, Ufo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,23 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_repr;
 
+pub use color::Color;
+pub use error::Error;
+pub use fontinfo::FontInfo;
+pub use glyph::{
+    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, PointType,
+};
+pub use guideline::{Guideline, Line};
+pub use identifier::Identifier;
+pub use layer::Layer;
+pub use names::GlyphName;
+pub use shared_types::{IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
+pub use ufo::{DataRequest, FormatVersion, LayerInfo, MetaInfo, Ufo};
+
+mod color;
 pub mod error;
 pub mod fontinfo;
 pub mod glyph;
-mod color;
 mod guideline;
 mod identifier;
 mod layer;
@@ -30,16 +43,3 @@ mod names;
 mod shared_types;
 mod ufo;
 mod upconversion;
-
-pub use color::Color;
-pub use error::Error;
-pub use fontinfo::FontInfo;
-pub use glyph::{
-    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,
-    Image, PointType,
-};
-pub use guideline::{Guideline, Line};
-pub use identifier::Identifier;
-pub use layer::Layer;
-pub use shared_types::{IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
-pub use ufo::{DataRequest, FormatVersion, LayerInfo, MetaInfo, Ufo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate serde_repr;
 pub mod error;
 pub mod fontinfo;
 pub mod glyph;
+mod color;
 mod guideline;
 mod identifier;
 mod layer;
@@ -30,6 +31,7 @@ mod shared_types;
 mod ufo;
 mod upconversion;
 
+pub use color::Color;
 pub use error::Error;
 pub use fontinfo::FontInfo;
 pub use glyph::{
@@ -39,5 +41,5 @@ pub use glyph::{
 pub use guideline::{Guideline, Line};
 pub use identifier::Identifier;
 pub use layer::Layer;
-pub use shared_types::{Color, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
+pub use shared_types::{IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
 pub use ufo::{DataRequest, FormatVersion, LayerInfo, MetaInfo, Ufo};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate serde_repr;
 pub mod error;
 pub mod fontinfo;
 pub mod glyph;
+mod guideline;
 mod layer;
 mod names;
 mod shared_types;
@@ -34,8 +35,7 @@ pub use glyph::{
     AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,
     Image, PointType,
 };
+pub use guideline::{Guideline, Line};
 pub use layer::Layer;
-pub use shared_types::{
-    Color, Guideline, Identifier, IntegerOrFloat, Line, NonNegativeIntegerOrFloat, Plist,
-};
+pub use shared_types::{Color, Identifier, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
 pub use ufo::{DataRequest, FormatVersion, LayerInfo, MetaInfo, Ufo};

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,10 +1,13 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
 #[cfg(not(feature = "rayon"))]
 use std::cell::RefCell;
-use std::collections::HashSet;
 #[cfg(feature = "rayon")]
 use std::sync::RwLock;
 
-use crate::glyph::GlyphName;
+/// The name of a glyph.
+pub type GlyphName = Arc<str>;
 
 /// Manages interned names
 ///

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -4,14 +4,12 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use serde::de;
-use serde::de::Deserializer;
-use serde::ser;
-use serde::ser::{SerializeStruct, Serializer};
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "druid")]
 use druid::Data;
+use serde::de;
+use serde::de::Deserializer;
+use serde::ser::Serializer;
+use serde::{Deserialize, Serialize};
 
 use crate::error::ErrorKind;
 use crate::Error;
@@ -29,35 +27,6 @@ pub type Plist = plist::Dictionary;
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct Identifier(Arc<str>);
 
-/// A guideline associated with a glyph.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Guideline {
-    /// The line itself.
-    pub line: Line,
-    /// An arbitrary name for the guideline.
-    pub name: Option<String>,
-    /// The color of the line.
-    pub color: Option<Color>,
-    /// Unique identifier for the guideline within the glyph. This attribute is only required
-    /// when a lib is present and should otherwise only be added as needed.
-    identifier: Option<Identifier>,
-    /// The guideline's lib for arbitary data.
-    lib: Option<Plist>,
-}
-
-/// An infinite line.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Line {
-    /// A vertical line, passing through a given `x` coordinate.
-    Vertical(f32),
-    /// A horizontal line, passing through a given `y` coordinate.
-    Horizontal(f32),
-    /// An angled line passing through `(x, y)` at `degrees` degrees counteer-clockwise
-    /// to the horizontal.
-    // TODO: make a Degrees newtype that checks `0 <= degrees <= 360`.
-    Angle { x: f32, y: f32, degrees: f32 },
-}
-
 /// A color.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]
@@ -66,60 +35,6 @@ pub struct Color {
     pub green: f32,
     pub blue: f32,
     pub alpha: f32,
-}
-
-impl Guideline {
-    pub fn new(
-        line: Line,
-        name: Option<String>,
-        color: Option<Color>,
-        identifier: Option<Identifier>,
-        lib: Option<Plist>,
-    ) -> Self {
-        let mut this = Self { line, name, color, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
-    }
-
-    /// Returns an immutable reference to the Guideline's lib.
-    pub fn lib(&self) -> Option<&Plist> {
-        self.lib.as_ref()
-    }
-
-    /// Returns a mutable reference to the Guideline's lib.
-    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
-        self.lib.as_mut()
-    }
-
-    /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
-    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
-        self.lib.replace(lib)
-    }
-
-    /// Takes the lib out of the Guideline, leaving a None in its place.
-    pub fn take_lib(&mut self) -> Option<Plist> {
-        self.lib.take()
-    }
-
-    /// Returns an immutable reference to the Guideline's identifier.
-    pub fn identifier(&self) -> Option<&Identifier> {
-        self.identifier.as_ref()
-    }
-
-    /// Replaces the actual identifier by the identifier given in parameter,
-    /// returning the old identifier if present.
-    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
-        self.identifier.replace(id)
-    }
 }
 
 impl Identifier {
@@ -199,17 +114,6 @@ impl<'de> Deserialize<'de> for Color {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawGuideline {
-    x: Option<f32>,
-    y: Option<f32>,
-    angle: Option<f32>,
-    name: Option<String>,
-    color: Option<Color>,
-    identifier: Option<Identifier>,
-}
-
 fn is_valid_identifier(s: &Arc<str>) -> bool {
     s.len() <= 100 && s.bytes().all(|b| (0x20..=0x7E).contains(&b))
 }
@@ -234,74 +138,6 @@ impl<'de> Deserialize<'de> for Identifier {
     {
         let string = String::deserialize(deserializer)?;
         Identifier::new(string).map_err(|_| de::Error::custom("Identifier must be at most 100 characters long and contain only ASCII characters in the range 0x20 to 0x7E."))
-    }
-}
-
-impl Serialize for Guideline {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let (x, y, angle) = match self.line {
-            Line::Vertical(x) => (Some(x), None, None),
-            Line::Horizontal(y) => (None, Some(y), None),
-            Line::Angle { x, y, degrees } => {
-                if !(0.0..=360.0).contains(&degrees) {
-                    return Err(ser::Error::custom("angle must be between 0 and 360 degrees."));
-                }
-                (Some(x), Some(y), Some(degrees))
-            }
-        };
-
-        let mut guideline = serializer.serialize_struct("RawGuideline", 6)?;
-        guideline.serialize_field("x", &x)?;
-        guideline.serialize_field("y", &y)?;
-        guideline.serialize_field("angle", &angle)?;
-        guideline.serialize_field("name", &self.name)?;
-        guideline.serialize_field("color", &self.color)?;
-        guideline.serialize_field("identifier", &self.identifier)?;
-        guideline.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for Guideline {
-    fn deserialize<D>(deserializer: D) -> Result<Guideline, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let guideline = RawGuideline::deserialize(deserializer)?;
-
-        let x = guideline.x;
-        let y = guideline.y;
-        let angle = guideline.angle;
-
-        let line = match (x, y, angle) {
-            // Valid data:
-            (Some(x), None, None) => Line::Vertical(x),
-            (None, Some(y), None) => Line::Horizontal(y),
-            (Some(x), Some(y), Some(degrees)) => {
-                if !(0.0..=360.0).contains(&degrees) {
-                    return Err(de::Error::custom("angle must be between 0 and 360 degrees."));
-                }
-                Line::Angle { x, y, degrees }
-            }
-            // Invalid data:
-            (None, None, _) => {
-                return Err(de::Error::custom("x or y must be present in a guideline."))
-            }
-            (None, Some(_), Some(_)) | (Some(_), None, Some(_)) => {
-                return Err(de::Error::custom(
-                    "angle must only be specified when both x and y are specified.",
-                ))
-            }
-            (Some(_), Some(_), None) => {
-                return Err(de::Error::custom(
-                    "angle must be specified when both x and y are specified.",
-                ))
-            }
-        };
-
-        Ok(Guideline::new(line, guideline.name, guideline.color, guideline.identifier, None))
     }
 }
 
@@ -479,8 +315,10 @@ impl<'de> Deserialize<'de> for NonNegativeIntegerOrFloat {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_test::{assert_tokens, Token};
+
+    use super::*;
+    use crate::guideline::*;
 
     #[test]
     fn color_parsing() {

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -1,12 +1,10 @@
 use std::convert::TryFrom;
-use std::hash::Hash;
 use std::ops::Deref;
 use std::str::FromStr;
-use std::sync::Arc;
 
 #[cfg(feature = "druid")]
 use druid::Data;
-use serde::de;
+
 use serde::de::Deserializer;
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
@@ -19,14 +17,6 @@ pub static PUBLIC_OBJECT_LIBS_KEY: &str = "public.objectLibs";
 /// A Plist dictionary.
 pub type Plist = plist::Dictionary;
 
-/// Identifiers are optional attributes of several objects in the UFO.
-/// These identifiers are required to be unique within certain contexts
-/// as defined on a per object basis throughout this specification.
-/// Identifiers are specified as a string between one and 100 characters long.
-/// All characters must be in the printable ASCII range, 0x20 to 0x7E.
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
-pub struct Identifier(Arc<str>);
-
 /// A color.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]
@@ -35,43 +25,6 @@ pub struct Color {
     pub green: f32,
     pub blue: f32,
     pub alpha: f32,
-}
-
-impl Identifier {
-    /// Create a new `Identifier` from a `String`, if it is valid.
-    ///
-    /// A valid identifier must have between 0 and 100 characters, and each
-    /// character must be in the printable ASCII range, 0x20 to 0x7E.
-    pub fn new(s: impl Into<Arc<str>>) -> Result<Self, ErrorKind> {
-        let string = s.into();
-        if is_valid_identifier(&string) {
-            Ok(Identifier(string))
-        } else {
-            Err(ErrorKind::BadIdentifier)
-        }
-    }
-
-    pub fn from_uuidv4() -> Self {
-        Self::new(uuid::Uuid::new_v4().to_string()).unwrap()
-    }
-
-    /// Return the raw identifier, as a `&str`.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl PartialEq<String> for Identifier {
-    fn eq(&self, other: &String) -> bool {
-        *self.0 == *other
-    }
-}
-
-impl FromStr for Identifier {
-    type Err = ErrorKind;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Identifier::new(s)
-    }
 }
 
 impl FromStr for Color {
@@ -111,33 +64,6 @@ impl<'de> Deserialize<'de> for Color {
     {
         let string = String::deserialize(deserializer)?;
         Color::from_str(&string).map_err(|_| serde::de::Error::custom("Malformed color string."))
-    }
-}
-
-fn is_valid_identifier(s: &Arc<str>) -> bool {
-    s.len() <= 100 && s.bytes().all(|b| (0x20..=0x7E).contains(&b))
-}
-
-impl Serialize for Identifier {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        debug_assert!(
-            is_valid_identifier(&self.0),
-            "all identifiers are validated on construction"
-        );
-        serializer.serialize_str(&self.0)
-    }
-}
-
-impl<'de> Deserialize<'de> for Identifier {
-    fn deserialize<D>(deserializer: D) -> Result<Identifier, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let string = String::deserialize(deserializer)?;
-        Identifier::new(string).map_err(|_| de::Error::custom("Identifier must be at most 100 characters long and contain only ASCII characters in the range 0x20 to 0x7E."))
     }
 }
 
@@ -317,8 +243,10 @@ impl<'de> Deserialize<'de> for NonNegativeIntegerOrFloat {
 mod tests {
     use serde_test::{assert_tokens, Token};
 
-    use super::*;
     use crate::guideline::*;
+    use crate::identifier::Identifier;
+
+    use super::*;
 
     #[test]
     fn color_parsing() {

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -15,9 +15,9 @@ use serde::Serialize;
 
 use crate::error::GroupsValidationError;
 use crate::fontinfo::FontInfo;
-use crate::glyph::{Glyph, GlyphName};
+use crate::glyph::Glyph;
 use crate::layer::Layer;
-use crate::names::NameList;
+use crate::names::{GlyphName, NameList};
 use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
 use crate::upconversion;
 use crate::Error;
@@ -577,10 +577,12 @@ impl<'a> Serialize for KerningInnerSerializer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::shared_types::IntegerOrFloat;
     use maplit::btreemap;
     use serde_test::{assert_ser_tokens, Token};
+
+    use crate::shared_types::IntegerOrFloat;
+
+    use super::*;
 
     #[test]
     fn new_is_v3() {

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -215,7 +215,7 @@ mod tests {
     extern crate maplit;
 
     use super::*;
-    use crate::glyph::GlyphName;
+    use crate::names::GlyphName;
     use crate::ufo::{FormatVersion, Ufo};
     use maplit::btreemap;
 

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -1,6 +1,7 @@
 //! Testing saving files.
 
-use norad::{FormatVersion, Glyph, Identifier, Layer, Plist, Ufo};
+use norad::Identifier;
+use norad::{FormatVersion, Glyph, Layer, Plist, Ufo};
 
 #[test]
 fn save_default() {


### PR DESCRIPTION
I split various UFO types into their own files to better organize them in my head and reduce scrolling distance in various files. This is similar to how defcon and ufoLib2 are organized.