### PR TITLE
get_path is actually pretty handy, don't hide it

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -454,6 +454,9 @@ impl Layer {
         self.glyphs.values_mut().map(Arc::make_mut)
     }
 
+    /// Returns the path to the .glif file of a given glyph name.
+    ///
+    /// The returned path is relative to the path of the current layer.
     pub fn get_path(&self, name: &str) -> Option<&Path> {
         self.contents.get(name).map(PathBuf::as_path)
     }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -454,7 +454,6 @@ impl Layer {
         self.glyphs.values_mut().map(Arc::make_mut)
     }
 
-    #[cfg(test)]
     pub fn get_path(&self, name: &str) -> Option<&Path> {
         self.contents.get(name).map(PathBuf::as_path)
     }


### PR DESCRIPTION
This exposes the `get_path` function to get the path of a glif. This is useful when passing the glif to utilities which work on a .glif object, such as the MFEK stuff.

And in general, I'm a fan of giving the developer access to any information we hold that they claim to want, rather than questioning their motives. ;-)