### PR TITLE
Serialize less stuff

### DIFF
--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -58,14 +58,16 @@ impl Glyph {
             writer.write_event(guide.to_event())?;
         }
 
-        writer.write_event(Event::Start(BytesStart::borrowed_name(b"outline")))?;
-        for contour in &self.contours {
-            contour.write_xml(&mut writer)?;
+        if !self.contours.is_empty() || !self.components.is_empty() {
+            writer.write_event(Event::Start(BytesStart::borrowed_name(b"outline")))?;
+            for contour in &self.contours {
+                contour.write_xml(&mut writer)?;
+            }
+            for component in &self.components {
+                writer.write_event(component.to_event())?;
+            }
+            writer.write_event(Event::End(BytesEnd::borrowed(b"outline")))?;
         }
-        for component in &self.components {
-            writer.write_event(component.to_event())?;
-        }
-        writer.write_event(Event::End(BytesEnd::borrowed(b"outline")))?;
 
         for anchor in &self.anchors {
             writer.write_event(anchor.to_event())?;

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -32,14 +32,17 @@ impl Glyph {
             writer.write_event(char_to_event(*codepoint))?;
         }
 
-        let mut start = BytesStart::borrowed_name(b"advance");
-        if self.width != 0. {
-            start.push_attribute(("width", self.width.to_string().as_str()));
+        // don't serialize advance if 0, nan, etc
+        if self.width.is_normal() || self.height.is_normal() {
+            let mut start = BytesStart::borrowed_name(b"advance");
+            if self.width != 0. {
+                start.push_attribute(("width", self.width.to_string().as_str()));
+            }
+            if self.height != 0. {
+                start.push_attribute(("height", self.height.to_string().as_str()));
+            }
+            writer.write_event(Event::Empty(start))?;
         }
-        if self.height != 0. {
-            start.push_attribute(("height", self.height.to_string().as_str()));
-        }
-        writer.write_event(Event::Empty(start))?;
 
         if let Some(ref note) = self.note {
             writer.write_event(Event::Start(BytesStart::borrowed_name(b"note")))?;

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -108,6 +108,22 @@ fn save() {
     assert_eq!(glyph.guidelines, glyph2.guidelines);
 }
 
+// https://github.com/linebender/norad/issues/105
+#[test]
+fn skip_zero_advance() {
+    let glyph = Glyph::new_named("A");
+    let encoded = glyph.encode_xml().unwrap();
+    let as_str = String::from_utf8(encoded).expect("xml is valid utf-8");
+    assert!(!as_str.contains("advance"));
+
+    let mut glyph = Glyph::new_named("B");
+    glyph.width = 500.0;
+
+    let encoded = glyph.encode_xml().unwrap();
+    let as_str = String::from_utf8(encoded).expect("xml is valid utf-8");
+    assert!(as_str.contains("advance"));
+}
+
 #[test]
 fn notdef_failure() {
     let bytes = include_bytes!("../../testdata/noto-cjk-notdef.glif");

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -124,6 +124,22 @@ fn skip_zero_advance() {
     assert!(as_str.contains("advance"));
 }
 
+// https://github.com/linebender/norad/issues/105
+#[test]
+fn skip_empty_outline() {
+    let glyph = Glyph::new_named("A");
+    let encoded = glyph.encode_xml().unwrap();
+    let as_str = String::from_utf8(encoded).expect("xml is valid utf-8");
+    assert!(!as_str.contains("outline"));
+
+    let mut glyph = Glyph::new_named("B");
+    glyph.components = vec![Component::new("A".into(), AffineTransform::default(), None, None)];
+
+    let encoded = glyph.encode_xml().unwrap();
+    let as_str = String::from_utf8(encoded).expect("xml is valid utf-8");
+    assert!(as_str.contains("outline"));
+}
+
 #[test]
 fn notdef_failure() {
     let bytes = include_bytes!("../../testdata/noto-cjk-notdef.glif");


### PR DESCRIPTION
With this patch we no longer serialize zero advance values, and we don't serialize empty outlines.

- closes #105