### PR TITLE
Use LayerInfo struct to deserialize layerinfo.plist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 features = ["kurbo"]
 
 [dependencies]
-plist = { version =  "1.2.1", features = ["serde"] }
+plist = { version =  "1.3.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["v4"] }
 serde = { version =  "1.0", features = ["rc"] }
 serde_derive = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,8 +91,6 @@ pub enum Error {
     ///
     /// The string is the dictionary key.
     ExpectedPlistDictionary(String),
-    /// An error returned when there is an unexpected plist string.
-    ExpectedPlistString,
     /// An error returned when there is an inappropriate negative sign on a value.
     ExpectedPositiveValue,
     /// An error returned when there is a problem with kurbo contour conversion.
@@ -317,7 +315,6 @@ impl std::fmt::Display for Error {
             Error::ExpectedPlistDictionary(key) => {
                 write!(f, "Expected a Plist dictionary at '{}'", key)
             }
-            Error::ExpectedPlistString => write!(f, "Expected a Plist string."),
             Error::ExpectedPositiveValue => {
                 write!(f, "PositiveIntegerOrFloat expects a positive value.")
             }


### PR DESCRIPTION
The new plist crate can hande nested `Value`s when deserializing, so we can now cut some code and an error.

Not sure yet what to do about serialization, because we have to do some post-processing.