### PR TITLE
Move Guideline to own file

### DIFF
--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ErrorKind;
 use crate::shared_types::{
-    Bitlist, Float, Guideline, Identifier, Integer, IntegerOrFloat, NonNegativeInteger,
-    NonNegativeIntegerOrFloat, Plist, PUBLIC_OBJECT_LIBS_KEY,
+    Bitlist, Float, Integer, IntegerOrFloat, NonNegativeInteger, NonNegativeIntegerOrFloat,
+    PUBLIC_OBJECT_LIBS_KEY,
 };
-use crate::{Error, FormatVersion};
+use crate::{Error, FormatVersion, Guideline, Identifier, Plist};
 
 /// The contents of the [`fontinfo.plist`][] file. This structure is hard-wired to the
 /// available attributes in UFO version 3.
@@ -1217,7 +1217,7 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shared_types::Line;
+    use crate::{Color, Identifier, Line};
     use serde_test::{assert_tokens, Token};
 
     #[test]
@@ -1232,8 +1232,6 @@ mod tests {
 
     #[test]
     fn fontinfo2() {
-        use crate::shared_types::{Color, Identifier, Line};
-
         let path = "testdata/fontinfotest.ufo/fontinfo.plist";
         let font_info: FontInfo = plist::from_file(path).expect("failed to load fontinfo");
         assert_eq!(font_info.family_name, Some("a".to_string()));

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -1,11 +1,10 @@
 use std::collections::HashSet;
 
 use crate::error::ErrorKind;
-use crate::glyph::{
+use crate::{
     AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,
-    Guideline, Image, PointType,
+    Guideline, Identifier, Image, Plist, PointType,
 };
-use crate::shared_types::{Identifier, Plist};
 
 // NOTE: The builders are private to the crate until we have a real-world use-case for making
 // them public. Then, we need to think about maybe doing without a GlyphBuilder at all (check

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -14,7 +14,8 @@ use druid::{Data, Lens};
 
 use crate::error::{Error, ErrorKind, GlifError, GlifErrorInternal};
 use crate::names::NameList;
-use crate::shared_types::{Color, Guideline, Identifier, Line, Plist, PUBLIC_OBJECT_LIBS_KEY};
+use crate::shared_types::PUBLIC_OBJECT_LIBS_KEY;
+use crate::{Color, Guideline, Identifier, Line, Plist};
 
 /// The name of a glyph.
 pub type GlyphName = Arc<str>;

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -7,9 +7,10 @@ use quick_xml::{
     Error as XmlError, Writer,
 };
 
-use super::{
+use super::PUBLIC_OBJECT_LIBS_KEY;
+use crate::{
     AffineTransform, Anchor, Color, Component, Contour, ContourPoint, GlifVersion, Glyph,
-    Guideline, Image, Line, Plist, PointType, PUBLIC_OBJECT_LIBS_KEY,
+    Guideline, Image, Line, Plist, PointType,
 };
 
 use crate::error::{GlifWriteError, WriteError};

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -1,0 +1,167 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+use serde::{de, ser};
+
+use crate::{Color, Identifier, Plist};
+
+/// A guideline associated with a glyph.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Guideline {
+    /// The line itself.
+    pub line: Line,
+    /// An arbitrary name for the guideline.
+    pub name: Option<String>,
+    /// The color of the line.
+    pub color: Option<Color>,
+    /// Unique identifier for the guideline within the glyph. This attribute is only required
+    /// when a lib is present and should otherwise only be added as needed.
+    identifier: Option<Identifier>,
+    /// The guideline's lib for arbitary data.
+    lib: Option<Plist>,
+}
+
+/// An infinite line.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Line {
+    /// A vertical line, passing through a given `x` coordinate.
+    Vertical(f32),
+    /// A horizontal line, passing through a given `y` coordinate.
+    Horizontal(f32),
+    /// An angled line passing through `(x, y)` at `degrees` degrees counteer-clockwise
+    /// to the horizontal.
+    // TODO: make a Degrees newtype that checks `0 <= degrees <= 360`.
+    Angle { x: f32, y: f32, degrees: f32 },
+}
+
+impl Guideline {
+    pub fn new(
+        line: Line,
+        name: Option<String>,
+        color: Option<Color>,
+        identifier: Option<Identifier>,
+        lib: Option<Plist>,
+    ) -> Self {
+        let mut this = Self { line, name, color, identifier: None, lib: None };
+        if let Some(id) = identifier {
+            this.replace_identifier(id);
+        }
+        if let Some(lib) = lib {
+            this.replace_lib(lib);
+        }
+        this
+    }
+
+    /// Returns an immutable reference to the Guideline's lib.
+    pub fn lib(&self) -> Option<&Plist> {
+        self.lib.as_ref()
+    }
+
+    /// Returns a mutable reference to the Guideline's lib.
+    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
+        self.lib.as_mut()
+    }
+
+    /// Replaces the actual lib by the lib given in parameter, returning the old
+    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
+        if self.identifier.is_none() {
+            self.identifier.replace(Identifier::from_uuidv4());
+        }
+        self.lib.replace(lib)
+    }
+
+    /// Takes the lib out of the Guideline, leaving a None in its place.
+    pub fn take_lib(&mut self) -> Option<Plist> {
+        self.lib.take()
+    }
+
+    /// Returns an immutable reference to the Guideline's identifier.
+    pub fn identifier(&self) -> Option<&Identifier> {
+        self.identifier.as_ref()
+    }
+
+    /// Replaces the actual identifier by the identifier given in parameter,
+    /// returning the old identifier if present.
+    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
+        self.identifier.replace(id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawGuideline {
+    x: Option<f32>,
+    y: Option<f32>,
+    angle: Option<f32>,
+    name: Option<String>,
+    color: Option<Color>,
+    identifier: Option<Identifier>,
+}
+
+impl Serialize for Guideline {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let (x, y, angle) = match self.line {
+            Line::Vertical(x) => (Some(x), None, None),
+            Line::Horizontal(y) => (None, Some(y), None),
+            Line::Angle { x, y, degrees } => {
+                if !(0.0..=360.0).contains(&degrees) {
+                    return Err(ser::Error::custom("angle must be between 0 and 360 degrees."));
+                }
+                (Some(x), Some(y), Some(degrees))
+            }
+        };
+
+        let mut guideline = serializer.serialize_struct("RawGuideline", 6)?;
+        guideline.serialize_field("x", &x)?;
+        guideline.serialize_field("y", &y)?;
+        guideline.serialize_field("angle", &angle)?;
+        guideline.serialize_field("name", &self.name)?;
+        guideline.serialize_field("color", &self.color)?;
+        guideline.serialize_field("identifier", &self.identifier)?;
+        guideline.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Guideline {
+    fn deserialize<D>(deserializer: D) -> Result<Guideline, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let guideline = RawGuideline::deserialize(deserializer)?;
+
+        let x = guideline.x;
+        let y = guideline.y;
+        let angle = guideline.angle;
+
+        let line = match (x, y, angle) {
+            // Valid data:
+            (Some(x), None, None) => Line::Vertical(x),
+            (None, Some(y), None) => Line::Horizontal(y),
+            (Some(x), Some(y), Some(degrees)) => {
+                if !(0.0..=360.0).contains(&degrees) {
+                    return Err(de::Error::custom("angle must be between 0 and 360 degrees."));
+                }
+                Line::Angle { x, y, degrees }
+            }
+            // Invalid data:
+            (None, None, _) => {
+                return Err(de::Error::custom("x or y must be present in a guideline."))
+            }
+            (None, Some(_), Some(_)) | (Some(_), None, Some(_)) => {
+                return Err(de::Error::custom(
+                    "angle must only be specified when both x and y are specified.",
+                ))
+            }
+            (Some(_), Some(_), None) => {
+                return Err(de::Error::custom(
+                    "angle must be specified when both x and y are specified.",
+                ))
+            }
+        };
+
+        Ok(Guideline::new(line, guideline.name, guideline.color, guideline.identifier, None))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate serde_repr;
 pub mod error;
 pub mod fontinfo;
 pub mod glyph;
+mod guideline;
 mod layer;
 mod names;
 mod shared_types;
@@ -34,8 +35,7 @@ pub use glyph::{
     AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,
     Image, PointType,
 };
+pub use guideline::{Guideline, Line};
 pub use layer::Layer;
-pub use shared_types::{
-    Color, Guideline, Identifier, IntegerOrFloat, Line, NonNegativeIntegerOrFloat, Plist,
-};
+pub use shared_types::{Color, Identifier, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
 pub use ufo::{DataRequest, FormatVersion, LayerInfo, MetaInfo, Ufo};

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -479,8 +479,11 @@ impl<'de> Deserialize<'de> for NonNegativeIntegerOrFloat {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::convert::TryFrom;
+
     use serde_test::{assert_tokens, Token};
+
+    use crate::{Color, Guideline, Identifier, IntegerOrFloat, Line, NonNegativeIntegerOrFloat};
 
     #[test]
     fn color_parsing() {

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -6,8 +6,7 @@ use std::sync::Arc;
 
 use serde::de;
 use serde::de::Deserializer;
-use serde::ser;
-use serde::ser::{SerializeStruct, Serializer};
+use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "druid")]
@@ -29,35 +28,6 @@ pub type Plist = plist::Dictionary;
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct Identifier(Arc<str>);
 
-/// A guideline associated with a glyph.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Guideline {
-    /// The line itself.
-    pub line: Line,
-    /// An arbitrary name for the guideline.
-    pub name: Option<String>,
-    /// The color of the line.
-    pub color: Option<Color>,
-    /// Unique identifier for the guideline within the glyph. This attribute is only required
-    /// when a lib is present and should otherwise only be added as needed.
-    identifier: Option<Identifier>,
-    /// The guideline's lib for arbitary data.
-    lib: Option<Plist>,
-}
-
-/// An infinite line.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Line {
-    /// A vertical line, passing through a given `x` coordinate.
-    Vertical(f32),
-    /// A horizontal line, passing through a given `y` coordinate.
-    Horizontal(f32),
-    /// An angled line passing through `(x, y)` at `degrees` degrees counteer-clockwise
-    /// to the horizontal.
-    // TODO: make a Degrees newtype that checks `0 <= degrees <= 360`.
-    Angle { x: f32, y: f32, degrees: f32 },
-}
-
 /// A color.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]
@@ -66,60 +36,6 @@ pub struct Color {
     pub green: f32,
     pub blue: f32,
     pub alpha: f32,
-}
-
-impl Guideline {
-    pub fn new(
-        line: Line,
-        name: Option<String>,
-        color: Option<Color>,
-        identifier: Option<Identifier>,
-        lib: Option<Plist>,
-    ) -> Self {
-        let mut this = Self { line, name, color, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
-    }
-
-    /// Returns an immutable reference to the Guideline's lib.
-    pub fn lib(&self) -> Option<&Plist> {
-        self.lib.as_ref()
-    }
-
-    /// Returns a mutable reference to the Guideline's lib.
-    pub fn lib_mut(&mut self) -> Option<&mut Plist> {
-        self.lib.as_mut()
-    }
-
-    /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
-    pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
-        self.lib.replace(lib)
-    }
-
-    /// Takes the lib out of the Guideline, leaving a None in its place.
-    pub fn take_lib(&mut self) -> Option<Plist> {
-        self.lib.take()
-    }
-
-    /// Returns an immutable reference to the Guideline's identifier.
-    pub fn identifier(&self) -> Option<&Identifier> {
-        self.identifier.as_ref()
-    }
-
-    /// Replaces the actual identifier by the identifier given in parameter,
-    /// returning the old identifier if present.
-    pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
-        self.identifier.replace(id)
-    }
 }
 
 impl Identifier {
@@ -199,17 +115,6 @@ impl<'de> Deserialize<'de> for Color {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawGuideline {
-    x: Option<f32>,
-    y: Option<f32>,
-    angle: Option<f32>,
-    name: Option<String>,
-    color: Option<Color>,
-    identifier: Option<Identifier>,
-}
-
 fn is_valid_identifier(s: &Arc<str>) -> bool {
     s.len() <= 100 && s.bytes().all(|b| (0x20..=0x7E).contains(&b))
 }
@@ -234,74 +139,6 @@ impl<'de> Deserialize<'de> for Identifier {
     {
         let string = String::deserialize(deserializer)?;
         Identifier::new(string).map_err(|_| de::Error::custom("Identifier must be at most 100 characters long and contain only ASCII characters in the range 0x20 to 0x7E."))
-    }
-}
-
-impl Serialize for Guideline {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let (x, y, angle) = match self.line {
-            Line::Vertical(x) => (Some(x), None, None),
-            Line::Horizontal(y) => (None, Some(y), None),
-            Line::Angle { x, y, degrees } => {
-                if !(0.0..=360.0).contains(&degrees) {
-                    return Err(ser::Error::custom("angle must be between 0 and 360 degrees."));
-                }
-                (Some(x), Some(y), Some(degrees))
-            }
-        };
-
-        let mut guideline = serializer.serialize_struct("RawGuideline", 6)?;
-        guideline.serialize_field("x", &x)?;
-        guideline.serialize_field("y", &y)?;
-        guideline.serialize_field("angle", &angle)?;
-        guideline.serialize_field("name", &self.name)?;
-        guideline.serialize_field("color", &self.color)?;
-        guideline.serialize_field("identifier", &self.identifier)?;
-        guideline.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for Guideline {
-    fn deserialize<D>(deserializer: D) -> Result<Guideline, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let guideline = RawGuideline::deserialize(deserializer)?;
-
-        let x = guideline.x;
-        let y = guideline.y;
-        let angle = guideline.angle;
-
-        let line = match (x, y, angle) {
-            // Valid data:
-            (Some(x), None, None) => Line::Vertical(x),
-            (None, Some(y), None) => Line::Horizontal(y),
-            (Some(x), Some(y), Some(degrees)) => {
-                if !(0.0..=360.0).contains(&degrees) {
-                    return Err(de::Error::custom("angle must be between 0 and 360 degrees."));
-                }
-                Line::Angle { x, y, degrees }
-            }
-            // Invalid data:
-            (None, None, _) => {
-                return Err(de::Error::custom("x or y must be present in a guideline."))
-            }
-            (None, Some(_), Some(_)) | (Some(_), None, Some(_)) => {
-                return Err(de::Error::custom(
-                    "angle must only be specified when both x and y are specified.",
-                ))
-            }
-            (Some(_), Some(_), None) => {
-                return Err(de::Error::custom(
-                    "angle must be specified when both x and y are specified.",
-                ))
-            }
-        };
-
-        Ok(Guideline::new(line, guideline.name, guideline.color, guideline.identifier, None))
     }
 }
 


### PR DESCRIPTION
I want to split various UFO types into their own files to better organize them in my head and reduce scrolling distance in various files. This is similar to how defcon and ufoLib2 are organized.