### PR TITLE
Add UFO dir and mandatory .plist file read path existence checks and invalid path diagnostics

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -119,7 +119,7 @@ impl Font {
 
     fn load_impl(path: &Path, request: DataRequest) -> Result<Font, Error> {
         if !path.exists() {
-            let msg = format!("invalid path: {:?}", &path);
+            let msg = format!("invalid path: {:?}", path);
             return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg).into());
         }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -119,11 +119,21 @@ impl Font {
 
     fn load_impl(path: &Path, request: DataRequest) -> Result<Font, Error> {
         if !path.exists() {
-            let msg = format!("invalid path: {:?}", path);
+            let msg = format!("invalid UFO directory path: {:?}", path);
             return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg).into());
         }
 
+        // ===============
+        // mandatory files
+        // ===============
+        // We abort read with error if any UFO spec defined mandatory file is missing
+
+        // metainfo.plist
         let meta_path = path.join(METAINFO_FILE);
+        if !meta_path.exists() {
+            let msg = format!("missing mandatory {} file in directory {:?}", METAINFO_FILE, path);
+            return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg).into());
+        }
         let mut meta: MetaInfo = plist::from_file(meta_path)?;
 
         let lib_path = path.join(LIB_FILE);
@@ -448,7 +458,7 @@ mod tests {
         let path = "totally/bogus/filepath/font.ufo";
         let font_obj = Font::load(path);
         assert!(font_obj.is_err());
-        assert_eq!(format!("{:?}", font_obj), "Err(IoError(Custom { kind: NotFound, error: \"invalid path: \\\"totally/bogus/filepath/font.ufo\\\"\" }))");
+        assert_eq!(format!("{:?}", font_obj), "Err(IoError(Custom { kind: NotFound, error: \"invalid UFO directory path: \\\"totally/bogus/filepath/font.ufo\\\"\" }))");
     }
 
     #[test]


### PR DESCRIPTION
Current formatted error:

```
UFO load failed with error: PlistError(Error { inner: ErrorImpl { kind: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" }), file_position: None } })
```

New formatted error with changes in this PR:

```
UFO load failed with error: invalid path: "bogus/path"
```

Tested in this executable with argument `bogus/path`:

```rust
fn main() {
    for arg in std::env::args().skip(1) {
        let mut ufo = match norad::Font::load(&arg) {
            Ok(u) => u,
            Err(e) => {
                eprintln!("UFO load failed with error: {}", e);
                std::process::exit(1);
            }
        };
    }
}
```