### PR TITLE
Implement to_kurbo on Contour

### DIFF
--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -289,11 +289,14 @@ impl Contour {
                     offs.clear();
                 }
                 PointType::QCurve => {
-                    while offs.len() > 1 {
-                        let implied_point = offs[0].midpoint(offs[1]);
-                        path.quad_to(offs.pop_front().unwrap(), implied_point);
+                    while let Some(pt) = offs.pop_front() {
+                        if let Some(next) = offs.front() {
+                            let implied_point = pt.midpoint(*next);
+                            path.quad_to(pt, implied_point);
+                        } else {
+                            path.quad_to(pt, kurbo_point);
+                        }
                     }
-                    path.quad_to(offs[0], kurbo_point);
                     offs.clear();
                 }
             }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -286,7 +286,7 @@ impl Contour {
                         &mut [p1, p2] => path.curve_to(p1, p2, kurbo_point),
                         _ => return Err(ErrorKind::TooManyOffCurves),
                     };
-                    offs.truncate(0);
+                    offs.clear();
                 }
                 PointType::QCurve => {
                     while offs.len() > 1 {
@@ -294,7 +294,7 @@ impl Contour {
                         path.quad_to(offs.pop_front().unwrap(), implied_point);
                     }
                     path.quad_to(offs[0], kurbo_point);
-                    offs.truncate(0);
+                    offs.clear();
                 }
             }
         }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -253,7 +253,7 @@ impl Contour {
         self.points.first().map_or(true, |v| v.typ != PointType::Move)
     }
 
-    /// Converts the contour to a kurbo::BezPath
+    /// Converts the `Contour` to a [`kurbo::BezPath`].
     #[cfg(feature = "kurbo")]
     pub fn to_kurbo(&self) -> Result<kurbo::BezPath, ErrorKind> {
         let mut path = kurbo::BezPath::new();
@@ -523,7 +523,7 @@ impl ContourPoint {
         self.identifier.replace(id)
     }
 
-    /// Returns a kurbo::Point with the ContourPoint's coordinates.
+    /// Returns a [`kurbo::Point`] with this `ContourPoint`'s coordinates.
     #[cfg(feature = "kurbo")]
     pub fn to_kurbo(&self) -> kurbo::Point {
         kurbo::Point::new(self.x as f64, self.y as f64)

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -258,6 +258,16 @@ impl Contour {
     pub fn to_kurbo(&self) -> Result<kurbo::BezPath, ErrorKind> {
         let mut path = kurbo::BezPath::new();
         let mut offs: VecDeque<kurbo::Point> = VecDeque::new();
+        // Add end-of-contour offcurves to queue
+        let mut i = self.points.len() - 1;
+        while i > 0 && self.points[i].typ == PointType::OffCurve {
+            let kurbo_point = kurbo::Point::new(self.points[i].x as f64, self.points[i].y as f64);
+            offs.push_front(kurbo_point);
+            i -= 1;
+        }
+        if self.is_closed() {
+            path.move_to(kurbo::Point::new(self.points[i].x as f64, self.points[i].y as f64));
+        }
         for pt in &self.points {
             let kurbo_point = kurbo::Point::new(pt.x as f64, pt.y as f64);
             match pt.typ {

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -273,7 +273,7 @@ impl Contour {
         if let Some(start) = points.next() {
             path.move_to(start.to_kurbo());
         }
-        for pt in &self.points {
+        for pt in points {
             let kurbo_point = pt.to_kurbo();
             match pt.typ {
                 PointType::Move => path.move_to(kurbo_point),

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -275,10 +275,10 @@ impl Contour {
                 PointType::Line => path.line_to(kurbo_point),
                 PointType::OffCurve => offs.push_back(kurbo_point),
                 PointType::Curve => {
-                    match offs.len() {
-                        0 => return Err(ErrorKind::BadPoint),
-                        1 => path.quad_to(offs[0], kurbo_point),
-                        2 => path.curve_to(offs[0], offs[1], kurbo_point),
+                    match offs.make_contiguous() {
+                        &mut [] => return Err(ErrorKind::BadPoint),
+                        &mut [p1] => path.quad_to(p1, kurbo_point),
+                        &mut [p1, p2] => path.curve_to(p1, p2, kurbo_point),
                         _ => return Err(ErrorKind::TooManyOffCurves),
                     };
                     offs.truncate(0);

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -6,7 +6,6 @@ mod serialize;
 #[cfg(test)]
 mod tests;
 
-use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -257,7 +256,7 @@ impl Contour {
     #[cfg(feature = "kurbo")]
     pub fn to_kurbo(&self) -> Result<kurbo::BezPath, ErrorKind> {
         let mut path = kurbo::BezPath::new();
-        let mut offs: VecDeque<kurbo::Point> = VecDeque::new();
+        let mut offs = std::collections::VecDeque::new();
         let mut points = if self.is_closed() {
             // Add end-of-contour offcurves to queue
             let rotate = self

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -269,7 +269,7 @@ impl Contour {
             path.move_to(kurbo::Point::new(self.points[i].x as f64, self.points[i].y as f64));
         }
         for pt in &self.points {
-            let kurbo_point = kurbo::Point::new(pt.x as f64, pt.y as f64);
+            let kurbo_point = pt.to_kurbo();
             match pt.typ {
                 PointType::Move => path.move_to(kurbo_point),
                 PointType::Line => path.line_to(kurbo_point),
@@ -513,6 +513,12 @@ impl ContourPoint {
     /// returning the old identifier if present.
     pub fn replace_identifier(&mut self, id: Identifier) -> Option<Identifier> {
         self.identifier.replace(id)
+    }
+
+    /// Returns a kurbo::Point with the ContourPoint's coordinates.
+    #[cfg(feature = "kurbo")]
+    pub fn to_kurbo(&self) -> kurbo::Point {
+        kurbo::Point::new(self.x as f64, self.y as f64)
     }
 }
 


### PR DESCRIPTION
This adds a `to_kurbo` method on a Contour, as discussed in #110.

Most of this has been tested in fonttools-rs, apart from the implied on-curve stuff because I can't find any UFOs that do that.