### PR TITLE
Remove Mutator Sans git submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "testdata/mutatorSans"]
-	path = testdata/mutatorSans
-	url = https://github.com/LettError/mutatorSans.git


### PR DESCRIPTION
The test data submodule dir was transitioned away from a git submodule.  This PR removes the git submodule config. 