### PR TITLE
Allow specifying whitespace on save

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ exclude = [
 features = ["kurbo"]
 
 [dependencies]
-plist = "1.2"
+# we need the enabled_fancy_long_feature feature until
+# https://github.com/ebarnard/rust-plist/pull/69 lands/is released
+plist = { version =  "~1.2", features = ["serde", "enable_unstable_features_that_may_break_with_minor_version_bumps"] }
 uuid = { version = "0.8", features = ["v4"] }
 serde = { version =  "1.0", features = ["rc"] }
 serde_derive = "1.0"

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -15,7 +15,7 @@ use druid::{Data, Lens};
 use crate::error::{Error, ErrorKind, GlifError, GlifErrorInternal};
 use crate::names::NameList;
 use crate::shared_types::PUBLIC_OBJECT_LIBS_KEY;
-use crate::{Color, Guideline, Identifier, Line, Plist};
+use crate::{Color, Guideline, Identifier, Line, Plist, WriteOptions};
 
 /// The name of a glyph.
 pub type GlyphName = Arc<str>;
@@ -64,13 +64,20 @@ impl Glyph {
 
     #[doc(hidden)]
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        let path = path.as_ref();
+        let opts = WriteOptions::default();
+        self.save_with_options(path, &opts)
+    }
+
+    pub(crate) fn save_with_options(&self, path: &Path, opts: &WriteOptions) -> Result<(), Error> {
         if self.format != GlifVersion::V2 {
             return Err(Error::DowngradeUnsupported);
         }
         if self.lib.contains_key(PUBLIC_OBJECT_LIBS_KEY) {
             return Err(Error::PreexistingPublicObjectLibsKey);
         }
-        let data = self.encode_xml()?;
+
+        let data = self.encode_xml_with_options(opts)?;
         std::fs::write(path, &data)?;
         Ok(())
     }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -35,6 +35,66 @@ fn serialize_full_glyph() {
 }
 
 #[test]
+fn serialize_with_default_formatting() {
+    let data = include_str!("../../testdata/small_lib.glif");
+    let glyph = parse_glyph(data.as_bytes()).unwrap();
+    let one_tab = glyph.encode_xml().unwrap();
+    let one_tab = std::str::from_utf8(&one_tab).unwrap();
+    pretty_assertions::assert_eq!(
+        one_tab,
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hello" format="2">
+	<advance width="1200"/>
+	<outline>
+		<contour>
+			<point x="2" y="30" type="line"/>
+			<point x="44" y="10" type="line"/>
+		</contour>
+	</outline>
+	<lib>
+		<dict>
+			<key>test.key</key>
+			<string>I am a creative professional :)</string>
+		</dict>
+	</lib>
+	<note>durp</note>
+</glyph>
+"#
+    );
+}
+
+#[test]
+fn serialize_with_custom_whitespace() {
+    let data = include_str!("../../testdata/small_lib.glif");
+    let glyph = parse_glyph(data.as_bytes()).unwrap();
+    let options = WriteOptions::default().whitespace("  ");
+    let two_spaces = glyph.encode_xml_with_options(&options).unwrap();
+    let two_spaces = std::str::from_utf8(&two_spaces).unwrap();
+
+    pretty_assertions::assert_eq!(
+        two_spaces,
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hello" format="2">
+  <advance width="1200"/>
+  <outline>
+    <contour>
+      <point x="2" y="30" type="line"/>
+      <point x="44" y="10" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>test.key</key>
+      <string>I am a creative professional :)</string>
+    </dict>
+  </lib>
+  <note>durp</note>
+</glyph>
+"#
+    );
+}
+
+#[test]
 fn parse() {
     let bytes = include_bytes!("../../testdata/sample_period.glif");
     let glyph = parse_glyph(bytes).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod names;
 mod shared_types;
 mod upconversion;
 pub mod util;
+mod write;
 
 pub use data_request::DataRequest;
 pub use error::Error;
@@ -50,6 +51,7 @@ pub use guideline::{Guideline, Line};
 pub use identifier::Identifier;
 pub use layer::{Layer, LayerSet};
 pub use shared_types::{Color, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
+pub use write::WriteOptions;
 
 #[allow(deprecated)]
 pub use font::Ufo;

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,0 +1,106 @@
+//! Customize serialization behaviour
+
+use std::{borrow::Cow, fs::File, io::BufWriter, path::Path};
+
+use plist::XmlWriteOptions;
+
+use crate::Error;
+
+/// Options that can be set when writing the UFO to disk.
+///
+/// You construct `WriteOptions` using builder semantics:
+///
+/// ```
+/// # use norad::WriteOptions;
+/// let single_tab = WriteOptions::default();
+///
+/// let two_tabs = WriteOptions::default()
+///     .whitespace("\t\t");
+///
+/// let spaces = WriteOptions::default()
+///     .whitespace("  ");
+/// ```
+#[derive(Debug, Clone)]
+pub struct WriteOptions {
+    // for annoying reasons we store three different representations.
+    pub(crate) indent_str: Cow<'static, str>,
+    xml_opts: XmlWriteOptions,
+    pub(crate) whitespace_char: u8,
+    pub(crate) whitespace_count: usize,
+}
+
+impl Default for WriteOptions {
+    fn default() -> Self {
+        WriteOptions {
+            indent_str: "\t".into(),
+            xml_opts: Default::default(),
+            whitespace_char: b'\t',
+            whitespace_count: 1,
+        }
+    }
+}
+
+impl WriteOptions {
+    /// Builder-style method to customize the whitespace.
+    ///
+    /// By default, we intent with a single tab ("\t").
+    ///
+    /// The argument, may be either a `'static str` or a `String`. You should
+    /// prefer to use a `'static str` where possible.
+    ///
+    /// The string can contain any number of *a single ASCII character*, but must
+    /// not contain multiple different characters. As an example, "\t\t" is
+    /// fine, but "\t  \t" is not, because it contains both tabs and spaces.
+    ///
+    /// This is not good API, but is a work around for the fact that the quick-xml
+    /// and plist crates both represent whitespace in different ways.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided string is empty, or if it contains multiple
+    /// different characters.
+    pub fn whitespace(mut self, indent_str: impl Into<Cow<'static, str>>) -> Self {
+        let indent_str = indent_str.into();
+        self.whitespace_char = indent_str.bytes().next().expect("whitespace str must not be empty");
+        assert!(indent_str.bytes().all(|c| c == self.whitespace_char), "invalid whitespace");
+        self.whitespace_count = indent_str.len();
+        self.indent_str = indent_str;
+        self.xml_opts = XmlWriteOptions::default().indent_string(self.indent_str.clone());
+        self
+    }
+
+    /// Return a reference to [`XmlWriteOptions`] for use with the `plist` crate.
+    pub fn xml_options(&self) -> &XmlWriteOptions {
+        &self.xml_opts
+    }
+}
+
+/// Write a `plist::Value` to file, providing custom options.
+pub fn write_plist_value_to_file(
+    path: &Path,
+    value: &plist::Value,
+    options: &XmlWriteOptions,
+) -> Result<(), Error> {
+    let mut file = File::create(path)?;
+    let writer = BufWriter::new(&mut file);
+    value.to_writer_xml_with_options(writer, options)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+/// Write any `Serialize` to file, providing custom options.
+pub fn write_xml_to_file(
+    path: &Path,
+    value: &impl serde::Serialize,
+    options: &XmlWriteOptions,
+) -> Result<(), Error> {
+    let mut file = File::create(path)?;
+    {
+        let buf_writer = BufWriter::new(&mut file);
+        let writer = plist::stream::XmlWriter::new_with_options(buf_writer, options);
+        let mut ser = plist::Serializer::new(writer);
+        value.serialize(&mut ser)?;
+    }
+    file.sync_all()?;
+    Ok(())
+}

--- a/testdata/small_lib.glif
+++ b/testdata/small_lib.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="hello" format="2">
+<advance width="1200"/>
+<note>
+durp
+</note>
+<outline>
+<contour>
+<point x="2" y="30" type="line"/>
+<point x="44" y="10" type="line"/>
+</contour>
+</outline>
+<lib>
+<dict>
+<key>test.key</key>
+<string>I am a creative professional :)</string>
+</dict>
+</lib>
+</glyph>


### PR DESCRIPTION
This lets the user optionally customize the whitespace used during
serialization.

The implementation is slightly annoying. the `quick_xml` and `rust-plist`
crates specify whitespace in different ways; `quick_xml` takes a (u8,
usize) pair (the byte and its count) and `rust-plist` takes a
`Cow<'static str>`. Additionally, in our own glyph serialization code we
need to write whitespace directly when appending the 'lib' section.

Anyway: you *create* a `WriteOptions` object by passing it a string, and
then we figure out what the appropriate (u8, usize) pair is. The reason
we want to think about this is because eventually writing out a UFO
should be parallelized, and that could mean cloning `WriteOptions` once
for each glyph; we would like to make sure this isn't allocating.

So this seems to work, even if some of the internals are a bit gross.

---

this is based off of #147, which should go in first.