### PR TITLE
[ci] Run clippy against all targets, check docs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,11 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install libgtk-dev
-        run: |
-          sudo apt update
-          sudo apt install libgtk-3-dev
-
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -43,16 +38,28 @@ jobs:
           profile: minimal
           override: true
 
+      - run: git submodule update --init --recursive
+
+      - name: cargo clippy --all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --all-targets -- -D warnings
+
       - name: cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features -- -D warnings
-
-      - run: git submodule update --init --recursive
+          args: --all-targets -- -D warnings
 
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
+
+      - name: cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all-features --document-private-items

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ kurbo = { version = "0.8.1", optional = true }
 [dependencies.druid]
 #git = "https://github.com/xi-editor/druid.git"
 #rev = "7fab0485"
+default-features = false
+features = ["x11"]
 version = "0.7.0"
 optional = true
 

--- a/examples/glif_note.rs
+++ b/examples/glif_note.rs
@@ -1,0 +1,15 @@
+use norad::*;
+
+static NOTE_TEXT: &str = r#"
+    def test:
+        print("love it")
+
+"#;
+fn main() {
+    let mut glif = Glyph::new_named("A");
+    glif.note = Some(NOTE_TEXT.into());
+
+    let encoded = glif.encode_xml().unwrap();
+    let string = String::from_utf8(encoded).unwrap();
+    print!("{}", string);
+}

--- a/examples/load_a_bunch.rs
+++ b/examples/load_a_bunch.rs
@@ -1,0 +1,8 @@
+use norad::Font;
+
+fn main() {
+    let _ = Font::load("/Users/rofls/dev/projects/fontville/fontfiles/NotoSans-Bold.ufo").unwrap();
+    let _ =
+        Font::load("/Users/rofls/dev/projects/fontville/fontfiles/NotoSans-Regular.ufo").unwrap();
+    let _ = Font::load("/Users/rofls/dev/projects/fontville/fontfiles/NotoSans-Light.ufo").unwrap();
+}

--- a/examples/normalize.rs
+++ b/examples/normalize.rs
@@ -52,12 +52,9 @@ fn main() {
         });
 
         ufo.meta.creator = "org.linebender.norad".to_string();
-        match ufo.save(arg) {
-            Err(e) => {
-                eprintln!("Saving UFO failed: {}", e);
-                std::process::exit(1);
-            }
-            _ => {}
-        };
+        if let Err(e) = ufo.save(arg) {
+            eprintln!("Saving UFO failed: {}", e);
+            std::process::exit(1);
+        }
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -422,11 +422,11 @@ mod tests {
 
         let mut font = Font::new();
         font.meta.format_version = FormatVersion::V1;
-        assert_eq!(font.save(&dir).is_err(), true);
+        assert!(font.save(&dir).is_err());
         font.meta.format_version = FormatVersion::V2;
-        assert_eq!(font.save(&dir).is_err(), true);
+        assert!(font.save(&dir).is_err());
         font.meta.format_version = FormatVersion::V3;
-        assert_eq!(font.save(&dir).is_ok(), true);
+        assert!(font.save(&dir).is_ok());
     }
 
     #[test]
@@ -441,7 +441,12 @@ mod tests {
             Some(&plist::Value::Boolean(true))
         );
         assert_eq!(font_obj.groups.unwrap().get("public.kern1.@MMK_L_A"), Some(&vec!["A".into()]));
-        assert_eq!(font_obj.kerning.unwrap().get("B").unwrap().get("H").unwrap(), &-40.0);
+
+        #[allow(clippy::float_cmp)]
+        {
+            assert_eq!(font_obj.kerning.unwrap().get("B").and_then(|k| k.get("H")), Some(&-40.0));
+        }
+
         assert_eq!(font_obj.features.unwrap(), "# this is the feature from lightWide\n");
     }
 

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1363,6 +1363,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn test_validate_head_created() {
         let mut fi = FontInfo::default();
         fi.open_type_head_created = Some("YYYY/MM/DD HH:MM:SS".to_string());

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -273,7 +273,8 @@ impl GlyphBuilder {
     }
 }
 
-/// An OutlineBuilder is a consuming builder for [`crate::glyph::Outline`], not unlike a [fontTools point pen].
+/// An OutlineBuilder is a consuming builder for [`Outline`], not unlike a
+/// [fontTools point pen].
 ///
 /// Primarily to be used in conjunction with [`GlyphBuilder`].
 ///

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -3,6 +3,7 @@ use super::*;
 use std::path::PathBuf;
 
 #[test]
+#[allow(clippy::float_cmp)]
 fn transform() {
     let transform = AffineTransform::default();
     assert_eq!(transform.x_scale, 1.0);
@@ -70,13 +71,14 @@ fn curve_types() {
     let glyph = parse_glyph(bytes).unwrap();
     assert_eq!(glyph.contours.len(), 2);
     assert_eq!(glyph.contours[1].points[0].typ, PointType::Line);
-    assert_eq!(glyph.contours[1].points[0].smooth, false);
-    assert_eq!(glyph.contours[1].points[1].smooth, true);
+    assert!(!glyph.contours[1].points[0].smooth);
+    assert!(glyph.contours[1].points[1].smooth);
     assert_eq!(glyph.contours[1].points[2].typ, PointType::OffCurve);
     assert_eq!(glyph.contours[1].points[4].typ, PointType::Curve);
 }
 
 #[test]
+#[allow(clippy::float_cmp)]
 fn guidelines() {
     let bytes = include_bytes!("../../testdata/Blinker_one.glif");
     let glyph = parse_glyph(bytes).unwrap();
@@ -111,6 +113,7 @@ fn parse_note() {
 }
 
 #[test]
+#[allow(clippy::float_cmp)]
 fn save() {
     let bytes = include_bytes!("../../testdata/sample_period.glif");
     let glyph = parse_glyph(bytes).expect("initial load failed");

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -478,6 +478,7 @@ mod tests {
     use std::path::Path;
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn load_layer() {
         let layer_path = "testdata/mutatorSans/MutatorSansBoldWide.ufo/glyphs";
         assert!(Path::new(layer_path).exists(), "missing test data. Did you `git submodule init`?");
@@ -553,6 +554,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn set_glyph() {
         let layer_path = "testdata/mutatorSans/MutatorSansBoldWide.ufo/glyphs";
         let mut layer = Layer::load(layer_path, DEFAULT_LAYER_NAME.into()).unwrap();
@@ -567,15 +569,15 @@ mod tests {
     fn layer_creation() {
         let mut ufo = crate::Font::load("testdata/mutatorSans/MutatorSansBoldWide.ufo").unwrap();
 
-        let default_layer = ufo.layers.get_or_create("foreground".into());
+        let default_layer = ufo.layers.get_or_create("foreground");
         assert!(!default_layer.is_empty());
         default_layer.clear();
 
-        let background_layer = ufo.layers.get_or_create("background".into());
+        let background_layer = ufo.layers.get_or_create("background");
         assert!(!background_layer.is_empty());
         background_layer.clear();
 
-        let misc_layer = ufo.layers.get_or_create("misc".into());
+        let misc_layer = ufo.layers.get_or_create("misc");
         assert!(misc_layer.is_empty());
         misc_layer.insert_glyph(Glyph::new_named("A"));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 //! assert_eq!(glyph_a.name.as_ref(), "A");
 //! ```
 
+#![deny(broken_intra_doc_links, unsafe_code)]
+
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -263,9 +263,11 @@ mod tests {
         let c4 = Color { red: 0.123, green: 0.456, blue: 0.789, alpha: 0.159 };
         assert_tokens(&c4, &[Token::Str("0.123,0.456,0.789,0.159")]);
 
+        #[allow(clippy::excessive_precision)]
         let c5 = Color { red: 0.123456789, green: 0.456789123, blue: 0.789123456, alpha: 0.1 };
         assert_ser_tokens(&c5, &[Token::Str("0.123,0.457,0.789,0.1")]);
 
+        #[allow(clippy::excessive_precision)]
         let c6 = Color { red: 0.123456789, green: 0.456789123, blue: 0.789123456, alpha: 0.1 };
         assert_de_tokens(&c6, &[Token::Str("0.123456789,0.456789123,0.789123456,0.1")]);
     }


### PR DESCRIPTION
We weren't doing this, which means our tests and examples were
un-clippy'd. They are now clippy'd.

We also now deny missing docs.