### PR TITLE
Minor refactoring

### DIFF
--- a/src/data_request.rs
+++ b/src/data_request.rs
@@ -1,0 +1,70 @@
+/// A type that describes which components of a UFO should be loaded.
+///
+/// By default, we load all components of the UFO file; however if you only
+/// need some subset of these, you can pass this struct to [`Ufo::with_fields`]
+/// in order to only load the fields specified in this object. This can help a
+/// lot with performance with large UFO files if you don't need the glyph data.
+///
+/// [`Ufo::with_fields`]: struct.Ufo.html#method.with_fields
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct DataRequest {
+    pub layers: bool,
+    pub lib: bool,
+    pub groups: bool,
+    pub kerning: bool,
+    pub features: bool,
+}
+
+impl DataRequest {
+    fn from_bool(b: bool) -> Self {
+        DataRequest { layers: b, lib: b, groups: b, kerning: b, features: b }
+    }
+
+    /// Returns a `DataRequest` requesting all UFO data.
+    pub fn all() -> Self {
+        DataRequest::from_bool(true)
+    }
+
+    /// Returns a `DataRequest` requesting no UFO data.
+    pub fn none() -> Self {
+        DataRequest::from_bool(false)
+    }
+
+    /// Request that returned UFO data include the glyph layers and points.
+    pub fn layers(&mut self, b: bool) -> &mut Self {
+        self.layers = b;
+        self
+    }
+
+    /// Request that returned UFO data include <lib> sections.
+    pub fn lib(&mut self, b: bool) -> &mut Self {
+        self.lib = b;
+        self
+    }
+
+    /// Request that returned UFO data include parsed `groups.plist`.
+    pub fn groups(&mut self, b: bool) -> &mut Self {
+        self.groups = b;
+        self
+    }
+
+    /// Request that returned UFO data include parsed `kerning.plist`.
+    pub fn kerning(&mut self, b: bool) -> &mut Self {
+        self.kerning = b;
+        self
+    }
+
+    /// Request that returned UFO data include OpenType Layout features in Adobe
+    /// .fea format.
+    pub fn features(&mut self, b: bool) -> &mut Self {
+        self.features = b;
+        self
+    }
+}
+
+impl Default for DataRequest {
+    fn default() -> Self {
+        DataRequest::from_bool(true)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,7 @@ pub enum GroupsValidationError {
     OverlappingKerningGroups { glyph_name: String, group_name: String },
 }
 
-/// A [`Color`] string was invalid.
+/// A [`crate::Color`] string was invalid.
 #[derive(Debug)]
 pub struct InvalidColorString {
     source: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,9 @@ pub enum GroupsValidationError {
     OverlappingKerningGroups { glyph_name: String, group_name: String },
 }
 
-/// A [`crate::Color`] string was invalid.
+/// A [`Color`] string was invalid.
+///
+/// [`Color`]: crate::Color
 #[derive(Debug)]
 pub struct InvalidColorString {
     source: String,

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,4 +1,4 @@
-//! Reading and (maybe) writing Unified Font Object files.
+//! Reading and writing Unified Font Object files.
 
 #![deny(broken_intra_doc_links)]
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -8,13 +8,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use serde::ser::{SerializeMap, Serializer};
-use serde::Serialize;
-
 use crate::error::GroupsValidationError;
 use crate::fontinfo::FontInfo;
 use crate::glyph::{Glyph, GlyphName};
 use crate::guideline::Guideline;
+use crate::kerning::Kerning;
 use crate::layer::{Layer, LayerSet, LAYER_CONTENTS_FILE};
 use crate::names::NameList;
 use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
@@ -32,10 +30,6 @@ static DEFAULT_METAINFO_CREATOR: &str = "org.linebender.norad";
 /// Groups is a map of group name to a list of glyph names. It's a BTreeMap because we need sorting
 /// for serialization.
 pub type Groups = BTreeMap<String, Vec<GlyphName>>;
-/// Kerning is a map of first half of a kerning pair (glyph name or group name) to the second half
-/// of a pair (glyph name or group name), which maps to the kerning value (high-level view:
-/// (first, second) => value). It's a BTreeMap because we need sorting for serialization.
-pub type Kerning = BTreeMap<String, BTreeMap<String, f32>>;
 
 /// A Unified Font Object.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -372,7 +366,7 @@ impl Font {
         }
 
         if let Some(kerning) = self.kerning.as_ref() {
-            let kerning_serializer = KerningSerializer { kerning: &kerning };
+            let kerning_serializer = crate::kerning::KerningSerializer { kerning: &kerning };
             plist::to_file_xml(path.join(KERNING_FILE), &kerning_serializer)?;
         }
 
@@ -506,54 +500,10 @@ fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidationError> {
     Ok(())
 }
 
-/// KerningSerializer is a crutch to serialize kerning values as integers if they are
-/// integers rather than floats. This spares us having to use a wrapper type like
-/// IntegerOrFloat for kerning values.
-struct KerningSerializer<'a> {
-    kerning: &'a Kerning,
-}
-
-struct KerningInnerSerializer<'a> {
-    inner_kerning: &'a BTreeMap<String, f32>,
-}
-
-impl<'a> Serialize for KerningSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(self.kerning.len()))?;
-        for (k, v) in self.kerning {
-            let inner_v = KerningInnerSerializer { inner_kerning: v };
-            map.serialize_entry(k, &inner_v)?;
-        }
-        map.end()
-    }
-}
-
-impl<'a> Serialize for KerningInnerSerializer<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(self.inner_kerning.len()))?;
-        for (k, v) in self.inner_kerning {
-            if (v - v.round()).abs() < std::f32::EPSILON {
-                map.serialize_entry(k, &(*v as i32))?;
-            } else {
-                map.serialize_entry(k, v)?;
-            }
-        }
-        map.end()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::shared_types::IntegerOrFloat;
-    use maplit::btreemap;
-    use serde_test::{assert_ser_tokens, Token};
 
     #[test]
     fn new_is_v3() {
@@ -671,37 +621,5 @@ mod tests {
         let path = "testdata/mutatorSans/MutatorSansLightWide.ufo/metainfo.plist";
         let meta: MetaInfo = plist::from_file(path).expect("failed to load metainfo");
         assert_eq!(meta.creator, "org.robofab.ufoLib");
-    }
-
-    #[test]
-    fn serialize_kerning() {
-        let kerning: Kerning = btreemap! {
-            "A".into() => btreemap!{
-                "A".into() => 1.0,
-            },
-            "B".into() => btreemap!{
-                "A".into() => 5.4,
-            },
-        };
-
-        let kerning_serializer = KerningSerializer { kerning: &kerning };
-
-        assert_ser_tokens(
-            &kerning_serializer,
-            &[
-                Token::Map { len: Some(2) },
-                Token::Str("A"),
-                Token::Map { len: Some(1) },
-                Token::Str("A"),
-                Token::I32(1),
-                Token::MapEnd,
-                Token::Str("B"),
-                Token::Map { len: Some(1) },
-                Token::Str("A"),
-                Token::F32(5.4),
-                Token::MapEnd,
-                Token::MapEnd,
-            ],
-        );
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -16,6 +16,7 @@ use crate::layer::{Layer, LayerSet, LAYER_CONTENTS_FILE};
 use crate::names::NameList;
 use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
 use crate::upconversion;
+use crate::DataRequest;
 use crate::Error;
 
 static METAINFO_FILE: &str = "metainfo.plist";
@@ -43,77 +44,6 @@ pub struct Font {
 #[doc(hidden)]
 #[deprecated(since = "0.4.0", note = "Renamed to Font")]
 pub type Ufo = Font;
-
-/// A type that describes which components of a UFO should be loaded.
-///
-/// By default, we load all components of the UFO file; however if you only
-/// need some subset of these, you can pass this struct to [`Ufo::with_fields`]
-/// in order to only load the fields specified in this object. This can help a
-/// lot with performance with large UFO files if you don't need the glyph data.
-///
-/// [`Ufo::with_fields`]: struct.Ufo.html#method.with_fields
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[non_exhaustive]
-pub struct DataRequest {
-    pub layers: bool,
-    pub lib: bool,
-    pub groups: bool,
-    pub kerning: bool,
-    pub features: bool,
-}
-
-impl DataRequest {
-    fn from_bool(b: bool) -> Self {
-        DataRequest { layers: b, lib: b, groups: b, kerning: b, features: b }
-    }
-
-    /// Returns a `DataRequest` requesting all UFO data.
-    pub fn all() -> Self {
-        DataRequest::from_bool(true)
-    }
-
-    /// Returns a `DataRequest` requesting no UFO data.
-    pub fn none() -> Self {
-        DataRequest::from_bool(false)
-    }
-
-    /// Request that returned UFO data include the glyph layers and points.
-    pub fn layers(&mut self, b: bool) -> &mut Self {
-        self.layers = b;
-        self
-    }
-
-    /// Request that returned UFO data include <lib> sections.
-    pub fn lib(&mut self, b: bool) -> &mut Self {
-        self.lib = b;
-        self
-    }
-
-    /// Request that returned UFO data include parsed `groups.plist`.
-    pub fn groups(&mut self, b: bool) -> &mut Self {
-        self.groups = b;
-        self
-    }
-
-    /// Request that returned UFO data include parsed `kerning.plist`.
-    pub fn kerning(&mut self, b: bool) -> &mut Self {
-        self.kerning = b;
-        self
-    }
-
-    /// Request that returned UFO data include OpenType Layout features in Adobe
-    /// .fea format.
-    pub fn features(&mut self, b: bool) -> &mut Self {
-        self.features = b;
-        self
-    }
-}
-
-impl Default for DataRequest {
-    fn default() -> Self {
-        DataRequest::from_bool(true)
-    }
-}
 
 /// A version of the [UFO spec].
 ///

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -3,8 +3,9 @@ use std::collections::{BTreeMap, HashSet};
 use crate::error::GroupsValidationError;
 use crate::GlyphName;
 
-/// Groups is a map of group name to a list of glyph names. It's a BTreeMap because we need sorting
-/// for serialization.
+/// A map of group name to a list of glyph names.
+///
+/// We use a BTreeMap because we need sorting for serialization.
 pub type Groups = BTreeMap<String, Vec<GlyphName>>;
 
 /// Validate the contents of the groups.plist file according to the rules in the

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,0 +1,50 @@
+use std::collections::{BTreeMap, HashSet};
+
+use crate::error::GroupsValidationError;
+use crate::GlyphName;
+
+/// Groups is a map of group name to a list of glyph names. It's a BTreeMap because we need sorting
+/// for serialization.
+pub type Groups = BTreeMap<String, Vec<GlyphName>>;
+
+/// Validate the contents of the groups.plist file according to the rules in the
+/// [Unified Font Object v3 specification for groups.plist](http://unifiedfontobject.org/versions/ufo3/groups.plist/#specification).
+pub(crate) fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidationError> {
+    let mut kern1_set = HashSet::new();
+    let mut kern2_set = HashSet::new();
+    for (group_name, group_glyph_names) in groups_map {
+        if group_name.is_empty() {
+            return Err(GroupsValidationError::InvalidName);
+        }
+
+        if group_name.starts_with("public.kern1.") {
+            if group_name.len() == 13 {
+                // Prefix but no actual name.
+                return Err(GroupsValidationError::InvalidName);
+            }
+            for glyph_name in group_glyph_names {
+                if !kern1_set.insert(glyph_name) {
+                    return Err(GroupsValidationError::OverlappingKerningGroups {
+                        glyph_name: glyph_name.to_string(),
+                        group_name: group_name.to_string(),
+                    });
+                }
+            }
+        } else if group_name.starts_with("public.kern2.") {
+            if group_name.len() == 13 {
+                // Prefix but no actual name.
+                return Err(GroupsValidationError::InvalidName);
+            }
+            for glyph_name in group_glyph_names {
+                if !kern2_set.insert(glyph_name) {
+                    return Err(GroupsValidationError::OverlappingKerningGroups {
+                        glyph_name: glyph_name.to_string(),
+                        group_name: group_name.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -1,0 +1,90 @@
+use std::collections::BTreeMap;
+
+use serde::ser::{SerializeMap, Serializer};
+use serde::Serialize;
+
+/// Kerning is a map of first half of a kerning pair (glyph name or group name) to the second half
+/// of a pair (glyph name or group name), which maps to the kerning value (high-level view:
+/// (first, second) => value). It's a BTreeMap because we need sorting for serialization.
+pub type Kerning = BTreeMap<String, BTreeMap<String, f32>>;
+
+/// KerningSerializer is a crutch to serialize kerning values as integers if they are
+/// integers rather than floats. This spares us having to use a wrapper type like
+/// IntegerOrFloat for kerning values.
+pub(crate) struct KerningSerializer<'a> {
+    pub(crate) kerning: &'a Kerning,
+}
+
+struct KerningInnerSerializer<'a> {
+    inner_kerning: &'a BTreeMap<String, f32>,
+}
+
+impl<'a> Serialize for KerningSerializer<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.kerning.len()))?;
+        for (k, v) in self.kerning {
+            let inner_v = KerningInnerSerializer { inner_kerning: v };
+            map.serialize_entry(k, &inner_v)?;
+        }
+        map.end()
+    }
+}
+
+impl<'a> Serialize for KerningInnerSerializer<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.inner_kerning.len()))?;
+        for (k, v) in self.inner_kerning {
+            if (v - v.round()).abs() < std::f32::EPSILON {
+                map.serialize_entry(k, &(*v as i32))?;
+            } else {
+                map.serialize_entry(k, v)?;
+            }
+        }
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use maplit::btreemap;
+    use serde_test::{assert_ser_tokens, Token};
+
+    #[test]
+    fn serialize_kerning() {
+        let kerning: Kerning = btreemap! {
+            "A".into() => btreemap!{
+                "A".into() => 1.0,
+            },
+            "B".into() => btreemap!{
+                "A".into() => 5.4,
+            },
+        };
+
+        let kerning_serializer = KerningSerializer { kerning: &kerning };
+
+        assert_ser_tokens(
+            &kerning_serializer,
+            &[
+                Token::Map { len: Some(2) },
+                Token::Str("A"),
+                Token::Map { len: Some(1) },
+                Token::Str("A"),
+                Token::I32(1),
+                Token::MapEnd,
+                Token::Str("B"),
+                Token::Map { len: Some(1) },
+                Token::Str("A"),
+                Token::F32(5.4),
+                Token::MapEnd,
+                Token::MapEnd,
+            ],
+        );
+    }
+}

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -3,9 +3,13 @@ use std::collections::BTreeMap;
 use serde::ser::{SerializeMap, Serializer};
 use serde::Serialize;
 
-/// Kerning is a map of first half of a kerning pair (glyph name or group name) to the second half
-/// of a pair (glyph name or group name), which maps to the kerning value (high-level view:
-/// (first, second) => value). It's a BTreeMap because we need sorting for serialization.
+/// A map of kerning pairs.
+///
+/// This is represented as a map of first half of a kerning pair (glyph name or group name)
+/// to the second half of a pair (glyph name or group name), which maps to the kerning value
+/// (high-level view: (first, second) => value).
+///
+/// We use a `BTreeMap` because we need sorting for serialization.
 pub type Kerning = BTreeMap<String, BTreeMap<String, f32>>;
 
 /// KerningSerializer is a crutch to serialize kerning values as integers if they are

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -12,9 +12,11 @@ use serde::Serialize;
 /// We use a `BTreeMap` because we need sorting for serialization.
 pub type Kerning = BTreeMap<String, BTreeMap<String, f32>>;
 
+/// A helper for serializing kerning values.
+///
 /// KerningSerializer is a crutch to serialize kerning values as integers if they are
 /// integers rather than floats. This spares us having to use a wrapper type like
-/// IntegerOrFloat for kerning values.
+/// `IntegerOrFloat` for kerning values.
 pub(crate) struct KerningSerializer<'a> {
     pub(crate) kerning: &'a Kerning,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod fontinfo;
 mod glyph;
 mod guideline;
 mod identifier;
+pub mod kerning;
 mod layer;
 mod names;
 mod shared_types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod error;
 mod font;
 pub mod fontinfo;
 mod glyph;
+pub mod groups;
 mod guideline;
 mod identifier;
 pub mod kerning;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_repr;
 
+pub mod data_request;
 pub mod error;
 mod font;
 pub mod fontinfo;
@@ -35,8 +36,9 @@ mod shared_types;
 mod upconversion;
 pub mod util;
 
+pub use data_request::DataRequest;
 pub use error::Error;
-pub use font::{DataRequest, Font, FormatVersion, MetaInfo};
+pub use font::{Font, FormatVersion, MetaInfo};
 pub use fontinfo::FontInfo;
 pub use glyph::{
     AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -1,8 +1,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
-use crate::font::{Groups, Kerning};
+use crate::font::Groups;
 use crate::fontinfo::FontInfo;
+use crate::kerning::Kerning;
 use crate::names::NameList;
 use crate::shared_types::IntegerOrFloat;
 use crate::Error;

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
-use crate::font::Groups;
 use crate::fontinfo::FontInfo;
+use crate::groups::Groups;
 use crate::kerning::Kerning;
 use crate::names::NameList;
 use crate::shared_types::IntegerOrFloat;


### PR DESCRIPTION
Moving some code around to make files shorter and subdivide functions.

De-anonymizing `load_impl` drops 130 Kb from the release build of open_ufo.