### PR TITLE
Fold LayerInfo into Layer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,4 +40,4 @@ pub use guideline::{Guideline, Line};
 pub use identifier::Identifier;
 pub use layer::Layer;
 pub use shared_types::{Color, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
-pub use ufo::{DataRequest, FormatVersion, LayerInfo, MetaInfo, Ufo};
+pub use ufo::{DataRequest, FormatVersion, MetaInfo, Ufo};

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -50,7 +50,7 @@ fn save_new_file() {
 fn save_fancy() {
     let mut my_ufo = Ufo::new();
     let layer_path = "testdata/mutatorSans/MutatorSansBoldWide.ufo/glyphs";
-    let layer = Layer::load(layer_path).unwrap();
+    let layer = Layer::load("public.default", layer_path).unwrap();
     *my_ufo.get_default_layer_mut().unwrap() = layer;
 
     let dir = tempdir::TempDir::new("Fancy.ufo").unwrap();


### PR DESCRIPTION
I don't think they need to be separate.

I'm not entirely sure about `Layer::new_named` taking a layer _and_ dir name, but I suppose that's hard to avoid until we have a dedicated LayerSet stuct attached to Ufo that is essentially a HashMap and manages name and path name (collisions).