### PR TITLE
Add glif contour point PointType enum Display trait

### DIFF
--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -366,6 +366,20 @@ pub enum PointType {
     QCurve,
 }
 
+/// FromStr trait implementation for [`PointType`].
+impl std::str::FromStr for PointType {
+    type Err = ErrorKind;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "move" => Ok(PointType::Move),
+            "line" => Ok(PointType::Line),
+            "offcurve" => Ok(PointType::OffCurve),
+            "curve" => Ok(PointType::Curve),
+            "qcurve" => Ok(PointType::QCurve),
+            _other => Err(ErrorKind::UnknownPointType),
+        }
+    }
+}
 /// A 2D affine transformation.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -380,6 +380,20 @@ impl std::str::FromStr for PointType {
         }
     }
 }
+
+/// Display trait implementation for [`PointType`].
+impl std::fmt::Display for PointType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PointType::Move => write!(f, "move"),
+            PointType::Line => write!(f, "line"),
+            PointType::OffCurve => write!(f, "offcurve"),
+            PointType::Curve => write!(f, "curve"),
+            PointType::QCurve => write!(f, "qcurve"),
+        }
+    }
+}
+
 /// A 2D affine transformation.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -550,17 +550,3 @@ impl FromStr for GlifVersion {
         }
     }
 }
-
-impl FromStr for PointType {
-    type Err = ErrorKind;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "move" => Ok(PointType::Move),
-            "line" => Ok(PointType::Line),
-            "offcurve" => Ok(PointType::OffCurve),
-            "curve" => Ok(PointType::Curve),
-            "qcurve" => Ok(PointType::QCurve),
-            _other => Err(ErrorKind::UnknownPointType),
-        }
-    }
-}

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -2,6 +2,7 @@ use super::parse::parse_glyph;
 use super::*;
 use crate::write::QuoteChar;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 #[test]
 #[allow(clippy::float_cmp)]
@@ -571,4 +572,28 @@ fn empty_contours() {
     let test2 = parse_glyph(data2.as_bytes()).unwrap();
     assert_eq!(test2.components, vec![]);
     assert_eq!(test2.contours, vec![]);
+}
+
+#[test]
+fn pointtype_display_trait() {
+    assert_eq!(format!("{}", PointType::Move), "move");
+    assert_eq!(format!("{}", PointType::Line), "line");
+    assert_eq!(format!("{}", PointType::OffCurve), "offcurve");
+    assert_eq!(format!("{}", PointType::Curve), "curve");
+    assert_eq!(format!("{}", PointType::QCurve), "qcurve");
+}
+
+#[test]
+fn pointtype_from_str() {
+    assert!(PointType::from_str("move").unwrap() == PointType::Move);
+    assert!(PointType::from_str("line").unwrap() == PointType::Line);
+    assert!(PointType::from_str("offcurve").unwrap() == PointType::OffCurve);
+    assert!(PointType::from_str("curve").unwrap() == PointType::Curve);
+    assert!(PointType::from_str("qcurve").unwrap() == PointType::QCurve);
+}
+
+#[test]
+#[should_panic(expected = "UnknownPointType")]
+fn pointtype_from_str_unknown_type() {
+    PointType::from_str("bogus").unwrap();
 }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -584,7 +584,7 @@ fn pointtype_display_trait() {
 }
 
 #[test]
-fn pointtype_from_str() {
+fn pointtype_from_str_trait() {
     assert!(PointType::from_str("move").unwrap() == PointType::Move);
     assert!(PointType::from_str("line").unwrap() == PointType::Line);
     assert!(PointType::from_str("offcurve").unwrap() == PointType::OffCurve);


### PR DESCRIPTION
I used norad for outline incompatibility diagnostics across multiple UFO masters this week and it was helpful to have the glif contour point type attribute string format in the tests.   This PR includes a Display trait implementation, a refactor of the FromStr trait implementation to the module that contains the PointType enum, and  Display/FromStr/PartialEq tests.