### PR TITLE
Layer API improvements and fixups

### DIFF
--- a/examples/normalize.rs
+++ b/examples/normalize.rs
@@ -30,7 +30,7 @@ fn main() {
         });
 
         // Prune all glyphs' libs.
-        for glyph in default_layer.iter_contents_mut() {
+        for glyph in default_layer.iter_mut() {
             glyph.lib.retain(|k, &mut _| {
                 (k.starts_with("public.")
                     || k.starts_with("com.schriftgestaltung.")

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,14 @@ pub enum Error {
     DuplicateLayer(String),
     MissingLayerContents,
     InvalidColor(InvalidColorString),
+    DuplicateGlyph {
+        layer: String,
+        glyph: String,
+    },
+    MissingGlyph {
+        layer: String,
+        glyph: String,
+    },
     IoError(IoError),
     ParseError(XmlError),
     Glif(GlifError),
@@ -152,6 +160,12 @@ impl std::fmt::Display for Error {
             Error::MissingLayer(name) => write!(f, "Layer name '{}' does not exist.", name),
             Error::MissingLayerContents => {
                 write!(f, "Missing required 'layercontents.plist' file.")
+            }
+            Error::DuplicateGlyph { layer, glyph } => {
+                write!(f, "Glyph named '{}' already exists in layer '{}'", glyph, layer)
+            }
+            Error::MissingGlyph { layer, glyph } => {
+                write!(f, "Glyph '{}' missing from layer '{}'", glyph, layer)
             }
             Error::IoError(e) => e.fmt(f),
             Error::ParseError(e) => e.fmt(f),

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -59,12 +59,12 @@ fn save_fancy() {
     let loaded = Font::load(dir).unwrap();
     let pre_layer = my_ufo.default_layer();
     let post_layer = loaded.default_layer();
-    assert_eq!(pre_layer.iter_contents().count(), post_layer.iter_contents().count());
+    assert_eq!(pre_layer.iter().count(), post_layer.iter().count());
 
-    for glyph in pre_layer.iter_contents() {
+    for glyph in pre_layer.iter() {
         let other = post_layer.get_glyph(&glyph.name);
         assert!(other.is_some(), "missing {}", &glyph.name);
-        assert_eq!(&glyph, other.unwrap());
+        assert_eq!(glyph, other.unwrap());
     }
 }
 


### PR DESCRIPTION
- Added LayerSet::new
- Added Layer::rename_glyph
- Fixed bug where get_glyph_mut used Arc::get_mut instead of Arc::make_mut
- Renamed get_glyph to glyph
- Renamed get_glyph_mut to glyph_mut
- Renamed iter_contents & iter_contents_mut -> iter & iter_mut
- Removed deprecated method

A few other things along these lines


----

this is also split off from #114 