### PR TITLE
I don't think the fontinfo and glyph mods need to be pub?

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ extern crate serde_derive;
 extern crate serde_repr;
 
 pub mod error;
-pub mod fontinfo;
-pub mod glyph;
+mod fontinfo;
+mod glyph;
 mod guideline;
 mod layer;
 mod names;


### PR DESCRIPTION
Does `error` need to be pub? :thinking: 