### PR TITLE
Rejig error hierarchy

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,32 +9,15 @@ use thiserror::Error;
 
 use crate::write::CustomSerializationError;
 
-/// Errors that occur while working with font objects.
+/// An error representing a failure to (re)name something.
 #[derive(Debug, Error)]
-#[non_exhaustive]
-pub enum Error {
-    /// An error returned when an expected layer is missing.
-    #[error("layer name '{0}' does not exist")]
-    MissingLayer(String),
-    /// An error returned when a layer is duplicated.
-    #[error("layer name '{0}' already exists")]
-    DuplicateLayer(String),
-    /// An error returned when there is a duplicate glyph.
-    #[error("glyph named '{glyph}' already exists in layer '{layer}'")]
-    DuplicateGlyph {
-        /// The layer name.
-        layer: String,
-        /// The glyph name.
-        glyph: String,
-    },
-    /// An error returned when there is a missing expected glyph
-    #[error("glyph '{glyph}' missing from layer '{layer}'")]
-    MissingGlyph {
-        /// The layer name.
-        layer: String,
-        /// The glyph name.
-        glyph: String,
-    },
+pub enum NamingError {
+    /// An error returned when an item is duplicated.
+    #[error("item '{0}' already exists")]
+    Duplicate(String),
+    /// An error returned when an expected item is missing.
+    #[error("item '{0}' does not exist")]
+    Missing(String),
 }
 
 /// An error that occurs while attempting to read a .glif file from disk.

--- a/src/error.rs
+++ b/src/error.rs
@@ -241,11 +241,11 @@ impl std::fmt::Display for FontInfoErrorKind {
             FontInfoErrorKind::InvalidOs2FamilyClass => {
                 write!(f, "openTypeOS2FamilyClass must be two numbers in the range 0-14 and 0-15, respectively")
             }
-            FontInfoErrorKind::InvalidPostscriptListLength { name: s, max_len: l, len: m } => {
+            FontInfoErrorKind::InvalidPostscriptListLength { name, max_len, len } => {
                 write!(
                     f,
                     "the Postscript field '{}' must contain at most {} items but found {}",
-                    s, l, m
+                    name, max_len, len
                 )
             }
             FontInfoErrorKind::UnknownFontStyle(s) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,12 +38,6 @@ pub enum Error {
         /// The glyph name.
         glyph: String,
     },
-    /// An error returned when there is an input problem during processing
-    #[error(transparent)]
-    FontLoad(FontLoadError),
-    /// An error returned when there is an output problem during processing
-    #[error(transparent)]
-    FontWrite(FontWriteError),
     /// An error returned when there is an inappropriate negative sign on a value.
     #[error("positiveIntegerOrFloat expects a positive value")]
     ExpectedPositiveValue,

--- a/src/error.rs
+++ b/src/error.rs
@@ -177,39 +177,70 @@ pub enum FontInfoLoadError {
 }
 
 /// An error pointing to invalid data in the font's info.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum FontInfoErrorKind {
     /// openTypeOS2Selection contained bits 0, 5 or 6.
-    #[error("openTypeOS2Selection must not contain bits 0, 5 or 6")]
     DisallowedSelectionBits,
     /// Guideline identifiers were not unique within the fontinfo.plist file.
-    #[error("guideline identifiers must be unique within the fontinfo.plist file")]
     DuplicateGuidelineIdentifiers,
     /// Found an empty WOFF element or record. If you have them, you have to fill them all in.
-    #[error("a '{0}' element must not be empty")]
     EmptyWoffAttribute(&'static str),
     /// The openTypeHeadCreated had the wrong format.
-    #[error("openTypeHeadCreated must be of format 'YYYY/MM/DD HH:MM:SS'")]
     InvalidOpenTypeHeadCreatedDate,
     /// The openTypeOS2FamilyClass had out of range values.
-    #[error("openTypeOS2FamilyClass must be two numbers in the range 0-14 and 0-15, respectively")]
     InvalidOs2FamilyClass,
     /// A Postscript data list had more elements than the specification allows.
-    #[error("the Postscript field '{0}' must contain at most {1} items but found {2}")]
     InvalidPostscriptListLength(&'static str, u8, usize),
     /// Unrecognized UFO v1 fontStyle field.
-    #[error("unrecognized fontStyle '{0}'")]
     UnknownFontStyle(i32),
     /// Unrecognized UFO v1 msCharSet field.
-    #[error("unrecognized msCharSet '{0}'")]
     UnknownMsCharSet(i32),
     /// Unrecognized openTypeOS2WidthClass.
-    #[error("unrecognized OS/2 width class '{0}'")]
     UnknownWidthClass(String),
     /// The openTypeGaspRangeRecords field was unsorted.
-    #[error("openTypeGaspRangeRecords must be sorted by their rangeMaxPPEM values")]
     UnsortedGaspEntries,
+}
+
+impl std::fmt::Display for FontInfoErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FontInfoErrorKind::DisallowedSelectionBits => {
+                write!(f, "openTypeOS2Selection must not contain bits 0, 5 or 6")
+            }
+            FontInfoErrorKind::DuplicateGuidelineIdentifiers => {
+                write!(f, "guideline identifiers must be unique within the fontinfo.plist file")
+            }
+            FontInfoErrorKind::EmptyWoffAttribute(s) => {
+                write!(f, "a '{}' element must not be empty", s)
+            }
+            FontInfoErrorKind::InvalidOpenTypeHeadCreatedDate => {
+                write!(f, "openTypeHeadCreated must be of format 'YYYY/MM/DD HH:MM:SS'")
+            }
+            FontInfoErrorKind::InvalidOs2FamilyClass => {
+                write!(f, "openTypeOS2FamilyClass must be two numbers in the range 0-14 and 0-15, respectively")
+            }
+            FontInfoErrorKind::InvalidPostscriptListLength(s, l, m) => {
+                write!(
+                    f,
+                    "the Postscript field '{}' must contain at most {} items but found {}",
+                    s, l, m
+                )
+            }
+            FontInfoErrorKind::UnknownFontStyle(s) => {
+                write!(f, "unrecognized fontStyle '{}'", s)
+            }
+            FontInfoErrorKind::UnknownMsCharSet(c) => {
+                write!(f, "unrecognized msCharSet '{}'", c)
+            }
+            FontInfoErrorKind::UnknownWidthClass(w) => {
+                write!(f, "unrecognized OS/2 width class '{}'", w)
+            }
+            FontInfoErrorKind::UnsortedGaspEntries => {
+                write!(f, "openTypeGaspRangeRecords must be sorted by their rangeMaxPPEM values")
+            }
+        }
+    }
 }
 
 /// An error representing a failure with a particular [`crate::datastore::Store`] entry.

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,10 +35,6 @@ pub enum Error {
         /// The glyph name.
         glyph: String,
     },
-    /// An error returned when there is a problem with kurbo contour conversion.
-    #[cfg(feature = "kurbo")]
-    #[error("failed to convert contour: '{0}'")]
-    ConvertContour(ErrorKind),
 }
 
 /// An error that occurs while attempting to read a .glif file from disk.
@@ -328,6 +324,19 @@ impl InvalidColorString {
 #[derive(Debug, Error)]
 #[error("expected a positive value")]
 pub struct ExpectedPositiveValue;
+
+/// An error returned when there is a problem with kurbo contour conversion.
+#[cfg(feature = "kurbo")]
+#[derive(Debug, Error)]
+#[error("failed to convert contour: '{0}'")]
+pub struct ConvertContourError(ErrorKind);
+
+#[cfg(feature = "kurbo")]
+impl ConvertContourError {
+    pub(crate) fn new(kind: ErrorKind) -> Self {
+        ConvertContourError(kind)
+    }
+}
 
 /// An error that occurs while attempting to write a UFO package to disk.
 #[derive(Debug, Error)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,9 +19,6 @@ pub enum Error {
     /// An error returned when a layer is duplicated.
     #[error("layer name '{0}' already exists")]
     DuplicateLayer(String),
-    /// An error returned when there is an invalid color definition.
-    #[error(transparent)]
-    InvalidColor(InvalidColorString),
     /// An error returned when there is a duplicate glyph.
     #[error("glyph named '{glyph}' already exists in layer '{layer}'")]
     DuplicateGlyph {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,22 +7,12 @@ use plist::Error as PlistError;
 use quick_xml::Error as XmlError;
 use thiserror::Error;
 
-use crate::GlyphName;
+use crate::write::CustomSerializationError;
 
 /// Errors that occur while working with font objects.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
-    /// An error returned when trying to save an UFO in anything less than the latest version.
-    #[error("downgrading below UFO v3 is not currently supported")]
-    DowngradeUnsupported,
-    /// An error returned when trying to save a Glyph that contains a `public.objectLibs`
-    /// lib key already (the key is automatically managed by Norad).
-    #[error("the `public.objectLibs` lib key is managed by Norad and must not be set manually")]
-    PreexistingPublicObjectLibsKey,
-    /// An error returned when there is no default layer in the UFO directory.
-    #[error("missing default ('glyphs') layer")]
-    MissingDefaultLayer,
     /// An error returned when an expected layer is missing.
     #[error("layer name '{0}' does not exist")]
     MissingLayer(String),
@@ -49,68 +39,11 @@ pub enum Error {
         glyph: String,
     },
     /// An error returned when there is an input problem during processing
-    #[error("failed to read file or directory '{path}'")]
-    UfoLoad {
-        /// The path of the relevant file.
-        path: PathBuf,
-        /// The underlying error.
-        source: IoError,
-    },
+    #[error("failed to load font")]
+    UfoLoad(#[source] UfoLoadError),
     /// An error returned when there is an output problem during processing
-    #[error("failed to write file or directory '{path}'")]
-    UfoWrite {
-        /// The path of the relevant file.
-        path: PathBuf,
-        /// The underlying error.
-        source: IoError,
-    },
-    /// A `.glif` file could not be loaded.
-    #[error("failed to read glyph file from '{path}'")]
-    GlifLoad {
-        /// The path of the relevant `.glif` file.
-        path: PathBuf,
-        /// The underlying error.
-        source: GlifLoadError,
-    },
-    /// An error that occurs when attempting to write a [`Glyph`] to disk.
-    ///
-    /// [`Glyph`]: crate::Glyph
-    #[error("failed to write out glyph '{}'", .0.name)]
-    GlifWrite(#[from] GlifWriteError),
-    /// A plist file could not be read.
-    #[error("failed to read Plist file from '{path}'")]
-    PlistLoad {
-        /// The path of the relevant file.
-        path: PathBuf,
-        /// The underlying error.
-        source: PlistError,
-    },
-    /// A plist file could not be written.
-    #[error("failed to write Plist file to '{path}'")]
-    PlistWrite {
-        /// The path of the relevant file.
-        path: PathBuf,
-        /// The underlying error.
-        source: PlistError,
-    },
-    /// An error returned when there is invalid fontinfo.plist data.
-    #[error("fontInfo contains invalid data")]
-    InvalidFontInfo,
-    /// An error returned when there is a problem during fontinfo.plist version up-conversion.
-    #[error("fontInfo contains invalid data after upconversion")]
-    FontInfoUpconversion,
-    /// An error returned when there is invalid groups.plist data.
-    #[error(transparent)]
-    InvalidGroups(#[from] GroupsValidationError),
-    /// An error returned when there is a problem during groups.plist version up-conversion.
-    #[error("upconverting UFO v1 or v2 kerning data to v3 failed")]
-    GroupsUpconversionFailure(GroupsValidationError),
-    /// An error returned when there is a problem parsing plist data into
-    /// [`plist::Dictionary`] types.
-    ///
-    /// The string is the dictionary key.
-    #[error("expected a Plist dictionary at '{0}'")]
-    ExpectedPlistDictionary(String),
+    #[error("failed to write font")]
+    UfoWrite(#[source] UfoWriteError),
     /// An error returned when there is an inappropriate negative sign on a value.
     #[error("positiveIntegerOrFloat expects a positive value")]
     ExpectedPositiveValue,
@@ -118,21 +51,11 @@ pub enum Error {
     #[cfg(feature = "kurbo")]
     #[error("failed to convert contour: '{0}'")]
     ConvertContour(ErrorKind),
-    /// An error returned when there is a missing mandatory file.
-    #[error("missing required {0} file")]
-    MissingFile(String),
-    /// An error returned when the requested UFO directory path is not present.
-    #[error("{0} directory was not found")]
-    MissingUfoDir(String),
-    /// An error returned when there is an invalid entry in an image or data store.
-    ///
-    /// This error wraps a [`StoreError`] type and provides additional path data.
-    #[error("store entry '{0}' is invalid")]
-    InvalidStoreEntry(PathBuf, #[source] StoreError),
 }
 
 /// An error that occurs while attempting to read a .glif file from disk.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum GlifLoadError {
     /// An [`std::io::Error`].
     #[error("failed to read file")]
@@ -141,8 +64,167 @@ pub enum GlifLoadError {
     #[error("failed to read or parse XML structure")]
     Xml(#[from] XmlError),
     /// The .glif file was malformed.
-    #[error("failed to parse glyph data: {0}")]
+    #[error("failed to parse glyph data")]
     Parse(#[from] ErrorKind),
+    /// The glyph lib's `public.objectLibs` value was something other than a dictionary.
+    #[error("the glyph lib's 'public.objectLibs' value must be a dictionary")]
+    PublicObjectLibsMustBeDictionary,
+    /// The entry with the given identifier within the glyph lib's `public.objectLibs` dictionary was not a dictionary.
+    #[error("the glyph lib's 'public.objectLibs' entry for the object with identifier '{0}' must be a dictionary")]
+    ObjectLibMustBeDictionary(String),
+}
+
+/// An error that occurs while attempting to read a UFO package from disk.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum UfoLoadError {
+    /// The UFO cannot be accessed.
+    #[error("cannot access UFO package")]
+    AccessingUfoDir(#[source] IoError),
+    /// The upgrade process failed to move font info data from the old lib.plist schema to the new fontinfo.plist schema.
+    #[error("failed to upgrade old lib.plist to current fontinfo.plist data: {0}")]
+    FontInfoV1Upconversion(FontInfoErrorKind),
+    /// The upgrade process failed to convert kerning groups from old to the new UFO v3 format.
+    #[error("failed to upconvert groups to the latest supported format")]
+    GroupsUpconversionFailure(#[source] GroupsValidationError),
+    /// The (kerning) groups in kerning.plist fail validation.
+    #[error("failed to load (kerning) groups")]
+    InvalidGroups(#[source] GroupsValidationError),
+    /// The lib.plist file was something other than a dictionary.
+    #[error("the lib.plist file must contain a dictionary (<dict>...</dict>)")]
+    LibFileMustBeDictionary,
+    /// Failed to load a file from the data store.
+    #[error("failed to load data store")]
+    LoadingDataStore(#[source] StoreEntryError),
+    /// Failed to load the features.fea file.
+    #[error("failed to read features.fea file")]
+    LoadingFeatureFile(#[source] IoError),
+    /// Failed to load the fontinfo.plist file.
+    #[error("failed to load font info data")]
+    LoadingFontInfo(#[source] FontInfoLoadError),
+    /// Failed to load a file from the image store.
+    #[error("failed to load images store")]
+    LoadingImagesStore(#[source] StoreEntryError),
+    /// Failed to load a specific layer.
+    #[error("failed to load layer '{0}' from '{1}'")]
+    LoadingLayer(String, PathBuf, #[source] LayerLoadError),
+    /// The UFO does not have a default layer.
+    #[error("missing the default layer ('glyphs' subdirectory)")]
+    MissingDefaultLayer,
+    /// The UFO does not have a default layer.
+    #[error("cannot find the layercontents.plist file")]
+    MissingLayerContentsFile,
+    /// The UFO does not have a metainfo.plist layer.
+    #[error("cannot find the metainfo.plist file")]
+    MissingMetaInfoFile,
+    /// Failed to parse the groups.plist file.
+    #[error("failed to parse groups.plist file")]
+    ParsingGroupsFile(#[source] PlistError),
+    /// Failed to parse the kerning.plist file.
+    #[error("failed to parse kerning.plist file")]
+    ParsingKerningFile(#[source] PlistError),
+    /// Failed to parse the layercontents.plist file.
+    #[error("failed to parse layercontents.plist file")]
+    ParsingLayerContentsFile(#[source] PlistError),
+    /// Failed to parse the lib.plist file.
+    #[error("failed to parse lib.plist file")]
+    ParsingLibFile(#[source] PlistError),
+    /// Failed to parse the metainfo.plist file.
+    #[error("failed to parse metainfo.plist file")]
+    ParsingMetaInfoFile(#[source] PlistError),
+    /// Norad can currently only open UFO (directory) packages.
+    #[error("only UFO (directory) packages are supported")]
+    UfoNotADir,
+}
+
+/// An error that occurs while attempting to read a UFO layer from disk.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LayerLoadError {
+    /// Loading a glyph from a path failed.
+    #[error("failed to load glyph '{0}' from '{1}'")]
+    LoadingGlyph(String, PathBuf, #[source] GlifLoadError),
+    /// Could not find the layer's contents.plist.
+    #[error("cannot find the contents.plist file")]
+    MissingContentsFile,
+    /// Could not parse the layer's contents.plist.
+    #[error("failed to parse contents.plist file")]
+    ParsingContentsFile(#[source] PlistError),
+    /// Could not parse the layer's layerinfo.plist.
+    #[error("failed to parse layerinfo.plist file")]
+    ParsingLayerInfoFile(#[source] PlistError),
+}
+
+/// An error that occurs while attempting to read a UFO fontinfo.plist file from disk.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum FontInfoLoadError {
+    /// The upgrade process failed to convert an older fontinfo.plist to newer data structures.
+    #[error("failed to upgrade fontinfo.plist contents to latest UFO version data: {0}")]
+    FontInfoUpconversion(FontInfoErrorKind),
+    /// The UFO lib.plist's `public.objectLibs` entry for the given guideline is not a dictionary.
+    #[error("the lib.plist file's 'public.objectLibs' entry for the global guideline with identifier '{0}' in the fontinfo.plist file must be a dictionary")]
+    GlobalGuidelineLibMustBeDictionary(String),
+    /// The fontinfo.plist file contains invalid data.
+    #[error("fontinfo.plist contains invalid data: {0}")]
+    InvalidData(FontInfoErrorKind),
+    /// Could not parse the UFO's fontinfo.plist.
+    #[error("failed to parse fontinfo.plist file")]
+    ParsingFontInfoFile(#[source] PlistError),
+    /// The font lib's `public.objectLibs` value was something other than a dictionary.
+    #[error("the lib.plist file's 'public.objectLibs' value must be a dictionary")]
+    PublicObjectLibsMustBeDictionary,
+}
+
+/// An error pointing to invalid data in the font's info.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum FontInfoErrorKind {
+    /// openTypeOS2Selection contained bits 0, 5 or 6.
+    #[error("openTypeOS2Selection must not contain bits 0, 5 or 6")]
+    DisallowedSelectionBits,
+    /// Guideline identifiers were not unique within the fontinfo.plist file.
+    #[error("guideline identifiers must be unique within the fontinfo.plist file")]
+    DuplicateGuidelineIdentifiers,
+    /// Found an empty WOFF element or record. If you have them, you have to fill them all in.
+    #[error("a '{0}' element must not be empty")]
+    EmptyWoffAttribute(&'static str),
+    /// The openTypeHeadCreated had the wrong format.
+    #[error("openTypeHeadCreated must be of format 'YYYY/MM/DD HH:MM:SS'")]
+    InvalidOpenTypeHeadCreatedDate,
+    /// The openTypeOS2FamilyClass had out of range values.
+    #[error("openTypeOS2FamilyClass must be two numbers in the range 0-14 and 0-15, respectively")]
+    InvalidOs2FamilyClass,
+    /// A Postscript data list had more elements than the specification allows.
+    #[error("the Postscript field '{0}' must contain at most {1} items but found {2}")]
+    InvalidPostscriptListLength(&'static str, u8, usize),
+    /// Unrecognized UFO v1 fontStyle field.
+    #[error("unrecognized fontStyle '{0}'")]
+    UnknownFontStyle(i32),
+    /// Unrecognized UFO v1 msCharSet field.
+    #[error("unrecognized msCharSet '{0}'")]
+    UnknownMsCharSet(i32),
+    /// Unrecognized openTypeOS2WidthClass.
+    #[error("unrecognized OS/2 width class '{0}'")]
+    UnknownWidthClass(String),
+    /// The openTypeGaspRangeRecords field was unsorted.
+    #[error("openTypeGaspRangeRecords must be sorted by their rangeMaxPPEM values")]
+    UnsortedGaspEntries,
+}
+
+/// An error representing a failure with a particular [`crate::datastore::Store`] entry.
+#[derive(Debug, Error)]
+#[error("store entry '{path}' is invalid")]
+pub struct StoreEntryError {
+    path: PathBuf,
+    source: StoreError,
+}
+
+impl StoreEntryError {
+    /// Returns a new [`StoreEntryError`].
+    pub(crate) fn new(path: PathBuf, source: StoreError) -> Self {
+        Self { path, source }
+    }
 }
 
 /// An error representing a failure to insert content into a [`crate::datastore::Store`].
@@ -207,20 +289,97 @@ impl InvalidColorString {
     }
 }
 
-/// An error when attempting to write a .glif file.
+/// An error that occurs while attempting to write a UFO package to disk.
 #[derive(Debug, Error)]
-#[error("failed to write glyph '{name}'")]
-pub struct GlifWriteError {
-    /// The name of the glif where the error occured.
-    pub name: GlyphName,
-    /// The actual error.
-    pub source: WriteError,
+#[non_exhaustive]
+pub enum UfoWriteError {
+    /// Cannot clean up previous UFO package before writing out new one.
+    #[error("failed to remove target directory before overwriting")]
+    Cleanup(#[source] IoError),
+    /// Failed to create the data directory.
+    #[error("failed to create target data directory '{0}'")]
+    CreateDataDir(PathBuf, #[source] IoError),
+    /// Failed to create the images directory.
+    #[error("failed to create target image directory '{0}'")]
+    CreateImageDir(PathBuf, #[source] IoError),
+    /// Failed to create the UFO package directory.
+    #[error("failed to create target font directory")]
+    CreateUfoDir(#[source] IoError),
+    /// Norad does not currently support downgrading to older UFO formats.
+    #[error("downgrading below UFO v3 is not currently supported")]
+    Downgrade,
+    /// The font info contains invalid data.
+    #[error("font info contains invalid data: {0}")]
+    InvalidFontInfo(FontInfoErrorKind),
+    /// The groups contains invalid data.
+    #[error("failed to write (kerning) groups")]
+    InvalidGroups(#[source] GroupsValidationError),
+    /// The data or images store contains invalid data.
+    #[error("store entry '{0}' is invalid")]
+    InvalidStoreEntry(PathBuf, #[source] StoreError),
+    /// There exists a `public.objectLibs` lib key when it should be set only by norad.
+    #[error("the `public.objectLibs` lib key is managed by norad and must not be set manually")]
+    PreexistingPublicObjectLibsKey,
+    /// Failed to write data entry.
+    #[error("failed to write data file")]
+    WriteData(PathBuf, #[source] IoError),
+    /// Failed to write out the feature.fea file.
+    #[error("failed to write feature.fea file")]
+    WriteFeatureFile(#[source] IoError),
+    /// Failed to write out the fontinfo.plist file.
+    #[error("failed to write fontinfo.plist file")]
+    WriteFontInfo(#[source] CustomSerializationError),
+    /// Failed to write out the groups.plist file.
+    #[error("failed to write groups.plist file")]
+    WriteGroups(#[source] CustomSerializationError),
+    /// Failed to write out an image file.
+    #[error("failed to write image file")]
+    WriteImage(PathBuf, #[source] IoError),
+    /// Failed to write out the kerning.plist file.
+    #[error("failed to write kerning.plist file")]
+    WriteKerning(#[source] CustomSerializationError),
+    /// Failed to write out a layer.
+    #[error("failed to write layer '{0}' to '{1}'")]
+    WriteLayer(String, PathBuf, #[source] LayerWriteError),
+    /// Failed to write out the layercontents.plist file.
+    #[error("failed to write layercontents.plist file")]
+    WriteLayerContents(#[source] CustomSerializationError),
+    /// Failed to write out the lib.plist file.
+    #[error("failed to write lib.plist file")]
+    WriteLib(#[source] CustomSerializationError),
+    /// Failed to write out the metainfo.plist file.
+    #[error("failed to write metainfo.plist file")]
+    WriteMetaInfo(#[source] CustomSerializationError),
 }
 
-/// The possible inner error types that can occur when attempting to write
-/// out a .glif type.
+/// An error that occurs while attempting to read a UFO layer from disk.
 #[derive(Debug, Error)]
-pub enum WriteError {
+#[non_exhaustive]
+pub enum LayerWriteError {
+    /// Failed to create the layer's directory.
+    #[error("cannot create layer directory")]
+    CreateDir(#[source] IoError),
+    /// Failed to write out the contents.plist file
+    #[error("failed to write contents.plist file")]
+    WriteContents(#[source] CustomSerializationError),
+    /// Failed to write out a glyph.
+    #[error("failed to write glyph '{0}' to '{1}'")]
+    WriteGlyph(String, PathBuf, #[source] GlifWriteError),
+    /// Failed to write out the layerinfo.plist file
+    #[error("failed to write layerinfo.plist file")]
+    WriteLayerInfo(#[source] CustomSerializationError),
+}
+
+/// An error when attempting to write a .glif file.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum GlifWriteError {
+    /// Failed to serialize a glyph to an internal buffer.
+    #[error("failed to serialize glyph to an internal buffer")]
+    Buffer(#[source] IoError),
+    /// Norad does not currently support downgrading format versions.
+    #[error("downgrading below glyph format version 2 is unsupported")]
+    Downgrade,
     /// When writing out the 'lib' section, we use the plist crate to generate
     /// the plist xml, and then strip the preface and closing </plist> tag.
     ///
@@ -228,15 +387,18 @@ pub enum WriteError {
     /// be affected, although this is very unlikely.
     #[error("internal error while writing lib data, please open an issue")]
     InternalLibWriteError,
-    /// An error originating in [`std::io`].
-    #[error("error writing to disk")]
-    Io(#[from] IoError),
+    /// Failed to write a .glif file to disk.
+    #[error("failed to write .glif file")]
+    Io(#[source] IoError),
     /// Plist serialization error. Wraps a [PlistError].
-    #[error("error writing a Plist file to disk")]
-    Plist(#[from] PlistError),
-    /// XML serialzation error. Wraps a [XmlError].
-    #[error("error writing an XML file to disk")]
-    Xml(#[from] XmlError),
+    #[error("error serializing glyph lib data internally")]
+    Plist(#[source] PlistError),
+    /// There exists a `public.objectLibs` glyph lib key when it should be set only by norad.
+    #[error("the `public.objectLibs` lib key is managed by norad and must not be set manually")]
+    PreexistingPublicObjectLibsKey,
+    /// XML serialization error. Wraps a [XmlError].
+    #[error("error serializing glyph to XML")]
+    Xml(#[source] XmlError),
 }
 
 /// The reason for a glif parse failure.

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,7 +80,7 @@ pub enum GlifLoadError {
 pub enum FontLoadError {
     /// The UFO cannot be accessed.
     #[error("cannot access UFO package")]
-    AccessingUfoDir(#[source] IoError),
+    AccessUfoDir(#[source] IoError),
     /// The upgrade process failed to move font info data from the old lib.plist schema to the new fontinfo.plist schema.
     #[error("failed to upgrade old lib.plist to current fontinfo.plist data: {0}")]
     FontInfoV1Upconversion(FontInfoErrorKind),
@@ -95,19 +95,19 @@ pub enum FontLoadError {
     LibFileMustBeDictionary,
     /// Failed to load a file from the data store.
     #[error("failed to load data store")]
-    LoadingDataStore(#[source] StoreEntryError),
+    LoadDataStore(#[source] StoreEntryError),
     /// Failed to load the features.fea file.
     #[error("failed to read features.fea file")]
-    LoadingFeatureFile(#[source] IoError),
+    LoadFeatureFile(#[source] IoError),
     /// Failed to load the fontinfo.plist file.
     #[error("failed to load font info data")]
-    LoadingFontInfo(#[source] FontInfoLoadError),
+    LoadFontInfo(#[source] FontInfoLoadError),
     /// Failed to load a file from the image store.
     #[error("failed to load images store")]
-    LoadingImagesStore(#[source] StoreEntryError),
+    LoadImagesStore(#[source] StoreEntryError),
     /// Failed to load a specific layer.
     #[error("failed to load layer '{name}' from '{path}'")]
-    LoadingLayer {
+    LoadLayer {
         /// The layer name.
         name: String,
         /// The path to the layer.
@@ -126,19 +126,19 @@ pub enum FontLoadError {
     MissingMetaInfoFile,
     /// Failed to parse the groups.plist file.
     #[error("failed to parse groups.plist file")]
-    ParsingGroupsFile(#[source] PlistError),
+    ParseGroupsFile(#[source] PlistError),
     /// Failed to parse the kerning.plist file.
     #[error("failed to parse kerning.plist file")]
-    ParsingKerningFile(#[source] PlistError),
+    ParseKerningFile(#[source] PlistError),
     /// Failed to parse the layercontents.plist file.
     #[error("failed to parse layercontents.plist file")]
-    ParsingLayerContentsFile(#[source] PlistError),
+    ParseLayerContentsFile(#[source] PlistError),
     /// Failed to parse the lib.plist file.
     #[error("failed to parse lib.plist file")]
-    ParsingLibFile(#[source] PlistError),
+    ParseLibFile(#[source] PlistError),
     /// Failed to parse the metainfo.plist file.
     #[error("failed to parse metainfo.plist file")]
-    ParsingMetaInfoFile(#[source] PlistError),
+    ParseMetaInfoFile(#[source] PlistError),
     /// Norad can currently only open UFO (directory) packages.
     #[error("only UFO (directory) packages are supported")]
     UfoNotADir,
@@ -150,7 +150,7 @@ pub enum FontLoadError {
 pub enum LayerLoadError {
     /// Loading a glyph from a path failed.
     #[error("failed to load glyph '{name}' from '{path}'")]
-    LoadingGlyph {
+    LoadGlyph {
         /// The glyph name.
         name: String,
         /// The path to the glif file.
@@ -163,10 +163,10 @@ pub enum LayerLoadError {
     MissingContentsFile,
     /// Could not parse the layer's contents.plist.
     #[error("failed to parse contents.plist file")]
-    ParsingContentsFile(#[source] PlistError),
+    ParseContentsFile(#[source] PlistError),
     /// Could not parse the layer's layerinfo.plist.
     #[error("failed to parse layerinfo.plist file")]
-    ParsingLayerInfoFile(#[source] PlistError),
+    ParseLayerInfoFile(#[source] PlistError),
 }
 
 /// An error that occurs while attempting to read a UFO fontinfo.plist file from disk.
@@ -184,7 +184,7 @@ pub enum FontInfoLoadError {
     InvalidData(FontInfoErrorKind),
     /// Could not parse the UFO's fontinfo.plist.
     #[error("failed to parse fontinfo.plist file")]
-    ParsingFontInfoFile(#[source] PlistError),
+    ParseFontInfoFile(#[source] PlistError),
     /// The font lib's `public.objectLibs` value was something other than a dictionary.
     #[error("the lib.plist file's 'public.objectLibs' value must be a dictionary")]
     PublicObjectLibsMustBeDictionary,

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,11 +39,11 @@ pub enum Error {
         glyph: String,
     },
     /// An error returned when there is an input problem during processing
-    #[error("failed to load font")]
-    UfoLoad(#[source] UfoLoadError),
+    #[error(transparent)]
+    UfoLoad(UfoLoadError),
     /// An error returned when there is an output problem during processing
-    #[error("failed to write font")]
-    UfoWrite(#[source] UfoWriteError),
+    #[error(transparent)]
+    UfoWrite(UfoWriteError),
     /// An error returned when there is an inappropriate negative sign on a value.
     #[error("positiveIntegerOrFloat expects a positive value")]
     ExpectedPositiveValue,

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,21 +124,14 @@ pub enum FontLoadError {
     /// The UFO does not have a metainfo.plist layer.
     #[error("cannot find the metainfo.plist file")]
     MissingMetaInfoFile,
-    /// Failed to parse the groups.plist file.
-    #[error("failed to parse groups.plist file")]
-    ParseGroupsFile(#[source] PlistError),
-    /// Failed to parse the kerning.plist file.
-    #[error("failed to parse kerning.plist file")]
-    ParseKerningFile(#[source] PlistError),
-    /// Failed to parse the layercontents.plist file.
-    #[error("failed to parse layercontents.plist file")]
-    ParseLayerContentsFile(#[source] PlistError),
-    /// Failed to parse the lib.plist file.
-    #[error("failed to parse lib.plist file")]
-    ParseLibFile(#[source] PlistError),
-    /// Failed to parse the metainfo.plist file.
-    #[error("failed to parse metainfo.plist file")]
-    ParseMetaInfoFile(#[source] PlistError),
+    /// Failed to parse a .plist file.
+    #[error("failed to parse {name} file")]
+    ParsePlist {
+        /// The name of the file.
+        name: &'static str,
+        /// The underlying error.
+        source: PlistError,
+    },
     /// Norad can currently only open UFO (directory) packages.
     #[error("only UFO (directory) packages are supported")]
     UfoNotADir,
@@ -161,12 +154,14 @@ pub enum LayerLoadError {
     /// Could not find the layer's contents.plist.
     #[error("cannot find the contents.plist file")]
     MissingContentsFile,
-    /// Could not parse the layer's contents.plist.
-    #[error("failed to parse contents.plist file")]
-    ParseContentsFile(#[source] PlistError),
-    /// Could not parse the layer's layerinfo.plist.
-    #[error("failed to parse layerinfo.plist file")]
-    ParseLayerInfoFile(#[source] PlistError),
+    /// Failed to parse a .plist file.
+    #[error("failed to parse {name} file")]
+    ParsePlist {
+        /// The name of the file.
+        name: &'static str,
+        /// The underlying error.
+        source: PlistError,
+    },
 }
 
 /// An error that occurs while attempting to read a UFO fontinfo.plist file from disk.
@@ -387,6 +382,14 @@ pub enum FontWriteError {
     /// There exists a `public.objectLibs` lib key when it should be set only by norad.
     #[error("the `public.objectLibs` lib key is managed by norad and must not be set manually")]
     PreexistingPublicObjectLibsKey,
+    /// Failed to write out a customly-serialized file.
+    #[error("failed to write {name} file")]
+    WriteCustomFile {
+        /// The name of the file.
+        name: &'static str,
+        /// The underlying error.
+        source: CustomSerializationError,
+    },
     /// Failed to write data entry.
     #[error("failed to write data file")]
     WriteData {
@@ -398,12 +401,6 @@ pub enum FontWriteError {
     /// Failed to write out the feature.fea file.
     #[error("failed to write feature.fea file")]
     WriteFeatureFile(#[source] IoError),
-    /// Failed to write out the fontinfo.plist file.
-    #[error("failed to write fontinfo.plist file")]
-    WriteFontInfo(#[source] CustomSerializationError),
-    /// Failed to write out the groups.plist file.
-    #[error("failed to write groups.plist file")]
-    WriteGroups(#[source] CustomSerializationError),
     /// Failed to write out an image file.
     #[error("failed to write image file")]
     WriteImage {
@@ -412,9 +409,6 @@ pub enum FontWriteError {
         /// The underlying error.
         source: IoError,
     },
-    /// Failed to write out the kerning.plist file.
-    #[error("failed to write kerning.plist file")]
-    WriteKerning(#[source] CustomSerializationError),
     /// Failed to write out a layer.
     #[error("failed to write layer '{name}' to '{path}'")]
     WriteLayer {
@@ -425,15 +419,6 @@ pub enum FontWriteError {
         /// The underlying error.
         source: LayerWriteError,
     },
-    /// Failed to write out the layercontents.plist file.
-    #[error("failed to write layercontents.plist file")]
-    WriteLayerContents(#[source] CustomSerializationError),
-    /// Failed to write out the lib.plist file.
-    #[error("failed to write lib.plist file")]
-    WriteLib(#[source] CustomSerializationError),
-    /// Failed to write out the metainfo.plist file.
-    #[error("failed to write metainfo.plist file")]
-    WriteMetaInfo(#[source] CustomSerializationError),
 }
 
 /// An error that occurs while attempting to read a UFO layer from disk.

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,10 +40,10 @@ pub enum Error {
     },
     /// An error returned when there is an input problem during processing
     #[error(transparent)]
-    UfoLoad(UfoLoadError),
+    FontLoad(FontLoadError),
     /// An error returned when there is an output problem during processing
     #[error(transparent)]
-    UfoWrite(UfoWriteError),
+    FontWrite(FontWriteError),
     /// An error returned when there is an inappropriate negative sign on a value.
     #[error("positiveIntegerOrFloat expects a positive value")]
     ExpectedPositiveValue,
@@ -77,7 +77,7 @@ pub enum GlifLoadError {
 /// An error that occurs while attempting to read a UFO package from disk.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum UfoLoadError {
+pub enum FontLoadError {
     /// The UFO cannot be accessed.
     #[error("cannot access UFO package")]
     AccessingUfoDir(#[source] IoError),
@@ -323,7 +323,7 @@ impl InvalidColorString {
 /// An error that occurs while attempting to write a UFO package to disk.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum UfoWriteError {
+pub enum FontWriteError {
     /// Cannot clean up previous UFO package before writing out new one.
     #[error("failed to remove target directory before overwriting")]
     Cleanup(#[source] IoError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,9 +35,6 @@ pub enum Error {
         /// The glyph name.
         glyph: String,
     },
-    /// An error returned when there is an inappropriate negative sign on a value.
-    #[error("positiveIntegerOrFloat expects a positive value")]
-    ExpectedPositiveValue,
     /// An error returned when there is a problem with kurbo contour conversion.
     #[cfg(feature = "kurbo")]
     #[error("failed to convert contour: '{0}'")]
@@ -326,6 +323,11 @@ impl InvalidColorString {
         InvalidColorString { string: source }
     }
 }
+
+/// An error returned when there is an inappropriate negative sign on a value.
+#[derive(Debug, Error)]
+#[error("expected a positive value")]
+pub struct ExpectedPositiveValue;
 
 /// An error that occurs while attempting to write a UFO package to disk.
 #[derive(Debug, Error)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -328,17 +328,9 @@ pub enum FontWriteError {
     /// Cannot clean up previous UFO package before writing out new one.
     #[error("failed to remove target directory before overwriting")]
     Cleanup(#[source] IoError),
-    /// Failed to create the data directory.
-    #[error("failed to create target data directory '{path}'")]
-    CreateDataDir {
-        /// The path to the entry.
-        path: PathBuf,
-        /// The underlying error.
-        source: IoError,
-    },
     /// Failed to create the images directory.
-    #[error("failed to create target image directory '{path}'")]
-    CreateImageDir {
+    #[error("failed to create store directory '{path}'")]
+    CreateStoreDir {
         /// The path to the entry.
         path: PathBuf,
         /// The underlying error.

--- a/src/font.rs
+++ b/src/font.rs
@@ -509,7 +509,7 @@ impl Font {
         for layer in self.layers.iter() {
             let layer_path = path.join(&layer.path);
             layer.save_with_options(&layer_path, options).map_err(|source| {
-                FontWriteError::WriteLayer(layer.name.to_string(), layer_path, source)
+                FontWriteError::WriteLayer { name: layer.name.to_string(), path: layer_path, source }
             })?;
         }
 
@@ -521,12 +521,12 @@ impl Font {
                         let destination = data_dir.join(data_path);
                         let destination_parent = destination.parent().unwrap();
                         fs::create_dir_all(&destination_parent).map_err(|source| {
-                            FontWriteError::CreateDataDir(destination_parent.into(), source)
+                            FontWriteError::CreateDataDir { path: destination_parent.into(), source }
                         })?;
                         fs::write(&destination, &*data)
-                            .map_err(|source| FontWriteError::WriteData(destination, source))?;
+                            .map_err(|source| FontWriteError::WriteData { path: destination, source })?;
                     }
-                    Err(e) => return Err(FontWriteError::InvalidStoreEntry(data_path.clone(), e)),
+                    Err(e) => return Err(FontWriteError::InvalidStoreEntry { path: data_path.clone(), source: e }),
                 }
             }
         }
@@ -534,15 +534,15 @@ impl Font {
         if !self.images.is_empty() {
             let images_dir = path.join(IMAGES_DIR);
             fs::create_dir(&images_dir) // Only a flat directory.
-                .map_err(|source| FontWriteError::CreateImageDir(images_dir.clone(), source))?;
+                .map_err(|source| FontWriteError::CreateImageDir { path: images_dir.clone(), source })?;
             for (image_path, contents) in self.images.iter() {
                 match contents {
                     Ok(data) => {
                         let destination = images_dir.join(image_path);
                         fs::write(&destination, &*data)
-                            .map_err(|source| FontWriteError::WriteImage(destination, source))?;
+                            .map_err(|source| FontWriteError::WriteImage { path: destination, source })?;
                     }
-                    Err(e) => return Err(FontWriteError::InvalidStoreEntry(image_path.clone(), e)),
+                    Err(e) => return Err(FontWriteError::InvalidStoreEntry { path: image_path.clone(), source: e }),
                 }
             }
         }
@@ -750,11 +750,11 @@ mod tests {
         let font_load_res = Font::load(path);
         assert!(matches!(
             font_load_res,
-            Err(Error::FontLoad(FontLoadError::LoadingLayer(
-                _,
-                _,
-                LayerLoadError::MissingContentsFile
-            )))
+            Err(Error::FontLoad(FontLoadError::LoadingLayer {
+                name: _,
+                path: _,
+                source: LayerLoadError::MissingContentsFile
+            }))
         ));
     }
 
@@ -766,11 +766,11 @@ mod tests {
         let font_load_res = Font::load(path);
         assert!(matches!(
             font_load_res,
-            Err(Error::FontLoad(FontLoadError::LoadingLayer(
-                _,
-                _,
-                LayerLoadError::MissingContentsFile
-            )))
+            Err(Error::FontLoad(FontLoadError::LoadingLayer {
+                name: _,
+                path: _,
+                source: LayerLoadError::MissingContentsFile
+            }))
         ));
     }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -527,7 +527,7 @@ impl Font {
                         let destination = data_dir.join(data_path);
                         let destination_parent = destination.parent().unwrap();
                         fs::create_dir_all(&destination_parent).map_err(|source| {
-                            FontWriteError::CreateDataDir {
+                            FontWriteError::CreateStoreDir {
                                 path: destination_parent.into(),
                                 source,
                             }
@@ -549,7 +549,7 @@ impl Font {
         if !self.images.is_empty() {
             let images_dir = path.join(IMAGES_DIR);
             fs::create_dir(&images_dir) // Only a flat directory.
-                .map_err(|source| FontWriteError::CreateImageDir {
+                .map_err(|source| FontWriteError::CreateStoreDir {
                     path: images_dir.clone(),
                     source,
                 })?;

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -889,56 +889,56 @@ impl FontInfo {
         // The Postscript blue zone and stem widths lists have a length limitation.
         if let Some(v) = &self.postscript_blue_values {
             if v.len() > 14 {
-                return Err(FontInfoErrorKind::InvalidPostscriptListLength(
-                    "postscriptBlueValues",
-                    14,
-                    v.len(),
-                ));
+                return Err(FontInfoErrorKind::InvalidPostscriptListLength {
+                    name: "postscriptBlueValues",
+                    max_len: 14,
+                    len: v.len(),
+                });
             }
         }
         if let Some(v) = &self.postscript_other_blues {
             if v.len() > 10 {
-                return Err(FontInfoErrorKind::InvalidPostscriptListLength(
-                    "postscriptOtherBlues",
-                    10,
-                    v.len(),
-                ));
+                return Err(FontInfoErrorKind::InvalidPostscriptListLength {
+                    name: "postscriptOtherBlues",
+                    max_len: 10,
+                    len: v.len(),
+                });
             }
         }
         if let Some(v) = &self.postscript_family_blues {
             if v.len() > 14 {
-                return Err(FontInfoErrorKind::InvalidPostscriptListLength(
-                    "postscriptFamilyBlues",
-                    14,
-                    v.len(),
-                ));
+                return Err(FontInfoErrorKind::InvalidPostscriptListLength {
+                    name: "postscriptFamilyBlues",
+                    max_len: 14,
+                    len: v.len(),
+                });
             }
         }
         if let Some(v) = &self.postscript_family_other_blues {
             if v.len() > 10 {
-                return Err(FontInfoErrorKind::InvalidPostscriptListLength(
-                    "postscriptFamilyOtherBlues",
-                    10,
-                    v.len(),
-                ));
+                return Err(FontInfoErrorKind::InvalidPostscriptListLength {
+                    name: "postscriptFamilyOtherBlues",
+                    max_len: 10,
+                    len: v.len(),
+                });
             }
         }
         if let Some(v) = &self.postscript_stem_snap_h {
             if v.len() > 12 {
-                return Err(FontInfoErrorKind::InvalidPostscriptListLength(
-                    "postscriptStemSnapH",
-                    12,
-                    v.len(),
-                ));
+                return Err(FontInfoErrorKind::InvalidPostscriptListLength {
+                    name: "postscriptStemSnapH",
+                    max_len: 12,
+                    len: v.len(),
+                });
             }
         }
         if let Some(v) = &self.postscript_stem_snap_v {
             if v.len() > 12 {
-                return Err(FontInfoErrorKind::InvalidPostscriptListLength(
-                    "postscriptStemSnapV",
-                    12,
-                    v.len(),
-                ));
+                return Err(FontInfoErrorKind::InvalidPostscriptListLength {
+                    name: "postscriptStemSnapV",
+                    max_len: 12,
+                    len: v.len(),
+                });
             }
         }
 

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -507,14 +507,14 @@ impl FontInfo {
         match format_version {
             FormatVersion::V3 => {
                 let mut fontinfo: FontInfo =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParseFontInfoFile)?;
+                    plist::from_file(path).map_err(FontInfoLoadError::ParsePlist)?;
                 fontinfo.validate().map_err(FontInfoLoadError::InvalidData)?;
                 fontinfo.load_object_libs(lib)?;
                 Ok(fontinfo)
             }
             FormatVersion::V2 => {
                 let fontinfo_v2: FontInfoV2 =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParseFontInfoFile)?;
+                    plist::from_file(path).map_err(FontInfoLoadError::ParsePlist)?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v2.ascender,
                     cap_height: fontinfo_v2.capHeight,
@@ -669,7 +669,7 @@ impl FontInfo {
             }
             FormatVersion::V1 => {
                 let fontinfo_v1: FontInfoV1 =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParseFontInfoFile)?;
+                    plist::from_file(path).map_err(FontInfoLoadError::ParsePlist)?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v1.ascender,
                     cap_height: fontinfo_v1.capHeight,

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -9,7 +9,7 @@ use serde::de::Deserializer;
 use serde::ser::{SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
 
-use crate::error::{Error, FontInfoErrorKind, FontInfoLoadError};
+use crate::error::{ExpectedPositiveValue, FontInfoErrorKind, FontInfoLoadError};
 use crate::shared_types::PUBLIC_OBJECT_LIBS_KEY;
 use crate::{FormatVersion, Guideline, Identifier, Plist};
 
@@ -1069,12 +1069,12 @@ impl Deref for NonNegativeIntegerOrFloat {
 }
 
 impl TryFrom<f64> for NonNegativeIntegerOrFloat {
-    type Error = Error;
+    type Error = ExpectedPositiveValue;
 
     fn try_from(value: f64) -> Result<Self, Self::Error> {
         match NonNegativeIntegerOrFloat::new(value) {
             Some(v) => Ok(v),
-            _ => Err(Error::ExpectedPositiveValue),
+            _ => Err(ExpectedPositiveValue),
         }
     }
 }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -507,14 +507,14 @@ impl FontInfo {
         match format_version {
             FormatVersion::V3 => {
                 let mut fontinfo: FontInfo =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParsingFontInfoFile)?;
+                    plist::from_file(path).map_err(FontInfoLoadError::ParseFontInfoFile)?;
                 fontinfo.validate().map_err(FontInfoLoadError::InvalidData)?;
                 fontinfo.load_object_libs(lib)?;
                 Ok(fontinfo)
             }
             FormatVersion::V2 => {
                 let fontinfo_v2: FontInfoV2 =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParsingFontInfoFile)?;
+                    plist::from_file(path).map_err(FontInfoLoadError::ParseFontInfoFile)?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v2.ascender,
                     cap_height: fontinfo_v2.capHeight,
@@ -669,7 +669,7 @@ impl FontInfo {
             }
             FormatVersion::V1 => {
                 let fontinfo_v1: FontInfoV1 =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParsingFontInfoFile)?;
+                    plist::from_file(path).map_err(FontInfoLoadError::ParseFontInfoFile)?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v1.ascender,
                     cap_height: fontinfo_v1.capHeight,

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 #[cfg(feature = "kurbo")]
-use crate::Error;
+use crate::error::ConvertContourError;
 
 #[cfg(feature = "druid")]
 use druid::{Data, Lens};
@@ -326,7 +326,7 @@ impl Contour {
 
     /// Converts the `Contour` to a [`kurbo::BezPath`].
     #[cfg(feature = "kurbo")]
-    pub fn to_kurbo(&self) -> Result<kurbo::BezPath, Error> {
+    pub fn to_kurbo(&self) -> Result<kurbo::BezPath, ConvertContourError> {
         let mut path = kurbo::BezPath::new();
         let mut offs = std::collections::VecDeque::new();
         let mut points = if self.is_closed() {
@@ -352,10 +352,10 @@ impl Contour {
                 PointType::OffCurve => offs.push_back(kurbo_point),
                 PointType::Curve => {
                     match offs.make_contiguous() {
-                        [] => return Err(Error::ConvertContour(ErrorKind::BadPoint)),
+                        [] => return Err(ConvertContourError::new(ErrorKind::BadPoint)),
                         [p1] => path.quad_to(*p1, kurbo_point),
                         [p1, p2] => path.curve_to(*p1, *p2, kurbo_point),
-                        _ => return Err(Error::ConvertContour(ErrorKind::TooManyOffCurves)),
+                        _ => return Err(ConvertContourError::new(ErrorKind::TooManyOffCurves)),
                     };
                     offs.clear();
                 }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -9,10 +9,13 @@ mod tests;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(feature = "kurbo")]
+use crate::Error;
+
 #[cfg(feature = "druid")]
 use druid::{Data, Lens};
 
-use crate::error::{Error, ErrorKind, GlifLoadError};
+use crate::error::{ErrorKind, GlifLoadError, GlifWriteError};
 use crate::names::NameList;
 use crate::shared_types::PUBLIC_OBJECT_LIBS_KEY;
 use crate::{Color, Guideline, Identifier, Line, Plist, WriteOptions};
@@ -79,23 +82,27 @@ impl Glyph {
     }
 
     #[doc(hidden)]
-    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), GlifWriteError> {
         let path = path.as_ref();
         let opts = WriteOptions::default();
         self.save_with_options(path, &opts)
     }
 
-    pub(crate) fn save_with_options(&self, path: &Path, opts: &WriteOptions) -> Result<(), Error> {
+    pub(crate) fn save_with_options(
+        &self,
+        path: &Path,
+        opts: &WriteOptions,
+    ) -> Result<(), GlifWriteError> {
         if self.format != GlifVersion::V2 {
-            return Err(Error::DowngradeUnsupported);
+            return Err(GlifWriteError::Downgrade);
         }
         if self.lib.contains_key(PUBLIC_OBJECT_LIBS_KEY) {
-            return Err(Error::PreexistingPublicObjectLibsKey);
+            return Err(GlifWriteError::PreexistingPublicObjectLibsKey);
         }
 
         let data = self.encode_xml_with_options(opts)?;
-        std::fs::write(path, &data)
-            .map_err(|source| Error::UfoWrite { path: path.into(), source })?;
+        std::fs::write(path, &data).map_err(GlifWriteError::Io)?;
+
         Ok(())
     }
 
@@ -147,13 +154,15 @@ impl Glyph {
 
     /// Move libs from the lib's `public.objectLibs` into the actual objects.
     /// The key will be removed from the glyph lib.
-    fn load_object_libs(&mut self) -> Result<(), ErrorKind> {
+    fn load_object_libs(&mut self) -> Result<(), GlifLoadError> {
         // Use a macro to reduce boilerplate, to avoid having to mess with the typing system.
         macro_rules! transfer_lib {
             ($object:expr, $object_libs:expr) => {
                 if let Some(id) = $object.identifier().map(|v| v.as_str()) {
                     if let Some(lib) = $object_libs.remove(id) {
-                        let lib = lib.into_dictionary().ok_or(ErrorKind::BadLib)?;
+                        let lib = lib
+                            .into_dictionary()
+                            .ok_or(GlifLoadError::ObjectLibMustBeDictionary(id.into()))?;
                         $object.replace_lib(lib);
                     }
                 }
@@ -161,7 +170,9 @@ impl Glyph {
         }
 
         let mut object_libs = match self.lib.remove(PUBLIC_OBJECT_LIBS_KEY) {
-            Some(lib) => lib.into_dictionary().ok_or(ErrorKind::BadLib)?,
+            Some(lib) => {
+                lib.into_dictionary().ok_or(GlifLoadError::PublicObjectLibsMustBeDictionary)?
+            }
             None => return Ok(()),
         };
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -44,7 +44,8 @@ impl LayerSet {
     pub(crate) fn load(base_dir: &Path, glyph_names: &NameList) -> Result<LayerSet, FontLoadError> {
         let layer_contents_path = base_dir.join(LAYER_CONTENTS_FILE);
         let to_load: Vec<(LayerName, PathBuf)> = if layer_contents_path.exists() {
-            plist::from_file(&layer_contents_path).map_err(FontLoadError::ParseLayerContentsFile)?
+            plist::from_file(&layer_contents_path)
+                .map_err(|source| FontLoadError::ParsePlist { name: LAYER_CONTENTS_FILE, source })?
         } else {
             vec![(Arc::from(DEFAULT_LAYER_NAME), PathBuf::from(DEFAULT_GLYPHS_DIRNAME))]
         };
@@ -249,8 +250,8 @@ impl Layer {
         }
         // these keys are never used; a future optimization would be to skip the
         // names and deserialize to a vec; that would not be a one-liner, though.
-        let contents: BTreeMap<GlyphName, PathBuf> =
-            plist::from_file(&contents_path).map_err(LayerLoadError::ParseContentsFile)?;
+        let contents: BTreeMap<GlyphName, PathBuf> = plist::from_file(&contents_path)
+            .map_err(|source| LayerLoadError::ParsePlist { name: CONTENTS_FILE, source })?;
 
         #[cfg(feature = "rayon")]
         let iter = contents.par_iter();
@@ -296,8 +297,8 @@ impl Layer {
             #[serde(default)]
             lib: Plist,
         }
-        let layerinfo: LayerInfoHelper =
-            plist::from_file(path).map_err(LayerLoadError::ParseLayerInfoFile)?;
+        let layerinfo: LayerInfoHelper = plist::from_file(path)
+            .map_err(|source| LayerLoadError::ParsePlist { name: LAYER_INFO_FILE, source })?;
         Ok((layerinfo.color, layerinfo.lib))
     }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -55,7 +55,7 @@ impl LayerSet {
             .map(|(name, path)| {
                 let layer_path = base_dir.join(&path);
                 Layer::load_impl(&layer_path, name.clone(), glyph_names).map_err(|source| {
-                    FontLoadError::LoadingLayer(name.to_string(), layer_path, source)
+                    FontLoadError::LoadingLayer { name: name.to_string(), path: layer_path, source }
                 })
             })
             .collect::<Result<_, _>>()?;
@@ -268,8 +268,10 @@ impl Layer {
                         glyph.name = name.clone();
                         (name.clone(), Arc::new(glyph))
                     })
-                    .map_err(|source| {
-                        LayerLoadError::LoadingGlyph(name.to_string(), glyph_path, source)
+                    .map_err(|source| LayerLoadError::LoadingGlyph {
+                        name: name.to_string(),
+                        path: glyph_path,
+                        source,
                     })
             })
             .collect::<Result<_, _>>()?;
@@ -358,7 +360,7 @@ impl Layer {
             let glyph = self.glyphs.get(name).expect("all glyphs in contents must exist.");
             let glyph_path = path.join(glyph_path);
             glyph.save_with_options(&glyph_path, opts).map_err(|source| {
-                LayerWriteError::WriteGlyph(glyph.name.to_string(), glyph_path, source)
+                LayerWriteError::WriteGlyph { name: glyph.name.to_string(), path: glyph_path, source }
             })
         })
     }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
+use crate::error::{LayerLoadError, LayerWriteError, UfoLoadError};
 use crate::glyph::GlyphName;
 use crate::names::NameList;
 use crate::shared_types::Color;
@@ -40,11 +41,11 @@ impl LayerSet {
     ///
     /// The `glyph_names` argument allows norad to reuse glyph name strings,
     /// reducing memory use.
-    pub(crate) fn load(base_dir: &Path, glyph_names: &NameList) -> Result<LayerSet, Error> {
+    pub(crate) fn load(base_dir: &Path, glyph_names: &NameList) -> Result<LayerSet, UfoLoadError> {
         let layer_contents_path = base_dir.join(LAYER_CONTENTS_FILE);
         let to_load: Vec<(LayerName, PathBuf)> = if layer_contents_path.exists() {
             plist::from_file(&layer_contents_path)
-                .map_err(|source| Error::PlistLoad { path: layer_contents_path, source })?
+                .map_err(UfoLoadError::ParsingLayerContentsFile)?
         } else {
             vec![(Arc::from(DEFAULT_LAYER_NAME), PathBuf::from(DEFAULT_GLYPHS_DIRNAME))]
         };
@@ -53,7 +54,9 @@ impl LayerSet {
             .into_iter()
             .map(|(name, path)| {
                 let layer_path = base_dir.join(&path);
-                Layer::load_impl(&layer_path, name, glyph_names)
+                Layer::load_impl(&layer_path, name.clone(), glyph_names).map_err(|source| {
+                    UfoLoadError::LoadingLayer(name.to_string(), layer_path, source)
+                })
             })
             .collect::<Result<_, _>>()?;
 
@@ -61,7 +64,7 @@ impl LayerSet {
         let default_idx = layers
             .iter()
             .position(|l| l.path.to_str() == Some(DEFAULT_GLYPHS_DIRNAME))
-            .ok_or(Error::MissingDefaultLayer)?;
+            .ok_or(UfoLoadError::MissingDefaultLayer)?;
         layers.rotate_left(default_idx);
 
         Ok(LayerSet { layers })
@@ -226,7 +229,7 @@ impl Layer {
     /// You generally shouldn't need this; instead prefer to load all layers
     /// with [`LayerSet::load`] and then get the layer you need from there.
     #[cfg(test)]
-    pub(crate) fn load(path: impl AsRef<Path>, name: LayerName) -> Result<Layer, Error> {
+    pub(crate) fn load(path: impl AsRef<Path>, name: LayerName) -> Result<Layer, LayerLoadError> {
         let path = path.as_ref();
         let names = NameList::default();
         Layer::load_impl(path, name, &names)
@@ -240,15 +243,15 @@ impl Layer {
         path: &Path,
         name: LayerName,
         names: &NameList,
-    ) -> Result<Layer, Error> {
+    ) -> Result<Layer, LayerLoadError> {
         let contents_path = path.join(CONTENTS_FILE);
         if !contents_path.exists() {
-            return Err(Error::MissingFile(contents_path.display().to_string()));
+            return Err(LayerLoadError::MissingContentsFile);
         }
         // these keys are never used; a future optimization would be to skip the
         // names and deserialize to a vec; that would not be a one-liner, though.
-        let contents: BTreeMap<GlyphName, PathBuf> = plist::from_file(&contents_path)
-            .map_err(|source| Error::PlistLoad { path: contents_path, source })?;
+        let contents: BTreeMap<GlyphName, PathBuf> =
+            plist::from_file(&contents_path).map_err(LayerLoadError::ParsingContentsFile)?;
 
         #[cfg(feature = "rayon")]
         let iter = contents.par_iter();
@@ -257,15 +260,17 @@ impl Layer {
 
         let glyphs = iter
             .map(|(name, glyph_path)| {
-                let name = names.get(name);
+                let name = &names.get(name);
                 let glyph_path = path.join(glyph_path);
 
                 Glyph::load_with_names(&glyph_path, names)
                     .map(|mut glyph| {
                         glyph.name = name.clone();
-                        (name, Arc::new(glyph))
+                        (name.clone(), Arc::new(glyph))
                     })
-                    .map_err(|source| Error::GlifLoad { path: glyph_path, source })
+                    .map_err(|source| {
+                        LayerLoadError::LoadingGlyph(name.to_string(), glyph_path, source)
+                    })
             })
             .collect::<Result<_, _>>()?;
 
@@ -282,7 +287,7 @@ impl Layer {
         Ok(Layer { glyphs, name, path, contents, color, lib })
     }
 
-    fn parse_layer_info(path: &Path) -> Result<(Option<Color>, Plist), Error> {
+    fn parse_layer_info(path: &Path) -> Result<(Option<Color>, Plist), LayerLoadError> {
         // Pluck apart the data found in the file, as we want to insert it into `Layer`.
         #[derive(Deserialize)]
         struct LayerInfoHelper {
@@ -290,8 +295,8 @@ impl Layer {
             #[serde(default)]
             lib: Plist,
         }
-        let layerinfo: LayerInfoHelper = plist::from_file(path)
-            .map_err(|source| Error::PlistLoad { path: path.into(), source })?;
+        let layerinfo: LayerInfoHelper =
+            plist::from_file(path).map_err(LayerLoadError::ParsingLayerInfoFile)?;
         Ok((layerinfo.color, layerinfo.lib))
     }
 
@@ -299,7 +304,7 @@ impl Layer {
         &self,
         path: &Path,
         options: &WriteOptions,
-    ) -> Result<(), Error> {
+    ) -> Result<(), LayerWriteError> {
         if self.color.is_none() && self.lib.is_empty() {
             return Ok(());
         }
@@ -316,6 +321,7 @@ impl Layer {
         util::recursive_sort_plist_keys(&mut dict);
 
         crate::write::write_xml_to_file(&path.join(LAYER_INFO_FILE), &dict, options)
+            .map_err(LayerWriteError::WriteLayerInfo)
     }
 
     /// Serialize this layer to the given path with the default
@@ -323,7 +329,7 @@ impl Layer {
     ///
     /// The path should not exist.
     #[cfg(test)]
-    pub(crate) fn save(&self, path: impl AsRef<Path>) -> Result<(), Error> {
+    pub(crate) fn save(&self, path: impl AsRef<Path>) -> Result<(), LayerWriteError> {
         let options = WriteOptions::default();
         self.save_with_options(path.as_ref(), &options)
     }
@@ -332,9 +338,14 @@ impl Layer {
     /// [`WriteOptions`] serialization format configuration.
     ///
     /// The path should not exist.
-    pub(crate) fn save_with_options(&self, path: &Path, opts: &WriteOptions) -> Result<(), Error> {
-        fs::create_dir(&path).map_err(|source| Error::UfoWrite { path: path.into(), source })?;
-        crate::write::write_xml_to_file(&path.join(CONTENTS_FILE), &self.contents, opts)?;
+    pub(crate) fn save_with_options(
+        &self,
+        path: &Path,
+        opts: &WriteOptions,
+    ) -> Result<(), LayerWriteError> {
+        fs::create_dir(&path).map_err(LayerWriteError::CreateDir)?;
+        crate::write::write_xml_to_file(&path.join(CONTENTS_FILE), &self.contents, opts)
+            .map_err(LayerWriteError::WriteContents)?;
 
         self.layerinfo_to_file_if_needed(path, opts)?;
 
@@ -345,7 +356,10 @@ impl Layer {
 
         iter.try_for_each(|(name, glyph_path)| {
             let glyph = self.glyphs.get(name).expect("all glyphs in contents must exist.");
-            glyph.save_with_options(&path.join(glyph_path), opts)
+            let glyph_path = path.join(glyph_path);
+            glyph.save_with_options(&glyph_path, opts).map_err(|source| {
+                LayerWriteError::WriteGlyph(glyph.name.to_string(), glyph_path, source)
+            })
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,6 @@ pub(crate) mod util;
 mod write;
 
 pub use data_request::DataRequest;
-pub use error::Error;
 pub use font::{Font, FormatVersion, MetaInfo};
 pub use fontinfo::FontInfo;
 pub use glyph::{

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -148,7 +148,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     }
 
     // Read lib.plist again because it is easier than pulling out the data manually.
-    let lib_data: LibData = plist::from_file(lib_path).map_err(FontLoadError::ParsingLibFile)?;
+    let lib_data: LibData = plist::from_file(lib_path).map_err(FontLoadError::ParseLibFile)?;
 
     // Convert features.
     let mut features = String::new();

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
 use crate::error::FontLoadError;
+use crate::font::LIB_FILE;
 use crate::fontinfo::FontInfo;
 use crate::groups::Groups;
 use crate::kerning::Kerning;
@@ -148,7 +149,8 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     }
 
     // Read lib.plist again because it is easier than pulling out the data manually.
-    let lib_data: LibData = plist::from_file(lib_path).map_err(FontLoadError::ParseLibFile)?;
+    let lib_data: LibData = plist::from_file(lib_path)
+        .map_err(|source| FontLoadError::ParsePlist { name: LIB_FILE, source })?;
 
     // Convert features.
     let mut features = String::new();

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
-use crate::error::UfoLoadError;
+use crate::error::FontLoadError;
 use crate::fontinfo::FontInfo;
 use crate::groups::Groups;
 use crate::kerning::Kerning;
@@ -118,7 +118,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     lib_path: &Path,
     lib: &mut plist::Dictionary,
     font_info: &mut FontInfo,
-) -> Result<Option<String>, UfoLoadError> {
+) -> Result<Option<String>, FontLoadError> {
     #[derive(Debug, Deserialize)]
     struct LibData {
         #[serde(rename = "org.robofab.postScriptHintData")]
@@ -148,7 +148,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     }
 
     // Read lib.plist again because it is easier than pulling out the data manually.
-    let lib_data: LibData = plist::from_file(lib_path).map_err(UfoLoadError::ParsingLibFile)?;
+    let lib_data: LibData = plist::from_file(lib_path).map_err(FontLoadError::ParsingLibFile)?;
 
     // Convert features.
     let mut features = String::new();
@@ -196,7 +196,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
         font_info.postscript_stem_snap_h = ps_hinting_data.h_stems;
         font_info.postscript_stem_snap_v = ps_hinting_data.v_stems;
 
-        font_info.validate().map_err(UfoLoadError::FontInfoV1Upconversion)?;
+        font_info.validate().map_err(FontLoadError::FontInfoV1Upconversion)?;
     }
 
     lib.remove("org.robofab.postScriptHintData");

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -1,11 +1,11 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
+use crate::error::UfoLoadError;
 use crate::fontinfo::FontInfo;
 use crate::groups::Groups;
 use crate::kerning::Kerning;
 use crate::names::NameList;
-use crate::Error;
 
 /// Convert kerning groups and pairs from v1 and v2 informal conventions to
 /// v3 formal conventions. Converted groups are added (duplicated) rather than
@@ -118,7 +118,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     lib_path: &Path,
     lib: &mut plist::Dictionary,
     font_info: &mut FontInfo,
-) -> Result<Option<String>, Error> {
+) -> Result<Option<String>, UfoLoadError> {
     #[derive(Debug, Deserialize)]
     struct LibData {
         #[serde(rename = "org.robofab.postScriptHintData")]
@@ -148,8 +148,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     }
 
     // Read lib.plist again because it is easier than pulling out the data manually.
-    let lib_data: LibData = plist::from_file(lib_path)
-        .map_err(|source| Error::PlistLoad { path: lib_path.to_owned(), source })?;
+    let lib_data: LibData = plist::from_file(lib_path).map_err(UfoLoadError::ParsingLibFile)?;
 
     // Convert features.
     let mut features = String::new();
@@ -197,7 +196,7 @@ pub(crate) fn upconvert_ufov1_robofab_data(
         font_info.postscript_stem_snap_h = ps_hinting_data.h_stems;
         font_info.postscript_stem_snap_v = ps_hinting_data.v_stems;
 
-        font_info.validate().map_err(|_| Error::FontInfoUpconversion)?;
+        font_info.validate().map_err(UfoLoadError::FontInfoV1Upconversion)?;
     }
 
     lib.remove("org.robofab.postScriptHintData");


### PR DESCRIPTION
This experimental PR implements a more layered error hierarchy for better visibility into the error chain.

Example, messing with the `x` attribute for a point:

```
Error: failed to load font 'testdata/MutatorSansLightWide.ufo'

Caused by:
    0: failed to load font
    1: failed to load layer 'foreground' from 'testdata/MutatorSansLightWide.ufo/glyphs'
    2: failed to load glyph 'C' from 'testdata/MutatorSansLightWide.ufo/glyphs/C_.glif'
    3: failed to parse glyph data
    4: bad number
```

It is not entirely possible to have the detailed errors be private, as we expose several public methods that now return them. This made me think: Should we expose e.g. `FontInfo::from_file` and the `LayerSet::load` and `Layer::load` methods as public? 

TODO:
- [x] Decide visibility of new errors and therefore maybe limit the public API?
- [x] Rejig writing errors
- [ ] ~~Better errors for Glif parsing, `GlifLoadError::Parse` is a bit non-descript~~ better done in a separate PR