### PR TITLE
Use f64 instead of f32 everywhere

### DIFF
--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -87,8 +87,8 @@ use crate::{
 #[derive(Debug)]
 pub(crate) struct GlyphBuilder {
     glyph: Glyph,
-    height: Option<f32>,
-    width: Option<f32>,
+    height: Option<f64>,
+    width: Option<f64>,
     outline: Option<Outline>,
     lib: Option<Plist>,
     identifiers: HashSet<Identifier>, // All identifiers within a glyph must be unique.
@@ -116,7 +116,7 @@ impl GlyphBuilder {
     /// Set the glyph width.
     ///
     /// Errors when the function is called more than once.
-    pub fn width(&mut self, width: f32) -> Result<&mut Self, ErrorKind> {
+    pub fn width(&mut self, width: f64) -> Result<&mut Self, ErrorKind> {
         if self.width.is_some() {
             return Err(ErrorKind::UnexpectedDuplicate);
         }
@@ -127,7 +127,7 @@ impl GlyphBuilder {
     /// Set the glyph height.
     ///
     /// Errors when the function is called more than once.
-    pub fn height(&mut self, height: f32) -> Result<&mut Self, ErrorKind> {
+    pub fn height(&mut self, height: f64) -> Result<&mut Self, ErrorKind> {
         if self.height.is_some() {
             return Err(ErrorKind::UnexpectedDuplicate);
         }
@@ -346,7 +346,7 @@ impl OutlineBuilder {
     /// point.
     pub fn add_point(
         &mut self,
-        (x, y): (f32, f32),
+        (x, y): (f64, f64),
         segment_type: PointType,
         smooth: bool,
         name: Option<String>,

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -669,12 +669,12 @@ pub struct Image {
 impl From<AffineTransform> for kurbo::Affine {
     fn from(src: AffineTransform) -> kurbo::Affine {
         kurbo::Affine::new([
-            src.x_scale as f64,
-            src.xy_scale as f64,
-            src.yx_scale as f64,
-            src.y_scale as f64,
-            src.x_offset as f64,
-            src.y_offset as f64,
+            src.x_scale,
+            src.xy_scale,
+            src.yx_scale,
+            src.y_scale,
+            src.x_offset,
+            src.y_offset,
         ])
     }
 }
@@ -716,11 +716,6 @@ impl From<druid::piet::Color> for Color {
 #[cfg(feature = "druid")]
 impl From<Color> for druid::piet::Color {
     fn from(src: Color) -> druid::piet::Color {
-        druid::piet::Color::rgba(
-            src.red.into(),
-            src.green.into(),
-            src.blue.into(),
-            src.alpha.into(),
-        )
+        druid::piet::Color::rgba(src.red, src.green, src.blue, src.alpha)
     }
 }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -28,8 +28,8 @@ pub type GlyphName = Arc<str>;
 pub struct Glyph {
     pub name: GlyphName,
     pub format: GlifVersion,
-    pub height: f32,
-    pub width: f32,
+    pub height: f64,
+    pub width: f64,
     pub codepoints: Vec<char>,
     pub note: Option<String>,
     pub guidelines: Vec<Guideline>,
@@ -227,8 +227,8 @@ pub enum GlifVersion {
 /// [Anchor section]: https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#anchor
 #[derive(Debug, Clone, PartialEq)]
 pub struct Anchor {
-    pub x: f32,
-    pub y: f32,
+    pub x: f64,
+    pub y: f64,
     /// An arbitrary name for the anchor.
     pub name: Option<String>,
     pub color: Option<Color>,
@@ -323,8 +323,8 @@ impl Contour {
 /// A single point in a [`Contour`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct ContourPoint {
-    pub x: f32,
-    pub y: f32,
+    pub x: f64,
+    pub y: f64,
     pub typ: PointType,
     pub smooth: bool,
     pub name: Option<String>,
@@ -398,18 +398,18 @@ impl std::fmt::Display for PointType {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]
 pub struct AffineTransform {
-    pub x_scale: f32,
-    pub xy_scale: f32,
-    pub yx_scale: f32,
-    pub y_scale: f32,
-    pub x_offset: f32,
-    pub y_offset: f32,
+    pub x_scale: f64,
+    pub xy_scale: f64,
+    pub yx_scale: f64,
+    pub y_scale: f64,
+    pub x_offset: f64,
+    pub y_offset: f64,
 }
 
 impl Anchor {
     pub fn new(
-        x: f32,
-        y: f32,
+        x: f64,
+        y: f64,
         name: Option<String>,
         color: Option<Color>,
         identifier: Option<Identifier>,
@@ -515,8 +515,8 @@ impl Contour {
 
 impl ContourPoint {
     pub fn new(
-        x: f32,
-        y: f32,
+        x: f64,
+        y: f64,
         typ: PointType,
         smooth: bool,
         name: Option<String>,
@@ -684,12 +684,12 @@ impl From<kurbo::Affine> for AffineTransform {
     fn from(src: kurbo::Affine) -> AffineTransform {
         let coeffs = src.as_coeffs();
         AffineTransform {
-            x_scale: coeffs[0] as f32,
-            xy_scale: coeffs[1] as f32,
-            yx_scale: coeffs[2] as f32,
-            y_scale: coeffs[3] as f32,
-            x_offset: coeffs[4] as f32,
-            y_offset: coeffs[5] as f32,
+            x_scale: coeffs[0],
+            xy_scale: coeffs[1],
+            yx_scale: coeffs[2],
+            y_scale: coeffs[3],
+            x_offset: coeffs[4],
+            y_offset: coeffs[5],
         }
     }
 }
@@ -698,10 +698,10 @@ impl From<kurbo::Affine> for AffineTransform {
 impl From<druid::piet::Color> for Color {
     fn from(src: druid::piet::Color) -> Color {
         let rgba = src.as_rgba_u32();
-        let r = ((rgba >> 24) & 0xff) as f32 / 255.0;
-        let g = ((rgba >> 16) & 0xff) as f32 / 255.0;
-        let b = ((rgba >> 8) & 0xff) as f32 / 255.0;
-        let a = (rgba & 0xff) as f32 / 255.0;
+        let r = ((rgba >> 24) & 0xff) as f64 / 255.0;
+        let g = ((rgba >> 16) & 0xff) as f64 / 255.0;
+        let b = ((rgba >> 8) & 0xff) as f64 / 255.0;
+        let a = (rgba & 0xff) as f64 / 255.0;
         assert!((0.0..=1.0).contains(&b), "b: {}, raw {}", b, (rgba & (0xff << 8)));
 
         Color {

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -268,8 +268,8 @@ impl<'names> GlifParser<'names> {
         outline_builder: &mut OutlineBuilder,
     ) -> Result<(), Error> {
         let mut name: Option<String> = None;
-        let mut x: Option<f32> = None;
-        let mut y: Option<f32> = None;
+        let mut x: Option<f64> = None;
+        let mut y: Option<f64> = None;
         let mut typ = PointType::OffCurve;
         let mut identifier: Option<Identifier> = None;
         let mut smooth = false;
@@ -314,15 +314,15 @@ impl<'names> GlifParser<'names> {
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
     ) -> Result<(), Error> {
-        let mut width: f32 = 0.0;
-        let mut height: f32 = 0.0;
+        let mut width: f64 = 0.0;
+        let mut height: f64 = 0.0;
         for attr in data.attributes() {
             let attr = attr?;
             match attr.key {
                 b"width" | b"height" => {
                     let value = attr.unescaped_value()?;
                     let value = reader.decode(&value)?;
-                    let value: f32 =
+                    let value: f64 =
                         value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?;
                     match attr.key {
                         b"width" => width = value,
@@ -369,8 +369,8 @@ impl<'names> GlifParser<'names> {
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
     ) -> Result<(), Error> {
-        let mut x: Option<f32> = None;
-        let mut y: Option<f32> = None;
+        let mut x: Option<f64> = None;
+        let mut y: Option<f64> = None;
         let mut name: Option<String> = None;
         let mut color: Option<Color> = None;
         let mut identifier: Option<Identifier> = None;
@@ -411,9 +411,9 @@ impl<'names> GlifParser<'names> {
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
     ) -> Result<(), Error> {
-        let mut x: Option<f32> = None;
-        let mut y: Option<f32> = None;
-        let mut angle: Option<f32> = None;
+        let mut x: Option<f64> = None;
+        let mut y: Option<f64> = None;
+        let mut angle: Option<f64> = None;
         let mut name: Option<String> = None;
         let mut color: Option<Color> = None;
         let mut identifier: Option<Identifier> = None;

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -342,7 +342,7 @@ fn char_to_event(c: char) -> Event<'static> {
 }
 
 fn write_transform_attributes(element: &mut BytesStart, transform: &AffineTransform) {
-    if (transform.x_scale - 1.0).abs() > std::f32::EPSILON {
+    if (transform.x_scale - 1.0).abs() > std::f64::EPSILON {
         element.push_attribute(("xScale", transform.x_scale.to_string().as_str()));
     }
 
@@ -354,7 +354,7 @@ fn write_transform_attributes(element: &mut BytesStart, transform: &AffineTransf
         element.push_attribute(("yxScale", transform.yx_scale.to_string().as_str()));
     }
 
-    if (transform.y_scale - 1.0).abs() > std::f32::EPSILON {
+    if (transform.y_scale - 1.0).abs() > std::f64::EPSILON {
         element.push_attribute(("yScale", transform.y_scale.to_string().as_str()));
     }
 

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -24,13 +24,13 @@ pub struct Guideline {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Line {
     /// A vertical line, passing through a given `x` coordinate.
-    Vertical(f32),
+    Vertical(f64),
     /// A horizontal line, passing through a given `y` coordinate.
-    Horizontal(f32),
+    Horizontal(f64),
     /// An angled line passing through `(x, y)` at `degrees` degrees counteer-clockwise
     /// to the horizontal.
     // TODO: make a Degrees newtype that checks `0 <= degrees <= 360`.
-    Angle { x: f32, y: f32, degrees: f32 },
+    Angle { x: f64, y: f64, degrees: f64 },
 }
 
 impl Guideline {
@@ -90,9 +90,9 @@ impl Guideline {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawGuideline {
-    x: Option<f32>,
-    y: Option<f32>,
-    angle: Option<f32>,
+    x: Option<f64>,
+    y: Option<f64>,
+    angle: Option<f64>,
     name: Option<String>,
     color: Option<Color>,
     identifier: Option<Identifier>,

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 /// (high-level view: (first, second) => value).
 ///
 /// We use a `BTreeMap` because we need sorting for serialization.
-pub type Kerning = BTreeMap<String, BTreeMap<String, f32>>;
+pub type Kerning = BTreeMap<String, BTreeMap<String, f64>>;
 
 /// A helper for serializing kerning values.
 ///
@@ -22,7 +22,7 @@ pub(crate) struct KerningSerializer<'a> {
 }
 
 struct KerningInnerSerializer<'a> {
-    inner_kerning: &'a BTreeMap<String, f32>,
+    inner_kerning: &'a BTreeMap<String, f64>,
 }
 
 impl<'a> Serialize for KerningSerializer<'a> {
@@ -46,7 +46,7 @@ impl<'a> Serialize for KerningInnerSerializer<'a> {
     {
         let mut map = serializer.serialize_map(Some(self.inner_kerning.len()))?;
         for (k, v) in self.inner_kerning {
-            if (v - v.round()).abs() < std::f32::EPSILON {
+            if (v - v.round()).abs() < std::f64::EPSILON {
                 map.serialize_entry(k, &(*v as i32))?;
             } else {
                 map.serialize_entry(k, v)?;
@@ -87,7 +87,7 @@ mod tests {
                 Token::Str("B"),
                 Token::Map { len: Some(1) },
                 Token::Str("A"),
-                Token::F32(5.4),
+                Token::F64(5.4),
                 Token::MapEnd,
                 Token::MapEnd,
             ],

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -21,17 +21,17 @@ pub type Plist = plist::Dictionary;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]
 pub struct Color {
-    pub red: f32,
-    pub green: f32,
-    pub blue: f32,
-    pub alpha: f32,
+    pub red: f64,
+    pub green: f64,
+    pub blue: f64,
+    pub alpha: f64,
 }
 
 impl FromStr for Color {
     type Err = InvalidColorString;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut iter = s.split(',').map(|v| match v.parse::<f32>() {
+        let mut iter = s.split(',').map(|v| match v.parse::<f64>() {
             Ok(val) if (0.0..=1.0).contains(&val) => Ok(val),
             _ => Err(InvalidColorString::new(s.to_owned())),
         });
@@ -298,13 +298,13 @@ mod tests {
                 Token::Struct { name: "RawGuideline", len: 6 },
                 Token::Str("x"),
                 Token::Some,
-                Token::F32(10.0),
+                Token::F64(10.0),
                 Token::Str("y"),
                 Token::Some,
-                Token::F32(20.0),
+                Token::F64(20.0),
                 Token::Str("angle"),
                 Token::Some,
-                Token::F32(360.0),
+                Token::F64(360.0),
                 Token::Str("name"),
                 Token::Some,
                 Token::Str("hello"),

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -69,7 +69,7 @@ pub(crate) fn upconvert_kerning(
 
     for (first, seconds) in kerning {
         let first_new = groups_first_old_to_new.get(first).unwrap_or(first);
-        let mut seconds_new: BTreeMap<String, f32> = BTreeMap::new();
+        let mut seconds_new: BTreeMap<String, f64> = BTreeMap::new();
         for (second, value) in seconds {
             let second_new = groups_second_old_to_new.get(second).unwrap_or(second);
             seconds_new.insert(second_new.to_string(), *value);


### PR DESCRIPTION
Python floats as used by ufoLib are implicitly f64.

Closes https://github.com/linebender/norad/issues/164.

Maybe we need to change i32 to i64 as well at some point.