### PR TITLE
Refactor read and write configurations

### DIFF
--- a/src/data_request.rs
+++ b/src/data_request.rs
@@ -36,44 +36,44 @@ impl DataRequest {
     }
 
     /// Request that returned UFO data include the glyph layers and points.
-    pub fn layers(&mut self, b: bool) -> &mut Self {
+    pub fn layers(mut self, b: bool) -> Self {
         self.layers = b;
         self
     }
 
     /// Request that returned UFO data include <lib> sections.
-    pub fn lib(&mut self, b: bool) -> &mut Self {
+    pub fn lib(mut self, b: bool) -> Self {
         self.lib = b;
         self
     }
 
     /// Request that returned UFO data include parsed `groups.plist`.
-    pub fn groups(&mut self, b: bool) -> &mut Self {
+    pub fn groups(mut self, b: bool) -> Self {
         self.groups = b;
         self
     }
 
     /// Request that returned UFO data include parsed `kerning.plist`.
-    pub fn kerning(&mut self, b: bool) -> &mut Self {
+    pub fn kerning(mut self, b: bool) -> Self {
         self.kerning = b;
         self
     }
 
     /// Request that returned UFO data include OpenType Layout features in Adobe
     /// .fea format.
-    pub fn features(&mut self, b: bool) -> &mut Self {
+    pub fn features(mut self, b: bool) -> Self {
         self.features = b;
         self
     }
 
     /// Request that returned UFO data include data.
-    pub fn data(&mut self, b: bool) -> &mut Self {
+    pub fn data(mut self, b: bool) -> Self {
         self.data = b;
         self
     }
 
     /// Request that returned UFO data include images.
-    pub fn images(&mut self, b: bool) -> &mut Self {
+    pub fn images(mut self, b: bool) -> Self {
         self.images = b;
         self
     }
@@ -82,5 +82,60 @@ impl DataRequest {
 impl Default for DataRequest {
     fn default() -> Self {
         DataRequest::from_bool(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    fn all_fields_are_true(dr: &DataRequest) -> bool {
+        return dr.layers
+            && dr.lib
+            && dr.groups
+            && dr.kerning
+            && dr.features
+            && dr.data
+            && dr.images;
+    }
+
+    fn all_fields_are_false(dr: &DataRequest) -> bool {
+        return !dr.layers
+            && !dr.lib
+            && !dr.groups
+            && !dr.kerning
+            && !dr.features
+            && !dr.data
+            && !dr.images;
+    }
+
+    #[test]
+    fn test_datarequest_default() {
+        assert!(all_fields_are_true(&DataRequest::default()));
+    }
+
+    #[test]
+    fn test_datarequest_all() {
+        assert!(all_fields_are_true(&DataRequest::all()));
+    }
+
+    #[test]
+    fn test_datarequest_none() {
+        assert!(all_fields_are_false(&DataRequest::none()));
+    }
+
+    #[test]
+    fn test_datarequest_builder() {
+        let dr = DataRequest::default()
+            .layers(false)
+            .lib(false)
+            .groups(false)
+            .kerning(false)
+            .features(false)
+            .data(false)
+            .images(false);
+
+        assert!(all_fields_are_false(&dr));
     }
 }

--- a/src/data_request.rs
+++ b/src/data_request.rs
@@ -91,23 +91,11 @@ mod tests {
     use super::*;
 
     fn all_fields_are_true(dr: &DataRequest) -> bool {
-        return dr.layers
-            && dr.lib
-            && dr.groups
-            && dr.kerning
-            && dr.features
-            && dr.data
-            && dr.images;
+        dr.layers && dr.lib && dr.groups && dr.kerning && dr.features && dr.data && dr.images
     }
 
     fn all_fields_are_false(dr: &DataRequest) -> bool {
-        return !dr.layers
-            && !dr.lib
-            && !dr.groups
-            && !dr.kerning
-            && !dr.features
-            && !dr.data
-            && !dr.images;
+        !dr.layers && !dr.lib && !dr.groups && !dr.kerning && !dr.features && !dr.data && !dr.images
     }
 
     #[test]

--- a/src/font.rs
+++ b/src/font.rs
@@ -109,9 +109,9 @@ impl Font {
     /// Attempt to load the requested elements of a font object from a file.
     pub fn load_requested_data(
         path: impl AsRef<Path>,
-        request: impl Borrow<DataRequest>,
+        request: &DataRequest,
     ) -> Result<Font, Error> {
-        Self::load_impl(path.as_ref(), request.borrow())
+        Self::load_impl(path.as_ref(), request)
     }
 
     fn load_impl(path: &Path, request: &DataRequest) -> Result<Font, Error> {
@@ -234,10 +234,10 @@ impl Font {
     pub fn save_with_options(
         &self,
         path: impl AsRef<Path>,
-        options: impl Borrow<WriteOptions>,
+        options: &WriteOptions,
     ) -> Result<(), Error> {
         let path = path.as_ref();
-        self.save_impl(path, options.borrow())
+        self.save_impl(path, options)
     }
 
     fn save_impl(&self, path: &Path, options: &WriteOptions) -> Result<(), Error> {
@@ -553,18 +553,6 @@ mod tests {
     #[test]
     fn data_request() {
         let path = "testdata/MutatorSansLightWide.ufo";
-        let font_obj = Font::load_requested_data(path, DataRequest::none()).unwrap();
-        assert_eq!(font_obj.iter_layers().count(), 1);
-        assert!(font_obj.layers.default_layer().is_empty());
-        assert_eq!(font_obj.lib, Plist::new());
-        assert!(font_obj.groups.is_empty());
-        assert!(font_obj.kerning.is_empty());
-        assert!(font_obj.features.is_empty());
-    }
-
-    #[test]
-    fn data_request_reference_parameter() {
-        let path = "testdata/MutatorSansLightWide.ufo";
         let font_obj = Font::load_requested_data(path, &DataRequest::none()).unwrap();
         assert_eq!(font_obj.iter_layers().count(), 1);
         assert!(font_obj.layers.default_layer().is_empty());
@@ -681,15 +669,7 @@ mod tests {
     }
 
     #[test]
-    fn save_with_options_owned_wo_parameter() -> Result<(), Error> {
-        let opt = WriteOptions::default();
-        let ufo = Font::default();
-        let tmp = TempDir::new("test")?;
-        ufo.save_with_options(tmp, opt)
-    }
-
-    #[test]
-    fn save_with_options_reference_wo_parameter() -> Result<(), Error> {
+    fn save_with_options_with_writeoptions_parameter() -> Result<(), Error> {
         let opt = WriteOptions::default();
         let ufo = Font::default();
         let tmp = TempDir::new("test")?;

--- a/src/font.rs
+++ b/src/font.rs
@@ -234,10 +234,10 @@ impl Font {
     pub fn save_with_options(
         &self,
         path: impl AsRef<Path>,
-        options: &WriteOptions,
+        options: impl Borrow<WriteOptions>,
     ) -> Result<(), Error> {
         let path = path.as_ref();
-        self.save_impl(path, options)
+        self.save_impl(path, options.borrow())
     }
 
     fn save_impl(&self, path: &Path, options: &WriteOptions) -> Result<(), Error> {
@@ -678,5 +678,21 @@ mod tests {
                 Token::StructEnd,
             ],
         );
+    }
+
+    #[test]
+    fn save_with_options_owned_wo_parameter() -> Result<(), Error> {
+        let opt = WriteOptions::default();
+        let ufo = Font::default();
+        let tmp = TempDir::new("test")?;
+        ufo.save_with_options(tmp, opt)
+    }
+
+    #[test]
+    fn save_with_options_reference_wo_parameter() -> Result<(), Error> {
+        let opt = WriteOptions::default();
+        let ufo = Font::default();
+        let tmp = TempDir::new("test")?;
+        ufo.save_with_options(tmp, &opt)
     }
 }


### PR DESCRIPTION
Closes #200 

This PR refactors:

- the read and write configuration builder approaches to always return an owned configuration type across all builder methods
- the load and save methods where they are used to accept a reference parameter (always borrows)

The new approaches look like this:

### Configured Read

```rust
let datareq = DataRequest::default().layers(false).kerning(false);

let ufo = Font::load_requested_data("path/to/font.ufo", &datareq).expect("failed to load");
```

### Configured Write

```rust
let spaces = WriteOptions::default().whitespace("  ");

ufo.save_with_options("path/to/out-font3.ufo", &spaces);
```