### PR TITLE
LayerSet + other layer-related tweaks

### DIFF
--- a/examples/normalize.rs
+++ b/examples/normalize.rs
@@ -16,10 +16,15 @@ fn main() {
         };
 
         // Prune all non-foreground layers.
-        ufo.layers.retain(|l| l.name == "public.default");
+        let default_layer_name = ufo.layers.default_layer().name().clone();
+        let to_remove: Vec<_> =
+            ufo.layers.names().filter(|l| *l != &default_layer_name).cloned().collect();
+        for layer_name in to_remove {
+            ufo.layers.remove(&layer_name);
+        }
 
         // Prune the foreground layer's lib.
-        let default_layer = ufo.get_default_layer_mut().unwrap();
+        let default_layer = ufo.default_layer_mut();
         default_layer.lib.retain(|k, &mut _| {
             k.starts_with("public.") || k.starts_with("com.schriftgestaltung.layerId")
         });

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,10 @@ pub enum Error {
     /// An error returned when trying to save a Glyph that contains a `public.objectLibs`
     /// lib key already (the key is automatically managed by Norad).
     PreexistingPublicObjectLibsKey,
+    MissingDefaultLayer,
+    MissingLayer(String),
+    DuplicateLayer(String),
+    MissingLayerContents,
     IoError(IoError),
     ParseError(XmlError),
     Glif(GlifError),
@@ -134,6 +138,12 @@ impl std::fmt::Display for Error {
                 f,
                 "The `public.objectLibs` lib key is managed by Norad and must not be set manually."
             ),
+            Error::MissingDefaultLayer => write!(f, "Missing default ('glyphs') layer."),
+            Error::DuplicateLayer(name) => write!(f, "Layer name '{}' already exists.", name),
+            Error::MissingLayer(name) => write!(f, "Layer name '{}' does not exist.", name),
+            Error::MissingLayerContents => {
+                write!(f, "Missing required 'layercontents.plist' file.")
+            }
             Error::IoError(e) => e.fmt(f),
             Error::ParseError(e) => e.fmt(f),
             Error::Glif(GlifError { path, position, kind }) => {

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -539,47 +539,6 @@ impl AffineTransform {
     }
 }
 
-//NOTE: this is hacky, and intended mostly as a placeholder. It was adapted from
-// https://github.com/unified-font-object/ufoLib/blob/master/Lib/ufoLib/filenames.py
-/// given a glyph name, compute an appropriate file name.
-pub(crate) fn default_file_name_for_glyph_name(name: impl AsRef<str>) -> String {
-    fn fn_impl(name: &str) -> String {
-        static SPECIAL_ILLEGAL: &[char] = &['\\', '*', '+', '/', ':', '<', '>', '?', '[', ']', '|'];
-        static SUFFIX: &str = ".glif";
-        const MAX_LEN: usize = 255;
-
-        let mut result = String::with_capacity(name.len());
-
-        for c in name.chars() {
-            match c {
-                '.' if result.is_empty() => result.push('_'),
-                c if (c as u32) < 32 || (c as u32) == 0x7f || SPECIAL_ILLEGAL.contains(&c) => {
-                    result.push('_')
-                }
-                c if c.is_ascii_uppercase() => {
-                    result.push(c);
-                    result.push('_');
-                }
-                c => result.push(c),
-            }
-        }
-
-        //TODO: check for illegal names?
-        if result.len() + SUFFIX.len() > MAX_LEN {
-            let mut boundary = 255 - SUFFIX.len();
-            while !result.is_char_boundary(boundary) {
-                boundary -= 1;
-            }
-            result.truncate(boundary);
-        }
-        result.push_str(SUFFIX);
-        result
-    }
-
-    let name = name.as_ref();
-    fn_impl(name)
-}
-
 impl std::default::Default for AffineTransform {
     fn default() -> Self {
         Self::identity()

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -114,39 +114,6 @@ fn notdef_failure() {
     let _ = parse_glyph(bytes).unwrap();
 }
 
-#[test]
-fn path_for_name() {
-    fn trimmed_name(name: &str) -> String {
-        default_file_name_for_glyph_name(name).trim_end_matches(".glif").into()
-    }
-
-    assert_eq!(trimmed_name("newGlyph.1"), "newG_lyph.1".to_string());
-    assert_eq!(trimmed_name("a"), "a".to_string());
-    assert_eq!(trimmed_name("A"), "A_".to_string());
-    assert_eq!(trimmed_name("AE"), "A_E_".to_string());
-    assert_eq!(trimmed_name("Ae"), "A_e".to_string());
-    assert_eq!(trimmed_name("ae"), "ae".to_string());
-    assert_eq!(trimmed_name("aE"), "aE_".to_string());
-    assert_eq!(trimmed_name("a.alt"), "a.alt".to_string());
-    assert_eq!(trimmed_name("A.alt"), "A_.alt".to_string());
-    assert_eq!(trimmed_name("A.Alt"), "A_.A_lt".to_string());
-    assert_eq!(trimmed_name("A.aLt"), "A_.aL_t".to_string());
-    assert_eq!(trimmed_name("A.alT"), "A_.alT_".to_string());
-    assert_eq!(trimmed_name("T_H"), "T__H_".to_string());
-    assert_eq!(trimmed_name("T_h"), "T__h".to_string());
-    assert_eq!(trimmed_name("t_h"), "t_h".to_string());
-    assert_eq!(trimmed_name("F_F_I"), "F__F__I_".to_string());
-    assert_eq!(trimmed_name("f_f_i"), "f_f_i".to_string());
-    assert_eq!(trimmed_name("Aacute_V.swash"), "A_acute_V_.swash".to_string());
-    assert_eq!(trimmed_name(".notdef"), "_notdef".to_string());
-
-    //FIXME: we're ignoring 'reserved filenames' for now
-    //assert_eq!(trimmed_name("con"), "_con".to_string());
-    //assert_eq!(trimmed_name("CON"), "C_O_N_".to_string());
-    //assert_eq!(trimmed_name("con.alt"), "_con.alt".to_string());
-    //assert_eq!(trimmed_name("alt.con"), "alt._con".to_string());
-}
-
 #[cfg(feature = "druid")]
 #[test]
 fn druid_from_color() {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -171,7 +171,7 @@ impl Layer {
     pub fn insert_glyph(&mut self, glyph: impl Into<Arc<Glyph>>) {
         let glyph = glyph.into();
         if !self.contents.contains_key(&glyph.name) {
-            let path = crate::glyph::default_file_name_for_glyph_name(&glyph.name);
+            let path = crate::util::default_file_name_for_glyph_name(&glyph.name);
             self.contents.insert(glyph.name.clone(), path.into());
         }
         self.glyphs.insert(glyph.name.clone(), glyph);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod names;
 mod shared_types;
 mod ufo;
 mod upconversion;
+pub mod util;
 
 pub use error::Error;
 pub use fontinfo::FontInfo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,11 @@
 //! # Basic usage:
 //!
 //! ```no_run
-//! use norad::Ufo;
+//! use norad::Font;
 //!
-//! let path = "RoflsSansLight.ufo";
-//! let mut font_obj = Ufo::load(path).expect("failed to load font");
-//! let layer = font_obj.find_layer(|layer| layer.name == "glyphs").unwrap();
+//! let path = "RoflsExtraDim.ufo";
+//! let mut font_obj = Font::load(path).expect("failed to load font");
+//! let layer = font_obj.default_layer();
 //! let glyph_a = layer.get_glyph("A").expect("missing glyph");
 //! assert_eq!(glyph_a.name.as_ref(), "A");
 //! ```
@@ -39,9 +39,9 @@ pub use glyph::{
 };
 pub use guideline::{Guideline, Line};
 pub use identifier::Identifier;
-pub use layer::Layer;
+pub use layer::{Layer, LayerSet};
 pub use shared_types::{Color, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
-pub use ufo::{DataRequest, Font, FormatVersion, LayerInfo, MetaInfo};
+pub use ufo::{DataRequest, Font, FormatVersion, MetaInfo};
 
 #[allow(deprecated)]
 pub use ufo::Ufo;

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,3 +1,11 @@
+//! String interning
+//!
+//! Because glyph names can occur in many places (multiple layers, groups,
+//! kern lists) we use an interning strategy to reuse them.
+//!
+//! This module includes parallel and non-parallel implementations of a
+//! type for managing this interning.
+
 #[cfg(not(feature = "rayon"))]
 use std::cell::RefCell;
 use std::collections::HashSet;

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -7,12 +7,13 @@ use crate::shared_types::IntegerOrFloat;
 use crate::ufo::{Groups, Kerning};
 use crate::Error;
 
-/// Convert kerning groups and pairs from v1 and v2 informal conventions to v3 formal conventions.
-/// Converted groups are added (duplicated) rather than replacing the old ones to preserve all data
-/// that external entities might rely on. Kerning pairs are updated to reflect the new group names.
+/// Convert kerning groups and pairs from v1 and v2 informal conventions to
+/// v3 formal conventions. Converted groups are added (duplicated) rather than
+/// replacing the old ones to preserve all data that external entities might
+/// rely on. Kerning pairs are updated to reflect the new group names.
 ///
-/// This is an adaptation from the fontTools.ufoLib reference implementation. It will not check if
-/// the upgraded groups pass validation.
+/// This is an adaptation from the fontTools.ufoLib reference implementation.
+/// It will not check if the upgraded groups pass validation.
 pub(crate) fn upconvert_kerning(
     groups: &Groups,
     kerning: &Kerning,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,86 @@
+//! Common utilities.
+
+//NOTE: this is hacky, and intended mostly as a placeholder. It was adapted from
+// https://github.com/unified-font-object/ufoLib/blob/master/Lib/ufoLib/filenames.py
+/// given a glyph name, compute an appropriate file name.
+pub fn default_file_name_for_glyph_name(name: impl AsRef<str>) -> String {
+    let name = name.as_ref();
+    user_name_to_file_name(name, "", ".glif")
+}
+
+/// given a layer name, compute an appropriate file name.
+pub fn default_file_name_for_layer_name(name: &str) -> String {
+    user_name_to_file_name(name, "glyphs.", "")
+}
+
+//FIXME: this needs to also handle duplicate names, probably by passing in some
+// 'exists' fn, like: `impl Fn(&str) -> bool`
+fn user_name_to_file_name(name: &str, prefix: &str, suffix: &str) -> String {
+    static SPECIAL_ILLEGAL: &[char] = &['\\', '*', '+', '/', ':', '<', '>', '?', '[', ']', '|'];
+    const MAX_LEN: usize = 255;
+
+    let mut result = String::with_capacity(name.len() + prefix.len() + suffix.len());
+    result.push_str(prefix);
+
+    for c in name.chars() {
+        match c {
+            '.' if result.is_empty() => result.push('_'),
+            c if (c as u32) < 32 || (c as u32) == 0x7f || SPECIAL_ILLEGAL.contains(&c) => {
+                result.push('_')
+            }
+            c if c.is_ascii_uppercase() => {
+                result.push(c);
+                result.push('_');
+            }
+            c => result.push(c),
+        }
+    }
+
+    //TODO: check for illegal names, duplicate names
+    if result.len() + suffix.len() > MAX_LEN {
+        let mut boundary = 255 - suffix.len();
+        while !result.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        result.truncate(boundary);
+    }
+    result.push_str(suffix);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn path_for_name() {
+        fn trimmed_name(name: &str) -> String {
+            default_file_name_for_glyph_name(name).trim_end_matches(".glif").into()
+        }
+
+        assert_eq!(trimmed_name("newGlyph.1"), "newG_lyph.1".to_string());
+        assert_eq!(trimmed_name("a"), "a".to_string());
+        assert_eq!(trimmed_name("A"), "A_".to_string());
+        assert_eq!(trimmed_name("AE"), "A_E_".to_string());
+        assert_eq!(trimmed_name("Ae"), "A_e".to_string());
+        assert_eq!(trimmed_name("ae"), "ae".to_string());
+        assert_eq!(trimmed_name("aE"), "aE_".to_string());
+        assert_eq!(trimmed_name("a.alt"), "a.alt".to_string());
+        assert_eq!(trimmed_name("A.alt"), "A_.alt".to_string());
+        assert_eq!(trimmed_name("A.Alt"), "A_.A_lt".to_string());
+        assert_eq!(trimmed_name("A.aLt"), "A_.aL_t".to_string());
+        assert_eq!(trimmed_name("A.alT"), "A_.alT_".to_string());
+        assert_eq!(trimmed_name("T_H"), "T__H_".to_string());
+        assert_eq!(trimmed_name("T_h"), "T__h".to_string());
+        assert_eq!(trimmed_name("t_h"), "t_h".to_string());
+        assert_eq!(trimmed_name("F_F_I"), "F__F__I_".to_string());
+        assert_eq!(trimmed_name("f_f_i"), "f_f_i".to_string());
+        assert_eq!(trimmed_name("Aacute_V.swash"), "A_acute_V_.swash".to_string());
+        assert_eq!(trimmed_name(".notdef"), "_notdef".to_string());
+
+        //FIXME: we're ignoring 'reserved filenames' for now
+        //assert_eq!(trimmed_name("con"), "_con".to_string());
+        //assert_eq!(trimmed_name("CON"), "C_O_N_".to_string());
+        //assert_eq!(trimmed_name("con.alt"), "_con.alt".to_string());
+        //assert_eq!(trimmed_name("alt.con"), "alt._con".to_string());
+    }
+}


### PR DESCRIPTION
This adds a LayerSet type that enforces various constraints on
layers.

Among other things, this means that:

- Layer names are now also stored as Arc<str>
- There is no more LayerInfo type
- there is now always a default layer
- the default layer cannot be removed
- new layers can be added

This also introduces a few other breaking api changes; for instance
I'm removing `Font::get_default_layer(&self) -> Option<&Layer>`
in favour of `Font::default_layer(&self) -> &Layer`.

In addition it moves the "compute a file name from a user provided name"
logic into a new `util` module.

This was motivated by my experiments with python bindings,
but I think this is generally useful independent of that work
and so I'm PRing it separately.

- supersedes and closes #100
- closes #84 (with an asterisk, this method is on the public `LayerSet` type)
- closes #89 

@madig I caught a few issues here thanks to your tests! 🎉 