### PR TITLE
Error fixups

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,8 @@ pub enum Error {
     ExpectedPlistDictionary(String),
     ExpectedPlistString,
     ExpectedPositiveValue,
+    #[cfg(feature = "kurbo")]
+    ConvertContour(ErrorKind),
 }
 
 /// An error representing a failure to validate UFO groups.
@@ -182,6 +184,8 @@ impl std::fmt::Display for Error {
             Error::ExpectedPositiveValue => {
                 write!(f, "PositiveIntegerOrFloat expects a positive value.")
             }
+            #[cfg(feature = "kurbo")]
+            Error::ConvertContour(cause) => write!(f, "Failed to convert contour: '{}'", cause),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,13 +29,13 @@ pub enum Error {
     Glif(GlifError),
     GlifWrite(GlifWriteError),
     PlistError(PlistError),
-    FontInfoError,
-    FontInfoUpconversionError,
-    GroupsError(GroupsValidationError),
-    GroupsUpconversionError(GroupsValidationError),
+    InvalidFontInfo,
+    FontInfoUpconversion,
+    InvalidGroups(GroupsValidationError),
+    GroupsUpconversionFailure(GroupsValidationError),
     // the string is the key
     ExpectedPlistDictionary(String),
-    ExpectedPlistStringError,
+    ExpectedPlistString,
     ExpectedPositiveValue,
 }
 
@@ -167,18 +167,18 @@ impl std::fmt::Display for Error {
                 write!(f, "Failed to save glyph {}, error: '{}'", name, inner)
             }
             Error::PlistError(e) => e.fmt(f),
-            Error::FontInfoError => write!(f, "FontInfo contains invalid data"),
-            Error::FontInfoUpconversionError => {
+            Error::InvalidFontInfo => write!(f, "FontInfo contains invalid data"),
+            Error::FontInfoUpconversion => {
                 write!(f, "FontInfo contains invalid data after upconversion")
             }
-            Error::GroupsError(ge) => ge.fmt(f),
-            Error::GroupsUpconversionError(ge) => {
+            Error::InvalidGroups(ge) => ge.fmt(f),
+            Error::GroupsUpconversionFailure(ge) => {
                 write!(f, "Upconverting UFO v1 or v2 kerning data to v3 failed: {}", ge)
             }
             Error::ExpectedPlistDictionary(key) => {
                 write!(f, "Expected a Plist dictionary at '{}'", key)
             }
-            Error::ExpectedPlistStringError => write!(f, "Expected a Plist string."),
+            Error::ExpectedPlistString => write!(f, "Expected a Plist string."),
             Error::ExpectedPositiveValue => {
                 write!(f, "PositiveIntegerOrFloat expects a positive value.")
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Errors, errors, errors
+//! Error types.
 
 use std::io::Error as IoError;
 use std::path::PathBuf;
@@ -33,10 +33,10 @@ pub enum Error {
     FontInfoUpconversionError,
     GroupsError(GroupsValidationError),
     GroupsUpconversionError(GroupsValidationError),
-    ExpectedPlistDictionaryError,
+    // the string is the key
+    ExpectedPlistDictionary(String),
     ExpectedPlistStringError,
     ExpectedPositiveValue,
-    InvalidDataError(ErrorKind),
 }
 
 /// An error representing a failure to validate UFO groups.
@@ -175,13 +175,12 @@ impl std::fmt::Display for Error {
             Error::GroupsUpconversionError(ge) => {
                 write!(f, "Upconverting UFO v1 or v2 kerning data to v3 failed: {}", ge)
             }
-            Error::ExpectedPlistDictionaryError => write!(f, "Expected a Plist dictionary."),
+            Error::ExpectedPlistDictionary(key) => {
+                write!(f, "Expected a Plist dictionary at '{}'", key)
+            }
             Error::ExpectedPlistStringError => write!(f, "Expected a Plist string."),
             Error::ExpectedPositiveValue => {
                 write!(f, "PositiveIntegerOrFloat expects a positive value.")
-            }
-            Error::InvalidDataError(e) => {
-                write!(f, "Type parsing error: '{}", e)
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,9 +11,6 @@ use crate::GlyphName;
 /// Errors that occur while working with font objects.
 #[derive(Debug)]
 pub enum Error {
-    /// An error representing our refusal to save a UFO file that was
-    /// not originally created by norad.
-    NotCreatedHere,
     /// An error returned when trying to save an UFO in anything less than the latest version.
     DowngradeUnsupported,
     /// An error returned when trying to save a Glyph that contains a `public.objectLibs`
@@ -143,9 +140,6 @@ pub enum ErrorKind {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Error::NotCreatedHere => {
-                write!(f, "To prevent data loss, norad will not save files created elsewhere.")
-            }
             Error::DowngradeUnsupported => {
                 write!(f, "Downgrading below UFO v3 is not currently supported.")
             }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -496,7 +496,7 @@ impl FontInfo {
                     year: fontinfo_v2.year,
                     ..FontInfo::default()
                 };
-                fontinfo.validate().map_err(|_| Error::FontInfoUpconversionError)?;
+                fontinfo.validate().map_err(|_| Error::FontInfoUpconversion)?;
                 Ok(fontinfo)
             }
             FormatVersion::V1 => {
@@ -546,7 +546,7 @@ impl FontInfo {
                             "Expanded" => Some(Os2WidthClass::Expanded),
                             "Extra-expanded" => Some(Os2WidthClass::ExtraExpanded),
                             "Ultra-expanded" => Some(Os2WidthClass::UltraExpanded),
-                            _ => return Err(Error::FontInfoError),
+                            _ => return Err(Error::InvalidFontInfo),
                         },
                         None => None,
                     },
@@ -578,7 +578,7 @@ impl FontInfo {
                             222 => Some(PostscriptWindowsCharacterSet::Thai),
                             238 => Some(PostscriptWindowsCharacterSet::EasternEuropean),
                             255 => Some(PostscriptWindowsCharacterSet::Oem),
-                            _ => return Err(Error::FontInfoError),
+                            _ => return Err(Error::InvalidFontInfo),
                         },
                         None => None,
                     },
@@ -589,7 +589,7 @@ impl FontInfo {
                             1 => Some(StyleMapStyle::Italic),
                             32 => Some(StyleMapStyle::Bold),
                             33 => Some(StyleMapStyle::BoldItalic),
-                            _ => return Err(Error::FontInfoError),
+                            _ => return Err(Error::InvalidFontInfo),
                         },
                         None => None,
                     },
@@ -604,7 +604,7 @@ impl FontInfo {
                     year: fontinfo_v1.year,
                     ..FontInfo::default()
                 };
-                fontinfo.validate().map_err(|_| Error::FontInfoUpconversionError)?;
+                fontinfo.validate().map_err(|_| Error::FontInfoUpconversion)?;
                 Ok(fontinfo)
             }
         }
@@ -620,25 +620,25 @@ impl FontInfo {
         if let Some(v) = &self.open_type_head_created {
             const DATE_LENGTH: usize = 19;
             if v.len() != DATE_LENGTH {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
             if !v.chars().all(|b| b.is_ascii_digit() || b == ' ' || b == '/' || b == ':') {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
 
             if !(v[0..4].parse::<u16>().is_ok()
                 && &v[4..5] == "/"
-                && v[5..7].parse::<u8>().map_err(|_| Error::FontInfoError)? <= 12
+                && v[5..7].parse::<u8>().map_err(|_| Error::InvalidFontInfo)? <= 12
                 && &v[7..8] == "/"
-                && v[8..10].parse::<u8>().map_err(|_| Error::FontInfoError)? <= 31
+                && v[8..10].parse::<u8>().map_err(|_| Error::InvalidFontInfo)? <= 31
                 && &v[10..11] == " "
-                && v[11..13].parse::<u8>().map_err(|_| Error::FontInfoError)? < 24
+                && v[11..13].parse::<u8>().map_err(|_| Error::InvalidFontInfo)? < 24
                 && &v[13..14] == ":"
-                && v[14..16].parse::<u8>().map_err(|_| Error::FontInfoError)? < 60
+                && v[14..16].parse::<u8>().map_err(|_| Error::InvalidFontInfo)? < 60
                 && &v[16..17] == ":"
-                && v[17..19].parse::<u8>().map_err(|_| Error::FontInfoError)? < 60)
+                && v[17..19].parse::<u8>().map_err(|_| Error::InvalidFontInfo)? < 60)
             {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
 
@@ -653,7 +653,7 @@ impl FontInfo {
                 let mut last = vs_iter.next().unwrap();
                 for current in vs_iter {
                     if last > current {
-                        return Err(Error::FontInfoError);
+                        return Err(Error::InvalidFontInfo);
                     }
                     last = current;
                 }
@@ -666,7 +666,7 @@ impl FontInfo {
             for guideline in guidelines {
                 if let Some(id) = guideline.identifier() {
                     if !identifiers.insert(id.clone()) {
-                        return Err(Error::FontInfoError);
+                        return Err(Error::InvalidFontInfo);
                     }
                 }
             }
@@ -675,84 +675,84 @@ impl FontInfo {
         // openTypeOS2Selection must not contain bits 0, 5 or 6.
         if let Some(v) = &self.open_type_os2_selection {
             if v.contains(&0) || v.contains(&5) || v.contains(&6) {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
 
         if let Some(v) = &self.open_type_os2_family_class {
             if !v.is_valid() {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
 
         // The Postscript blue zone and stem widths lists have a length limitation.
         if let Some(v) = &self.postscript_blue_values {
             if v.len() > 14 {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
         if let Some(v) = &self.postscript_other_blues {
             if v.len() > 10 {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
         if let Some(v) = &self.postscript_family_blues {
             if v.len() > 14 {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
         if let Some(v) = &self.postscript_family_other_blues {
             if v.len() > 10 {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
         if let Some(v) = &self.postscript_stem_snap_h {
             if v.len() > 12 {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
         if let Some(v) = &self.postscript_stem_snap_v {
             if v.len() > 12 {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
 
         // Certain WOFF attributes must contain at least one item if they are present.
         if let Some(v) = &self.woff_metadata_extensions {
             if v.is_empty() {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
 
             for record in v.iter() {
                 if record.items.is_empty() {
-                    return Err(Error::FontInfoError);
+                    return Err(Error::InvalidFontInfo);
                 }
 
                 for record_item in record.items.iter() {
                     if record_item.names.is_empty() || record_item.values.is_empty() {
-                        return Err(Error::FontInfoError);
+                        return Err(Error::InvalidFontInfo);
                     }
                 }
             }
         }
         if let Some(v) = &self.woff_metadata_credits {
             if v.credits.is_empty() {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
         if let Some(v) = &self.woff_metadata_copyright {
             if v.text.is_empty() {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
         if let Some(v) = &self.woff_metadata_description {
             if v.text.is_empty() {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
         if let Some(v) = &self.woff_metadata_trademark {
             if v.text.is_empty() {
-                return Err(Error::FontInfoError);
+                return Err(Error::InvalidFontInfo);
             }
         }
 

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -260,7 +260,7 @@ impl Contour {
 
     /// Converts the `Contour` to a [`kurbo::BezPath`].
     #[cfg(feature = "kurbo")]
-    pub fn to_kurbo(&self) -> Result<kurbo::BezPath, ErrorKind> {
+    pub fn to_kurbo(&self) -> Result<kurbo::BezPath, Error> {
         let mut path = kurbo::BezPath::new();
         let mut offs = std::collections::VecDeque::new();
         let mut points = if self.is_closed() {
@@ -286,10 +286,10 @@ impl Contour {
                 PointType::OffCurve => offs.push_back(kurbo_point),
                 PointType::Curve => {
                     match offs.make_contiguous() {
-                        [] => return Err(ErrorKind::BadPoint),
+                        [] => return Err(Error::ConvertContour(ErrorKind::BadPoint)),
                         [p1] => path.quad_to(*p1, kurbo_point),
                         [p1, p2] => path.curve_to(*p1, *p2, kurbo_point),
-                        _ => return Err(ErrorKind::TooManyOffCurves),
+                        _ => return Err(Error::ConvertContour(ErrorKind::TooManyOffCurves)),
                     };
                     offs.clear();
                 }

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -422,7 +422,6 @@ impl<'names> GlifParser<'names> {
             let attr = attr?;
             let value = attr.unescaped_value()?;
             let value = reader.decode(&value)?;
-            let pos = reader.buffer_position();
             match attr.key {
                 b"x" => {
                     x = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?);
@@ -434,7 +433,9 @@ impl<'names> GlifParser<'names> {
                     angle = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?);
                 }
                 b"name" => name = Some(value.to_string()),
-                b"color" => color = Some(value.parse().map_err(|e: ErrorKind| e.to_error(pos))?),
+                b"color" => {
+                    color = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadColor))?)
+                }
                 b"identifier" => {
                     identifier = Some(value.parse().map_err(|kind| err!(reader, kind))?);
                 }
@@ -482,7 +483,9 @@ impl<'names> GlifParser<'names> {
                 b"yScale" => transform.y_scale = value.parse().map_err(|_| (kind, pos))?,
                 b"xOffset" => transform.x_offset = value.parse().map_err(|_| (kind, pos))?,
                 b"yOffset" => transform.y_offset = value.parse().map_err(|_| (kind, pos))?,
-                b"color" => color = Some(value.parse().map_err(|e: ErrorKind| e.to_error(pos))?),
+                b"color" => {
+                    color = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadColor))?)
+                }
                 b"fileName" => filename = Some(PathBuf::from(value.to_string())),
                 _other => return Err(err!(reader, ErrorKind::UnexpectedImageField)),
             }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -277,7 +277,7 @@ impl Layer {
         if let Some(v) = color_str {
             match v.into_string() {
                 Some(s) => color.replace(Color::from_str(&s).map_err(Error::InvalidColor)?),
-                None => return Err(Error::ExpectedPlistStringError),
+                None => return Err(Error::ExpectedPlistString),
             };
         };
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -276,7 +276,7 @@ impl Layer {
         let color_str = info_content.remove("color");
         if let Some(v) = color_str {
             match v.into_string() {
-                Some(s) => color.replace(Color::from_str(&s).map_err(Error::InvalidDataError)?),
+                Some(s) => color.replace(Color::from_str(&s).map_err(Error::InvalidColor)?),
                 None => return Err(Error::ExpectedPlistStringError),
             };
         };

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -270,7 +270,7 @@ impl Layer {
         let mut info_content = plist::Value::from_file(path)
             .map_err(Error::PlistError)?
             .into_dictionary()
-            .ok_or(Error::ExpectedPlistDictionaryError)?;
+            .ok_or_else(|| Error::ExpectedPlistDictionary(path.to_string_lossy().into_owned()))?;
 
         let mut color = None;
         let color_str = info_content.remove("color");
@@ -282,7 +282,9 @@ impl Layer {
         };
 
         let lib = match info_content.remove("lib") {
-            Some(v) => v.into_dictionary().ok_or(Error::ExpectedPlistDictionaryError)?,
+            Some(v) => v.into_dictionary().ok_or_else(|| {
+                Error::ExpectedPlistDictionary(format!("{} (lib)", path.to_string_lossy()))
+            })?,
             None => Plist::new(),
         };
 

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "druid")]
 use druid::Data;
 
-use crate::error::ErrorKind;
+use crate::error::InvalidColorString;
 use crate::Error;
 
 pub static PUBLIC_OBJECT_LIBS_KEY: &str = "public.objectLibs";
@@ -28,19 +28,19 @@ pub struct Color {
 }
 
 impl FromStr for Color {
-    type Err = ErrorKind;
+    type Err = InvalidColorString;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut iter = s.split(',').map(|v| match v.parse::<f32>() {
             Ok(val) if (0.0..=1.0).contains(&val) => Ok(val),
-            _ => Err(ErrorKind::BadColor),
+            _ => Err(InvalidColorString::new(s.to_owned())),
         });
-        let red = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
-        let green = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
-        let blue = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
-        let alpha = iter.next().unwrap_or(Err(ErrorKind::BadColor))?;
+        let red = iter.next().unwrap_or_else(|| Err(InvalidColorString::new(s.to_owned())))?;
+        let green = iter.next().unwrap_or_else(|| Err(InvalidColorString::new(s.to_owned())))?;
+        let blue = iter.next().unwrap_or_else(|| Err(InvalidColorString::new(s.to_owned())))?;
+        let alpha = iter.next().unwrap_or_else(|| Err(InvalidColorString::new(s.to_owned())))?;
         if iter.next().is_some() {
-            Err(ErrorKind::BadColor)
+            Err(InvalidColorString::new(s.to_owned()))
         } else {
             Ok(Color { red, green, blue, alpha })
         }

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -308,10 +308,6 @@ impl Font {
             return Err(Error::DowngradeUnsupported);
         }
 
-        if self.meta.creator.as_str() != DEFAULT_METAINFO_CREATOR {
-            return Err(Error::NotCreatedHere);
-        }
-
         if self.lib.contains_key(PUBLIC_OBJECT_LIBS_KEY) {
             return Err(Error::PreexistingPublicObjectLibsKey);
         }

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -192,9 +192,9 @@ impl Font {
 
             let lib_path = path.join(LIB_FILE);
             let mut lib = if lib_path.exists() && self.data_request.lib {
-                plist::Value::from_file(&lib_path)?
-                    .into_dictionary()
-                    .ok_or(Error::ExpectedPlistDictionaryError)?
+                plist::Value::from_file(&lib_path)?.into_dictionary().ok_or_else(|| {
+                    Error::ExpectedPlistDictionary(lib_path.to_string_lossy().into_owned())
+                })?
             } else {
                 Plist::new()
             };

--- a/src/ufo.rs
+++ b/src/ufo.rs
@@ -211,7 +211,7 @@ impl Font {
             let groups_path = path.join(GROUPS_FILE);
             let groups = if groups_path.exists() && self.data_request.groups {
                 let groups: Groups = plist::from_file(groups_path)?;
-                validate_groups(&groups).map_err(Error::GroupsError)?;
+                validate_groups(&groups).map_err(Error::InvalidGroups)?;
                 Some(groups)
             } else {
                 None
@@ -253,7 +253,7 @@ impl Font {
                 (_, Some(g), k) => {
                     let (groups, kerning) =
                         upconversion::upconvert_kerning(&g, &k.unwrap_or_default(), &glyph_names);
-                    validate_groups(&groups).map_err(Error::GroupsUpconversionError)?;
+                    validate_groups(&groups).map_err(Error::GroupsUpconversionFailure)?;
                     (Some(groups), Some(kerning))
                 }
             };
@@ -344,7 +344,7 @@ impl Font {
         }
 
         if let Some(groups) = self.groups.as_ref() {
-            validate_groups(&groups).map_err(Error::GroupsError)?;
+            validate_groups(&groups).map_err(Error::InvalidGroups)?;
             plist::to_file_xml(path.join(GROUPS_FILE), groups)?;
         }
 

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -196,7 +196,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
         fontinfo.postscript_stem_snap_h = ps_hinting_data.h_stems;
         fontinfo.postscript_stem_snap_v = ps_hinting_data.v_stems;
 
-        fontinfo.validate().map_err(|_| Error::FontInfoUpconversionError)?;
+        fontinfo.validate().map_err(|_| Error::FontInfoUpconversion)?;
     }
 
     lib.remove("org.robofab.postScriptHintData");


### PR DESCRIPTION
This is a bunch of little tweaks to error types.

The initial motivation was trying to be more consistent about the use of `ErrorKind`, which really isn't intended to be used as an error type directly. I totally understand the appeal of doing this, though, especially after muddying through this patch.

other things:

- renamed some `Error::` variants to not have the `Error` suffix
- added a field to `Error::ExpectedPlistDictionary` to indicate the location of the error (this is still not great)
- removed `NotCreatedHere` (closes #124)