### PR TITLE
Error tweaks

### DIFF
--- a/examples/load_save.rs
+++ b/examples/load_save.rs
@@ -9,7 +9,7 @@ use norad::Font;
 
 static HELP: &str = "
 USAGE:
-    open_ufo PATH [OUTPATH]
+    load_save PATH [OUTPATH]
 
 If an OUTPATH is provided, the UFO will be saved after opening.
 ";

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,17 +170,6 @@ impl InvalidColorString {
     }
 }
 
-/// An error representing a failure during .glif file parsing.
-#[derive(Debug)]
-pub struct GlifError {
-    /// The glif file path.
-    pub path: Option<PathBuf>,
-    /// The buffer position.
-    pub position: usize,
-    /// The kind of error.
-    pub kind: ErrorKind,
-}
-
 /// An error when attempting to write a .glif file.
 #[derive(Debug)]
 pub struct GlifWriteError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,7 +100,7 @@ pub enum Error {
 #[derive(Debug)]
 pub enum GlifLoadError {
     /// An [`std::io::Error`].
-    IoError(IoError),
+    Io(IoError),
     /// A [`quick_xml::Error`].
     Xml(XmlError),
     /// The .glif file was malformed.
@@ -190,8 +190,8 @@ pub enum WriteError {
     /// If for some reason the implementation of that crate changes, we could
     /// be affected, although this is very unlikely.
     InternalLibWriteError,
-    /// Generic serialization error.  Wraps an [IoError].
-    IoError(IoError),
+    /// An error originating in [`std::io`].
+    Io(IoError),
     /// Plist serialization error. Wraps a [PlistError].
     Plist(PlistError),
 }
@@ -334,7 +334,7 @@ impl std::fmt::Display for GlifLoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             GlifLoadError::Xml(err) => err.fmt(f),
-            GlifLoadError::IoError(err) => err.fmt(f),
+            GlifLoadError::Io(err) => err.fmt(f),
             GlifLoadError::Parse(err) => err.fmt(f),
         }
     }
@@ -427,7 +427,7 @@ impl std::fmt::Display for ErrorKind {
 impl std::fmt::Display for WriteError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            WriteError::IoError(err) => err.fmt(f),
+            WriteError::Io(err) => err.fmt(f),
             WriteError::Xml(err) => err.fmt(f),
             WriteError::Plist(err) => err.fmt(f),
             WriteError::InternalLibWriteError => {
@@ -446,7 +446,7 @@ impl std::fmt::Display for GlifWriteError {
 impl std::error::Error for WriteError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            WriteError::IoError(inner) => Some(inner),
+            WriteError::Io(inner) => Some(inner),
             WriteError::Xml(inner) => Some(inner),
             WriteError::Plist(inner) => Some(inner),
             WriteError::InternalLibWriteError => None,
@@ -510,7 +510,7 @@ impl From<XmlError> for WriteError {
 #[doc(hidden)]
 impl From<IoError> for WriteError {
     fn from(src: IoError) -> WriteError {
-        WriteError::IoError(src)
+        WriteError::Io(src)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -460,6 +460,16 @@ impl std::error::Error for GlifWriteError {
     }
 }
 
+impl std::error::Error for GlifLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            GlifLoadError::Io(e) => Some(e),
+            GlifLoadError::Xml(e) => Some(e),
+            GlifLoadError::Parse(_) => None,
+        }
+    }
+}
+
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@ pub enum Error {
         glyph: String,
     },
     /// An error returned when there is an input/output problem during processing
-    IoError(IoError),
+    Io(IoError),
     /// A `.glif` file could not be loaded.
     GlifLoad {
         /// The path of the relevant `.glif` file.
@@ -53,14 +53,14 @@ pub enum Error {
     /// [`Glyph`]: crate::Glyph
     GlifWrite(GlifWriteError),
     /// A plist file could not be read.
-    PlistLoadError {
+    PlistLoad {
         /// The path of the relevant file.
         path: PathBuf,
         /// The underlying error.
         error: PlistError,
     },
     /// A plist file could not be written.
-    PlistWriteError {
+    PlistWrite {
         /// The path of the relevant file.
         path: PathBuf,
         /// The underlying error.
@@ -286,7 +286,7 @@ impl std::fmt::Display for Error {
             Error::MissingGlyph { layer, glyph } => {
                 write!(f, "Glyph '{}' missing from layer '{}'", glyph, layer)
             }
-            Error::IoError(e) => e.fmt(f),
+            Error::Io(e) => e.fmt(f),
             Error::InvalidColor(e) => e.fmt(f),
             Error::GlifLoad { path, inner } => {
                 write!(f, "Error reading glif '{}': '{}'", path.display(), inner)
@@ -294,10 +294,10 @@ impl std::fmt::Display for Error {
             Error::GlifWrite(GlifWriteError { name, inner }) => {
                 write!(f, "Failed to save glyph {}, error: '{}'", name, inner)
             }
-            Error::PlistLoadError { path, error } => {
+            Error::PlistLoad { path, error } => {
                 write!(f, "Error reading plist at path '{}': {}", path.display(), error)
             }
-            Error::PlistWriteError { path, error } => {
+            Error::PlistWrite { path, error } => {
                 write!(f, "Error writing plist to path '{}': {}", path.display(), error)
             }
             Error::InvalidFontInfo => write!(f, "FontInfo contains invalid data"),
@@ -463,8 +463,8 @@ impl std::error::Error for GlifWriteError {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Error::IoError(inner) => Some(inner),
-            Error::PlistLoadError { error, .. } => Some(error),
+            Error::Io(inner) => Some(inner),
+            Error::PlistLoad { error, .. } => Some(error),
             Error::GlifWrite(inner) => Some(&inner.inner),
             _ => None,
         }
@@ -496,7 +496,7 @@ impl From<GlifWriteError> for Error {
 #[doc(hidden)]
 impl From<IoError> for Error {
     fn from(src: IoError) -> Error {
-        Error::IoError(src)
+        Error::Io(src)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,8 +41,6 @@ pub enum Error {
     },
     /// An error returned when there is an input/output problem during processing
     IoError(IoError),
-    /// An error returned when there is an XML parsing problem.
-    ParseError(XmlError),
     /// A `.glif` file could not be loaded.
     GlifLoad {
         /// The path of the relevant `.glif` file.
@@ -289,7 +287,6 @@ impl std::fmt::Display for Error {
                 write!(f, "Glyph '{}' missing from layer '{}'", glyph, layer)
             }
             Error::IoError(e) => e.fmt(f),
-            Error::ParseError(e) => e.fmt(f),
             Error::InvalidColor(e) => e.fmt(f),
             Error::GlifLoad { path, inner } => {
                 write!(f, "Error reading glif '{}': '{}'", path.display(), inner)
@@ -493,13 +490,6 @@ impl From<InvalidColorString> for Error {
 impl From<GlifWriteError> for Error {
     fn from(src: GlifWriteError) -> Error {
         Error::GlifWrite(src)
-    }
-}
-
-#[doc(hidden)]
-impl From<XmlError> for Error {
-    fn from(src: XmlError) -> Error {
-        Error::ParseError(src)
     }
 }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -202,7 +202,8 @@ impl Font {
         if !meta_path.exists() {
             return Err(Error::MissingFile(meta_path.display().to_string()));
         }
-        let mut meta: MetaInfo = plist::from_file(meta_path)?;
+        let mut meta: MetaInfo = plist::from_file(&meta_path)
+            .map_err(|error| Error::PlistLoadError { path: meta_path, error })?;
 
         let lib_path = path.join(LIB_FILE);
         let mut lib =
@@ -569,7 +570,8 @@ impl Font {
 }
 
 fn load_lib(lib_path: &Path) -> Result<plist::Dictionary, Error> {
-    plist::Value::from_file(lib_path)?
+    plist::Value::from_file(lib_path)
+        .map_err(|error| Error::PlistLoadError { path: lib_path.to_owned(), error })?
         .into_dictionary()
         .ok_or_else(|| Error::ExpectedPlistDictionary(lib_path.to_string_lossy().into_owned()))
 }
@@ -584,13 +586,15 @@ fn load_fontinfo(
 }
 
 fn load_groups(groups_path: &Path) -> Result<Groups, Error> {
-    let groups: Groups = plist::from_file(groups_path)?;
+    let groups: Groups = plist::from_file(groups_path)
+        .map_err(|error| Error::PlistLoadError { path: groups_path.to_owned(), error })?;
     validate_groups(&groups).map_err(Error::InvalidGroups)?;
     Ok(groups)
 }
 
 fn load_kerning(kerning_path: &Path) -> Result<Kerning, Error> {
-    let kerning: Kerning = plist::from_file(kerning_path)?;
+    let kerning: Kerning = plist::from_file(kerning_path)
+        .map_err(|error| Error::PlistLoadError { path: kerning_path.to_owned(), error })?;
     Ok(kerning)
 }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -203,7 +203,7 @@ impl Font {
             return Err(Error::MissingFile(meta_path.display().to_string()));
         }
         let mut meta: MetaInfo = plist::from_file(&meta_path)
-            .map_err(|error| Error::PlistLoadError { path: meta_path, error })?;
+            .map_err(|error| Error::PlistLoad { path: meta_path, error })?;
 
         let lib_path = path.join(LIB_FILE);
         let mut lib =
@@ -571,7 +571,7 @@ impl Font {
 
 fn load_lib(lib_path: &Path) -> Result<plist::Dictionary, Error> {
     plist::Value::from_file(lib_path)
-        .map_err(|error| Error::PlistLoadError { path: lib_path.to_owned(), error })?
+        .map_err(|error| Error::PlistLoad { path: lib_path.to_owned(), error })?
         .into_dictionary()
         .ok_or_else(|| Error::ExpectedPlistDictionary(lib_path.to_string_lossy().into_owned()))
 }
@@ -587,14 +587,14 @@ fn load_fontinfo(
 
 fn load_groups(groups_path: &Path) -> Result<Groups, Error> {
     let groups: Groups = plist::from_file(groups_path)
-        .map_err(|error| Error::PlistLoadError { path: groups_path.to_owned(), error })?;
+        .map_err(|error| Error::PlistLoad { path: groups_path.to_owned(), error })?;
     validate_groups(&groups).map_err(Error::InvalidGroups)?;
     Ok(groups)
 }
 
 fn load_kerning(kerning_path: &Path) -> Result<Kerning, Error> {
     let kerning: Kerning = plist::from_file(kerning_path)
-        .map_err(|error| Error::PlistLoadError { path: kerning_path.to_owned(), error })?;
+        .map_err(|error| Error::PlistLoad { path: kerning_path.to_owned(), error })?;
     Ok(kerning)
 }
 

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -464,14 +464,14 @@ impl FontInfo {
         match format_version {
             FormatVersion::V3 => {
                 let mut fontinfo: FontInfo = plist::from_file(path)
-                    .map_err(|error| Error::PlistLoadError { path: path.to_owned(), error })?;
+                    .map_err(|error| Error::PlistLoad { path: path.to_owned(), error })?;
                 fontinfo.validate()?;
                 fontinfo.load_object_libs(lib)?;
                 Ok(fontinfo)
             }
             FormatVersion::V2 => {
                 let fontinfo_v2: FontInfoV2 = plist::from_file(path)
-                    .map_err(|error| Error::PlistLoadError { path: path.to_owned(), error })?;
+                    .map_err(|error| Error::PlistLoad { path: path.to_owned(), error })?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v2.ascender,
                     cap_height: fontinfo_v2.capHeight,
@@ -626,7 +626,7 @@ impl FontInfo {
             }
             FormatVersion::V1 => {
                 let fontinfo_v1: FontInfoV1 = plist::from_file(path)
-                    .map_err(|error| Error::PlistLoadError { path: path.to_owned(), error })?;
+                    .map_err(|error| Error::PlistLoad { path: path.to_owned(), error })?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v1.ascender,
                     cap_height: fontinfo_v1.capHeight,

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -460,15 +460,18 @@ impl FontInfo {
         format_version: FormatVersion,
         lib: &mut Plist,
     ) -> Result<Self, Error> {
+        let path = path.as_ref();
         match format_version {
             FormatVersion::V3 => {
-                let mut fontinfo: FontInfo = plist::from_file(path)?;
+                let mut fontinfo: FontInfo = plist::from_file(path)
+                    .map_err(|error| Error::PlistLoadError { path: path.to_owned(), error })?;
                 fontinfo.validate()?;
                 fontinfo.load_object_libs(lib)?;
                 Ok(fontinfo)
             }
             FormatVersion::V2 => {
-                let fontinfo_v2: FontInfoV2 = plist::from_file(path)?;
+                let fontinfo_v2: FontInfoV2 = plist::from_file(path)
+                    .map_err(|error| Error::PlistLoadError { path: path.to_owned(), error })?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v2.ascender,
                     cap_height: fontinfo_v2.capHeight,
@@ -622,7 +625,8 @@ impl FontInfo {
                 Ok(fontinfo)
             }
             FormatVersion::V1 => {
-                let fontinfo_v1: FontInfoV1 = plist::from_file(path)?;
+                let fontinfo_v1: FontInfoV1 = plist::from_file(path)
+                    .map_err(|error| Error::PlistLoadError { path: path.to_owned(), error })?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v1.ascender,
                     cap_height: fontinfo_v1.capHeight,

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -94,7 +94,8 @@ impl Glyph {
         }
 
         let data = self.encode_xml_with_options(opts)?;
-        std::fs::write(path, &data)?;
+        std::fs::write(path, &data)
+            .map_err(|inner| Error::UfoWrite { path: path.into(), inner })?;
         Ok(())
     }
 

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -74,7 +74,7 @@ impl Glyph {
     /// occurs multiple times (such as in components or in different layers).
     pub fn load_with_names(path: &Path, names: &NameList) -> Result<Self, GlifLoadError> {
         std::fs::read(path)
-            .map_err(GlifLoadError::IoError)
+            .map_err(GlifLoadError::Io)
             .and_then(|data| parse::GlifParser::from_xml(&data, Some(names)))
     }
 

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -6,27 +6,19 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use super::*;
-use crate::error::{ErrorKind, GlifErrorInternal};
+use crate::error::{ErrorKind, GlifLoadError};
 use crate::glyph::builder::{GlyphBuilder, Outline, OutlineBuilder};
 use crate::names::NameList;
 
 use quick_xml::{
     events::{BytesStart, Event},
-    Reader,
+    Error as XmlError, Reader,
 };
 
 #[cfg(test)]
-pub(crate) fn parse_glyph(xml: &[u8]) -> Result<Glyph, GlifErrorInternal> {
+pub(crate) fn parse_glyph(xml: &[u8]) -> Result<Glyph, GlifLoadError> {
     GlifParser::from_xml(xml, None)
 }
-
-macro_rules! err {
-    ($r:expr, $errtype:expr) => {
-        GlifErrorInternal::Spec { kind: $errtype, position: $r.buffer_position() }
-    };
-}
-
-type Error = GlifErrorInternal;
 
 pub(crate) struct GlifParser<'names> {
     builder: GlyphBuilder,
@@ -35,14 +27,17 @@ pub(crate) struct GlifParser<'names> {
 }
 
 impl<'names> GlifParser<'names> {
-    pub(crate) fn from_xml(xml: &[u8], names: Option<&'names NameList>) -> Result<Glyph, Error> {
+    pub(crate) fn from_xml(
+        xml: &[u8],
+        names: Option<&'names NameList>,
+    ) -> Result<Glyph, GlifLoadError> {
         let mut reader = Reader::from_reader(xml);
         let mut buf = Vec::new();
         reader.trim_text(true);
 
-        let builder = start(&mut reader, &mut buf)?;
-        let this = GlifParser { builder, names };
-        this.parse_body(&mut reader, xml, &mut buf)
+        start(&mut reader, &mut buf).and_then(|builder| {
+            GlifParser { builder, names }.parse_body(&mut reader, xml, &mut buf)
+        })
     }
 
     fn parse_body(
@@ -50,7 +45,7 @@ impl<'names> GlifParser<'names> {
         reader: &mut Reader<&[u8]>,
         raw_xml: &[u8],
         buf: &mut Vec<u8>,
-    ) -> Result<Glyph, Error> {
+    ) -> Result<Glyph, GlifLoadError> {
         loop {
             match reader.read_event(buf)? {
                 // outline, lib and note are expected to be start element tags.
@@ -60,7 +55,7 @@ impl<'names> GlifParser<'names> {
                         "outline" => self.parse_outline(reader, buf)?,
                         "lib" => self.parse_lib(reader, raw_xml, buf)?, // do this at some point?
                         "note" => self.parse_note(reader, buf)?,
-                        _other => return Err(err!(reader, ErrorKind::UnexpectedTag)),
+                        _other => return Err(ErrorKind::UnexpectedTag.into()),
                     }
                 }
                 // The rest are expected to be empty element tags (exception: outline) with attributes.
@@ -69,26 +64,23 @@ impl<'names> GlifParser<'names> {
                     match tag_name.borrow() {
                         "outline" => {
                             // ufoLib parses `<outline/>` as an empty outline.
-                            self.builder
-                                .outline(Outline::default(), HashSet::new())
-                                .map_err(|e| err!(reader, e))?;
+                            self.builder.outline(Outline::default(), HashSet::new())?;
                         }
                         "advance" => self.parse_advance(reader, start)?,
                         "unicode" => self.parse_unicode(reader, start)?,
                         "anchor" => self.parse_anchor(reader, start)?,
                         "guideline" => self.parse_guideline(reader, start)?,
                         "image" => self.parse_image(reader, start)?,
-                        _other => return Err(err!(reader, ErrorKind::UnexpectedTag)),
+                        _other => return Err(ErrorKind::UnexpectedTag.into()),
                     }
                 }
                 Event::End(ref end) if end.name() == b"glyph" => break,
-                _other => return Err(err!(reader, ErrorKind::MissingCloseTag)),
+                _other => return Err(ErrorKind::MissingCloseTag.into()),
             }
         }
 
-        let mut glyph = self.builder.finish().map_err(|e| err!(reader, e))?;
-        // FIXME: Error returns the end of the byte stream as the location, which is misleading.
-        glyph.load_object_libs().map_err(|e| err!(reader, e))?;
+        let mut glyph = self.builder.finish()?;
+        glyph.load_object_libs()?;
 
         Ok(glyph)
     }
@@ -97,7 +89,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &mut Reader<&[u8]>,
         buf: &mut Vec<u8>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let mut outline_builder = OutlineBuilder::new();
 
         loop {
@@ -109,7 +101,7 @@ impl<'names> GlifParser<'names> {
                         "contour" => {
                             self.parse_contour(start, reader, &mut new_buf, &mut outline_builder)?
                         }
-                        _other => return Err(err!(reader, ErrorKind::UnexpectedTag)),
+                        _other => return Err(ErrorKind::UnexpectedTag.into()),
                     }
                 }
                 Event::Empty(start) => {
@@ -119,17 +111,17 @@ impl<'names> GlifParser<'names> {
                         // https://github.com/unified-font-object/ufo-spec/issues/150
                         "contour" => (),
                         "component" => self.parse_component(reader, start, &mut outline_builder)?,
-                        _other => return Err(err!(reader, ErrorKind::UnexpectedTag)),
+                        _other => return Err(ErrorKind::UnexpectedTag.into()),
                     }
                 }
                 Event::End(ref end) if end.name() == b"outline" => break,
-                Event::Eof => return Err(err!(reader, ErrorKind::UnexpectedEof)),
-                _other => return Err(err!(reader, ErrorKind::UnexpectedElement)),
+                Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
+                _other => return Err(ErrorKind::UnexpectedElement.into()),
             }
         }
 
-        let (outline, identifiers) = outline_builder.finish().map_err(|e| err!(reader, e))?;
-        self.builder.outline(outline, identifiers).map_err(|e| err!(reader, e))?;
+        let (outline, identifiers) = outline_builder.finish()?;
+        self.builder.outline(outline, identifiers)?;
 
         Ok(())
     }
@@ -140,34 +132,34 @@ impl<'names> GlifParser<'names> {
         reader: &mut Reader<&[u8]>,
         buf: &mut Vec<u8>,
         outline_builder: &mut OutlineBuilder,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let mut identifier = None;
         for attr in data.attributes() {
             if self.builder.get_format() == &GlifVersion::V1 {
-                return Err(err!(reader, ErrorKind::UnexpectedAttribute));
+                return Err(ErrorKind::UnexpectedAttribute.into());
             }
             let attr = attr?;
             match attr.key {
                 b"identifier" => {
                     let ident = attr.unescape_and_decode_value(reader)?;
-                    identifier = Some(Identifier::new(ident).map_err(|kind| err!(reader, kind))?);
+                    identifier = Some(Identifier::new(ident)?);
                 }
-                _other => return Err(err!(reader, ErrorKind::UnexpectedAttribute)),
+                _other => return Err(ErrorKind::UnexpectedAttribute.into()),
             }
         }
 
-        outline_builder.begin_path(identifier).map_err(|e| err!(reader, e))?;
+        outline_builder.begin_path(identifier)?;
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"contour" => break,
                 Event::Empty(ref start) if start.name() == b"point" => {
                     self.parse_point(reader, start, outline_builder)?;
                 }
-                Event::Eof => return Err(err!(reader, ErrorKind::UnexpectedEof)),
-                _other => return Err(err!(reader, ErrorKind::UnexpectedElement)),
+                Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
+                _other => return Err(ErrorKind::UnexpectedElement.into()),
             }
         }
-        outline_builder.end_path().map_err(|e| err!(reader, e))?;
+        outline_builder.end_path()?;
 
         Ok(())
     }
@@ -177,7 +169,7 @@ impl<'names> GlifParser<'names> {
         reader: &mut Reader<&[u8]>,
         start: BytesStart,
         outline_builder: &mut OutlineBuilder,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let mut base: Option<GlyphName> = None;
         let mut identifier: Option<Identifier> = None;
         let mut transform = AffineTransform::default();
@@ -186,15 +178,14 @@ impl<'names> GlifParser<'names> {
             let attr = attr?;
             let value = attr.unescaped_value()?;
             let value = reader.decode(&value)?;
-            let pos = reader.buffer_position();
             let kind = ErrorKind::BadNumber;
             match attr.key {
-                b"xScale" => transform.x_scale = value.parse().map_err(|_| (kind, pos))?,
-                b"xyScale" => transform.xy_scale = value.parse().map_err(|_| (kind, pos))?,
-                b"yxScale" => transform.yx_scale = value.parse().map_err(|_| (kind, pos))?,
-                b"yScale" => transform.y_scale = value.parse().map_err(|_| (kind, pos))?,
-                b"xOffset" => transform.x_offset = value.parse().map_err(|_| (kind, pos))?,
-                b"yOffset" => transform.y_offset = value.parse().map_err(|_| (kind, pos))?,
+                b"xScale" => transform.x_scale = value.parse().map_err(|_| kind)?,
+                b"xyScale" => transform.xy_scale = value.parse().map_err(|_| kind)?,
+                b"yxScale" => transform.yx_scale = value.parse().map_err(|_| kind)?,
+                b"yScale" => transform.y_scale = value.parse().map_err(|_| kind)?,
+                b"xOffset" => transform.x_offset = value.parse().map_err(|_| kind)?,
+                b"yOffset" => transform.y_offset = value.parse().map_err(|_| kind)?,
                 b"base" => {
                     let name: Arc<str> = value.into();
                     let name = match self.names.as_ref() {
@@ -204,19 +195,17 @@ impl<'names> GlifParser<'names> {
                     base = Some(name);
                 }
                 b"identifier" => {
-                    identifier = Some(value.parse().map_err(|kind| err!(reader, kind))?);
+                    identifier = Some(value.parse()?);
                 }
-                _other => return Err(err!(reader, ErrorKind::UnexpectedComponentField)),
+                _other => return Err(ErrorKind::UnexpectedComponentField.into()),
             }
         }
 
         if base.is_none() {
-            return Err(err!(reader, ErrorKind::BadComponent));
+            return Err(ErrorKind::BadComponent.into());
         }
 
-        outline_builder
-            .add_component(base.unwrap(), transform, identifier)
-            .map_err(|e| err!(reader, e))?;
+        outline_builder.add_component(base.unwrap(), transform, identifier)?;
         Ok(())
     }
 
@@ -225,13 +214,13 @@ impl<'names> GlifParser<'names> {
         reader: &mut Reader<&[u8]>,
         raw_xml: &[u8],
         buf: &mut Vec<u8>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let start = reader.buffer_position();
         let mut end = start;
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"lib" => break,
-                Event::Eof => return Err(err!(reader, ErrorKind::UnexpectedEof)),
+                Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
                 _other => end = reader.buffer_position(),
             }
         }
@@ -240,21 +229,23 @@ impl<'names> GlifParser<'names> {
         let dict = plist::Value::from_reader_xml(plist_slice)
             .ok()
             .and_then(plist::Value::into_dictionary)
-            .ok_or_else(|| err!(reader, ErrorKind::BadLib))?;
-        self.builder.lib(dict).map_err(|e| err!(reader, e))?;
+            .ok_or(ErrorKind::BadLib)?;
+        self.builder.lib(dict)?;
         Ok(())
     }
 
-    fn parse_note(&mut self, reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<(), Error> {
+    fn parse_note(
+        &mut self,
+        reader: &mut Reader<&[u8]>,
+        buf: &mut Vec<u8>,
+    ) -> Result<(), GlifLoadError> {
         loop {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"note" => break,
                 Event::Text(text) => {
-                    self.builder
-                        .note(text.unescape_and_decode(reader)?)
-                        .map_err(|e| err!(reader, e))?;
+                    self.builder.note(text.unescape_and_decode(reader)?)?;
                 }
-                Event::Eof => return Err(err!(reader, ErrorKind::UnexpectedEof)),
+                Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
                 _other => (),
             }
         }
@@ -266,7 +257,7 @@ impl<'names> GlifParser<'names> {
         reader: &Reader<&[u8]>,
         data: &BytesStart<'a>,
         outline_builder: &mut OutlineBuilder,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let mut name: Option<String> = None;
         let mut x: Option<f64> = None;
         let mut y: Option<f64> = None;
@@ -278,33 +269,28 @@ impl<'names> GlifParser<'names> {
             let attr = attr?;
             let value = attr.unescaped_value()?;
             let value = reader.decode(&value)?;
-            let pos = reader.buffer_position();
             match attr.key {
                 b"x" => {
-                    x = Some(value.parse().map_err(|_| (ErrorKind::BadNumber, pos))?);
+                    x = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
                 b"y" => {
-                    y = Some(value.parse().map_err(|_| (ErrorKind::BadNumber, pos))?);
+                    y = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
                 b"name" => name = Some(value.to_string()),
                 b"type" => {
-                    typ = value
-                        .parse()
-                        .map_err(|e: ErrorKind| e.to_error(reader.buffer_position()))?
+                    typ = value.parse()?;
                 }
                 b"smooth" => smooth = value == "yes",
                 b"identifier" => {
-                    identifier = Some(value.parse().map_err(|kind| err!(reader, kind))?);
+                    identifier = Some(value.parse()?);
                 }
-                _other => return Err(err!(reader, ErrorKind::UnexpectedPointField)),
+                _other => return Err(ErrorKind::UnexpectedPointField.into()),
             }
         }
         if x.is_none() || y.is_none() {
-            return Err(err!(reader, ErrorKind::BadPoint));
+            return Err(ErrorKind::BadPoint.into());
         }
-        outline_builder
-            .add_point((x.unwrap(), y.unwrap()), typ, smooth, name, identifier)
-            .map_err(|e| err!(reader, e))?;
+        outline_builder.add_point((x.unwrap(), y.unwrap()), typ, smooth, name, identifier)?;
 
         Ok(())
     }
@@ -313,7 +299,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let mut width: f64 = 0.0;
         let mut height: f64 = 0.0;
         for attr in data.attributes() {
@@ -322,22 +308,17 @@ impl<'names> GlifParser<'names> {
                 b"width" | b"height" => {
                     let value = attr.unescaped_value()?;
                     let value = reader.decode(&value)?;
-                    let value: f64 =
-                        value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?;
+                    let value: f64 = value.parse().map_err(|_| ErrorKind::BadNumber)?;
                     match attr.key {
                         b"width" => width = value,
                         b"height" => height = value,
                         _other => unreachable!(),
                     };
                 }
-                _other => return Err(err!(reader, ErrorKind::UnexpectedAttribute)),
+                _other => return Err(ErrorKind::UnexpectedAttribute.into()),
             }
         }
-        self.builder
-            .width(width)
-            .map_err(|e| err!(reader, e))?
-            .height(height)
-            .map_err(|e| err!(reader, e))?;
+        self.builder.width(width)?.height(height)?;
         Ok(())
     }
 
@@ -345,7 +326,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         for attr in data.attributes() {
             let attr = attr?;
             match attr.key {
@@ -355,10 +336,10 @@ impl<'names> GlifParser<'names> {
                     let chr = u32::from_str_radix(value, 16)
                         .map_err(|_| value.to_string())
                         .and_then(|n| char::try_from(n).map_err(|_| value.to_string()))
-                        .map_err(|_| err!(reader, ErrorKind::BadHexValue))?;
+                        .map_err(|_| ErrorKind::BadHexValue)?;
                     self.builder.unicode(chr);
                 }
-                _other => return Err(err!(reader, ErrorKind::UnexpectedAttribute)),
+                _other => return Err(ErrorKind::UnexpectedAttribute.into()),
             }
         }
         Ok(())
@@ -368,7 +349,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let mut x: Option<f64> = None;
         let mut y: Option<f64> = None;
         let mut name: Option<String> = None;
@@ -381,28 +362,24 @@ impl<'names> GlifParser<'names> {
             let value = reader.decode(&value)?;
             match attr.key {
                 b"x" => {
-                    x = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?);
+                    x = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
                 b"y" => {
-                    y = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?);
+                    y = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
                 b"name" => name = Some(value.to_string()),
-                b"color" => {
-                    color = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadColor))?)
-                }
+                b"color" => color = Some(value.parse().map_err(|_| ErrorKind::BadColor)?),
                 b"identifier" => {
-                    identifier = Some(value.parse().map_err(|kind| err!(reader, kind))?);
+                    identifier = Some(value.parse()?);
                 }
-                _other => return Err(err!(reader, ErrorKind::UnexpectedAnchorField)),
+                _other => return Err(ErrorKind::UnexpectedAnchorField.into()),
             }
         }
 
         if x.is_none() || y.is_none() {
-            return Err(err!(reader, ErrorKind::BadAnchor));
+            return Err(ErrorKind::BadAnchor.into());
         }
-        self.builder
-            .anchor(Anchor::new(x.unwrap(), y.unwrap(), name, color, identifier, None))
-            .map_err(|e| err!(reader, e))?;
+        self.builder.anchor(Anchor::new(x.unwrap(), y.unwrap(), name, color, identifier, None))?;
         Ok(())
     }
 
@@ -410,7 +387,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let mut x: Option<f64> = None;
         let mut y: Option<f64> = None;
         let mut angle: Option<f64> = None;
@@ -424,22 +401,20 @@ impl<'names> GlifParser<'names> {
             let value = reader.decode(&value)?;
             match attr.key {
                 b"x" => {
-                    x = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?);
+                    x = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
                 b"y" => {
-                    y = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?);
+                    y = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
                 b"angle" => {
-                    angle = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadNumber))?);
+                    angle = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
                 b"name" => name = Some(value.to_string()),
-                b"color" => {
-                    color = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadColor))?)
-                }
+                b"color" => color = Some(value.parse().map_err(|_| ErrorKind::BadColor)?),
                 b"identifier" => {
-                    identifier = Some(value.parse().map_err(|kind| err!(reader, kind))?);
+                    identifier = Some(value.parse()?);
                 }
-                _other => return Err(err!(reader, ErrorKind::UnexpectedGuidelineField)),
+                _other => return Err(ErrorKind::UnexpectedGuidelineField.into()),
             }
         }
 
@@ -448,15 +423,13 @@ impl<'names> GlifParser<'names> {
             (None, Some(y), None) => Line::Horizontal(y),
             (Some(x), Some(y), Some(degrees)) => {
                 if !(0.0..=360.0).contains(&degrees) {
-                    return Err(err!(reader, ErrorKind::BadGuideline));
+                    return Err(ErrorKind::BadGuideline.into());
                 }
                 Line::Angle { x, y, degrees }
             }
-            _other => return Err(err!(reader, ErrorKind::BadGuideline)),
+            _other => return Err(ErrorKind::BadGuideline.into()),
         };
-        self.builder
-            .guideline(Guideline::new(line, name, color, identifier, None))
-            .map_err(|e| err!(reader, e))?;
+        self.builder.guideline(Guideline::new(line, name, color, identifier, None))?;
 
         Ok(())
     }
@@ -465,7 +438,7 @@ impl<'names> GlifParser<'names> {
         &mut self,
         reader: &Reader<&[u8]>,
         data: BytesStart<'a>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), GlifLoadError> {
         let mut filename: Option<PathBuf> = None;
         let mut color: Option<Color> = None;
         let mut transform = AffineTransform::default();
@@ -474,36 +447,31 @@ impl<'names> GlifParser<'names> {
             let attr = attr?;
             let value = attr.unescaped_value()?;
             let value = reader.decode(&value)?;
-            let pos = reader.buffer_position();
             let kind = ErrorKind::BadNumber;
             match attr.key {
-                b"xScale" => transform.x_scale = value.parse().map_err(|_| (kind, pos))?,
-                b"xyScale" => transform.xy_scale = value.parse().map_err(|_| (kind, pos))?,
-                b"yxScale" => transform.yx_scale = value.parse().map_err(|_| (kind, pos))?,
-                b"yScale" => transform.y_scale = value.parse().map_err(|_| (kind, pos))?,
-                b"xOffset" => transform.x_offset = value.parse().map_err(|_| (kind, pos))?,
-                b"yOffset" => transform.y_offset = value.parse().map_err(|_| (kind, pos))?,
-                b"color" => {
-                    color = Some(value.parse().map_err(|_| err!(reader, ErrorKind::BadColor))?)
-                }
+                b"xScale" => transform.x_scale = value.parse().map_err(|_| kind)?,
+                b"xyScale" => transform.xy_scale = value.parse().map_err(|_| kind)?,
+                b"yxScale" => transform.yx_scale = value.parse().map_err(|_| kind)?,
+                b"yScale" => transform.y_scale = value.parse().map_err(|_| kind)?,
+                b"xOffset" => transform.x_offset = value.parse().map_err(|_| kind)?,
+                b"yOffset" => transform.y_offset = value.parse().map_err(|_| kind)?,
+                b"color" => color = Some(value.parse().map_err(|_| ErrorKind::BadColor)?),
                 b"fileName" => filename = Some(PathBuf::from(value.to_string())),
-                _other => return Err(err!(reader, ErrorKind::UnexpectedImageField)),
+                _other => return Err(ErrorKind::UnexpectedImageField.into()),
             }
         }
 
         if filename.is_none() {
-            return Err(err!(reader, ErrorKind::BadImage));
+            return Err(ErrorKind::BadImage.into());
         }
 
-        self.builder
-            .image(Image { file_name: filename.unwrap(), color, transform })
-            .map_err(|e| err!(reader, e))?;
+        self.builder.image(Image { file_name: filename.unwrap(), color, transform })?;
 
         Ok(())
     }
 }
 
-fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<GlyphBuilder, Error> {
+fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<GlyphBuilder, GlifLoadError> {
     loop {
         match reader.read_event(buf)? {
             Event::Comment(_) => (),
@@ -511,6 +479,7 @@ fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<GlyphBuilder, 
             Event::Start(ref start) if start.name() == b"glyph" => {
                 let mut name = String::new();
                 let mut format: Option<GlifVersion> = None;
+                //let mut pos
                 for attr in start.attributes() {
                     let attr = attr?;
                     // XXX: support `formatMinor`
@@ -521,21 +490,18 @@ fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<GlyphBuilder, 
                         b"format" => {
                             let value = attr.unescaped_value()?;
                             let value = reader.decode(&value)?;
-                            format =
-                                Some(value.parse().map_err(|e: ErrorKind| {
-                                    e.to_error(reader.buffer_position())
-                                })?);
+                            format = Some(value.parse()?);
                         }
-                        _other => return Err(err!(reader, ErrorKind::UnexpectedAttribute)),
+                        _other => return Err(ErrorKind::UnexpectedAttribute.into()),
                     }
                 }
                 if !name.is_empty() && format.is_some() {
                     return Ok(GlyphBuilder::new(name, format.take().unwrap()));
                 } else {
-                    return Err(err!(reader, ErrorKind::WrongFirstElement));
+                    return Err(ErrorKind::WrongFirstElement.into());
                 }
             }
-            _other => return Err(err!(reader, ErrorKind::WrongFirstElement)),
+            _other => return Err(ErrorKind::WrongFirstElement.into()),
         }
     }
 }
@@ -548,5 +514,16 @@ impl FromStr for GlifVersion {
             "2" => Ok(GlifVersion::V2),
             _other => Err(ErrorKind::UnsupportedGlifVersion),
         }
+    }
+}
+
+impl From<ErrorKind> for GlifLoadError {
+    fn from(src: ErrorKind) -> GlifLoadError {
+        GlifLoadError::Parse(src)
+    }
+}
+impl From<XmlError> for GlifLoadError {
+    fn from(src: XmlError) -> GlifLoadError {
+        GlifLoadError::Xml(src)
     }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -346,7 +346,7 @@ impl Layer {
     ///
     /// The path should not exist.
     pub fn save_with_options(&self, path: &Path, opts: &WriteOptions) -> Result<(), Error> {
-        fs::create_dir(&path)?;
+        fs::create_dir(&path).map_err(|inner| Error::UfoWrite { path: path.into(), inner })?;
         crate::write::write_xml_to_file(&path.join(CONTENTS_FILE), &self.contents, opts)?;
 
         self.layerinfo_to_file_if_needed(path, opts)?;

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -403,7 +403,7 @@ impl Layer {
         GlyphName: Borrow<K>,
         K: Ord + ?Sized,
     {
-        self.glyphs.get_mut(glyph).map(|g| Arc::make_mut(g))
+        self.glyphs.get_mut(glyph).map(Arc::make_mut)
     }
 
     /// Returns `true` if this layer contains a glyph with this `name`.

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -45,7 +45,7 @@ impl LayerSet {
         let layer_contents_path = base_dir.join(LAYER_CONTENTS_FILE);
         let to_load: Vec<(LayerName, PathBuf)> = if layer_contents_path.exists() {
             plist::from_file(&layer_contents_path)
-                .map_err(|error| Error::PlistLoadError { path: layer_contents_path, error })?
+                .map_err(|error| Error::PlistLoad { path: layer_contents_path, error })?
         } else {
             vec![(Arc::from(DEFAULT_LAYER_NAME), PathBuf::from(DEFAULT_GLYPHS_DIRNAME))]
         };
@@ -248,7 +248,7 @@ impl Layer {
         // these keys are never used; a future optimization would be to skip the
         // names and deserialize to a vec; that would not be a one-liner, though.
         let contents: BTreeMap<GlyphName, PathBuf> = plist::from_file(&contents_path)
-            .map_err(|error| Error::PlistLoadError { path: contents_path, error })?;
+            .map_err(|error| Error::PlistLoad { path: contents_path, error })?;
 
         #[cfg(feature = "rayon")]
         let iter = contents.par_iter();
@@ -286,7 +286,7 @@ impl Layer {
     // Ser/de must be done manually...
     fn layerinfo_from_file(path: &Path) -> Result<(Option<Color>, Plist), Error> {
         let mut info_content = plist::Value::from_file(path)
-            .map_err(|error| Error::PlistLoadError { path: path.to_owned(), error })?
+            .map_err(|error| Error::PlistLoad { path: path.to_owned(), error })?
             .into_dictionary()
             .ok_or_else(|| Error::ExpectedPlistDictionary(path.to_string_lossy().into_owned()))?;
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -258,12 +258,13 @@ impl Layer {
                 let name = names.get(name);
                 let glyph_path = path.join(glyph_path);
 
-                Glyph::load_with_names(&glyph_path, names).map(|mut glyph| {
-                    glyph.name = name.clone();
-                    (name, Arc::new(glyph))
-                })
+                Glyph::load_with_names(&glyph_path, names)
+                    .map(|mut glyph| {
+                        glyph.name = name.clone();
+                        (name, Arc::new(glyph))
+                    })
+                    .map_err(|e| Error::GlifLoad { path: glyph_path, inner: e })
             })
-            //FIXME: come up with a better way of reporting errors than just aborting at first failure
             .collect::<Result<_, _>>()?;
 
         let layerinfo_path = path.join(LAYER_INFO_FILE);
@@ -439,7 +440,7 @@ impl Layer {
     /// be replaced.
     ///
     /// Returns an error if `overwrite` is false but a glyph with the new
-    /// name exists, or if no glyph with the old name exists.
+    /// name exists, or if no glyph with the old name exists
     pub fn rename_glyph(&mut self, old: &str, new: &str, overwrite: bool) -> Result<(), Error> {
         if !overwrite && self.glyphs.contains_key(new) {
             Err(Error::DuplicateGlyph { glyph: new.into(), layer: self.name.to_string() })

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -44,7 +44,8 @@ impl LayerSet {
     pub fn load(base_dir: &Path, glyph_names: &NameList) -> Result<LayerSet, Error> {
         let layer_contents_path = base_dir.join(LAYER_CONTENTS_FILE);
         let to_load: Vec<(LayerName, PathBuf)> = if layer_contents_path.exists() {
-            plist::from_file(layer_contents_path)?
+            plist::from_file(&layer_contents_path)
+                .map_err(|error| Error::PlistLoadError { path: layer_contents_path, error })?
         } else {
             vec![(Arc::from(DEFAULT_LAYER_NAME), PathBuf::from(DEFAULT_GLYPHS_DIRNAME))]
         };
@@ -246,7 +247,8 @@ impl Layer {
         }
         // these keys are never used; a future optimization would be to skip the
         // names and deserialize to a vec; that would not be a one-liner, though.
-        let contents: BTreeMap<GlyphName, PathBuf> = plist::from_file(contents_path)?;
+        let contents: BTreeMap<GlyphName, PathBuf> = plist::from_file(&contents_path)
+            .map_err(|error| Error::PlistLoadError { path: contents_path, error })?;
 
         #[cfg(feature = "rayon")]
         let iter = contents.par_iter();
@@ -284,7 +286,7 @@ impl Layer {
     // Ser/de must be done manually...
     fn layerinfo_from_file(path: &Path) -> Result<(Option<Color>, Plist), Error> {
         let mut info_content = plist::Value::from_file(path)
-            .map_err(Error::PlistError)?
+            .map_err(|error| Error::PlistLoadError { path: path.to_owned(), error })?
             .into_dictionary()
             .ok_or_else(|| Error::ExpectedPlistDictionary(path.to_string_lossy().into_owned()))?;
 

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -150,7 +150,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
 
     // Read lib.plist again because it is easier than pulling out the data manually.
     let lib_data: LibData = plist::from_file(lib_path)
-        .map_err(|error| Error::PlistLoadError { path: lib_path.to_owned(), error })?;
+        .map_err(|error| Error::PlistLoad { path: lib_path.to_owned(), error })?;
 
     // Convert features.
     let mut features = String::new();

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -149,7 +149,8 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     }
 
     // Read lib.plist again because it is easier than pulling out the data manually.
-    let lib_data: LibData = plist::from_file(lib_path)?;
+    let lib_data: LibData = plist::from_file(lib_path)
+        .map_err(|error| Error::PlistLoadError { path: lib_path.to_owned(), error })?;
 
     // Convert features.
     let mut features = String::new();

--- a/src/write.rs
+++ b/src/write.rs
@@ -119,7 +119,7 @@ pub fn write_plist_value_to_file(
     let writer = BufWriter::new(&mut file);
     value
         .to_writer_xml_with_options(writer, options.xml_options())
-        .map_err(|error| Error::PlistWriteError { path: path.to_owned(), error })?;
+        .map_err(|error| Error::PlistWrite { path: path.to_owned(), error })?;
     write_quote_style(&file, options)?;
     file.sync_all()?;
     Ok(())
@@ -134,7 +134,7 @@ pub fn write_xml_to_file(
     let mut file = File::create(path)?;
     let buf_writer = BufWriter::new(&mut file);
     plist::to_writer_xml_with_options(buf_writer, value, options.xml_options())
-        .map_err(|error| Error::PlistWriteError { path: path.to_owned(), error })?;
+        .map_err(|error| Error::PlistWrite { path: path.to_owned(), error })?;
     write_quote_style(&file, options)?;
     file.sync_all()?;
     Ok(())

--- a/src/write.rs
+++ b/src/write.rs
@@ -117,7 +117,9 @@ pub fn write_plist_value_to_file(
 ) -> Result<(), Error> {
     let mut file = File::create(path)?;
     let writer = BufWriter::new(&mut file);
-    value.to_writer_xml_with_options(writer, options.xml_options())?;
+    value
+        .to_writer_xml_with_options(writer, options.xml_options())
+        .map_err(|error| Error::PlistWriteError { path: path.to_owned(), error })?;
     write_quote_style(&file, options)?;
     file.sync_all()?;
     Ok(())
@@ -131,7 +133,8 @@ pub fn write_xml_to_file(
 ) -> Result<(), Error> {
     let mut file = File::create(path)?;
     let buf_writer = BufWriter::new(&mut file);
-    plist::to_writer_xml_with_options(buf_writer, value, options.xml_options())?;
+    plist::to_writer_xml_with_options(buf_writer, value, options.xml_options())
+        .map_err(|error| Error::PlistWriteError { path: path.to_owned(), error })?;
     write_quote_style(&file, options)?;
     file.sync_all()?;
     Ok(())


### PR DESCRIPTION
With this patch, we now track the path involved anytime we fail to load a `.glif` or a `.plist` file.

This also removes the position tracking for errors that occur when parsing glifs; there isn't a great way to get this information from `quick_xml`, and the information we *did* have was often inaccurate enough that it wasn't even on the correct line, which made it not very helpful for producing diagnostics.


@madig if you're interested in adding path information to other errors, I think you should be able to follow the pattern I've used here. 