### PR TITLE
Update to plist 1.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 keywords = ["font", "ufo", "fonts"]
 repository = "https://github.com/linebender/norad"
-description = "Read and write Unifed Font Object files."
+description = "Read and write Unified Font Object files."
 readme = "README.md"
 categories = ["graphics", "text-processing"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ features = ["kurbo"]
 [dependencies]
 # we need the enabled_fancy_long_feature feature until
 # https://github.com/ebarnard/rust-plist/pull/69 lands/is released
-plist = { version =  "~1.2", features = ["serde", "enable_unstable_features_that_may_break_with_minor_version_bumps"] }
+plist = { version =  "1.2.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["v4"] }
 serde = { version =  "1.0", features = ["rc"] }
 serde_derive = "1.0"

--- a/src/write.rs
+++ b/src/write.rs
@@ -130,12 +130,8 @@ pub fn write_xml_to_file(
     options: &WriteOptions,
 ) -> Result<(), Error> {
     let mut file = File::create(path)?;
-    {
-        let buf_writer = BufWriter::new(&mut file);
-        let writer = plist::stream::XmlWriter::new_with_options(buf_writer, options.xml_options());
-        let mut ser = plist::Serializer::new(writer);
-        value.serialize(&mut ser)?;
-    }
+    let buf_writer = BufWriter::new(&mut file);
+    plist::to_writer_xml_with_options(buf_writer, value, options.xml_options())?;
     write_quote_style(&file, options)?;
     file.sync_all()?;
     Ok(())


### PR DESCRIPTION
This lets us remove the enable_unstable_features feature.