### PR TITLE
Remove IntegerOrFloat

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -631,7 +631,6 @@ mod tests {
     use tempdir::TempDir;
 
     use super::*;
-    use crate::shared_types::IntegerOrFloat;
 
     #[test]
     fn new_is_v3() {
@@ -753,38 +752,14 @@ mod tests {
         assert_eq!(font_info.postscript_blue_shift, Some(7.));
         assert_eq!(
             font_info.postscript_blue_values,
-            Some(vec![
-                IntegerOrFloat::from(-10),
-                IntegerOrFloat::from(0),
-                IntegerOrFloat::from(482),
-                IntegerOrFloat::from(492),
-                IntegerOrFloat::from(694),
-                IntegerOrFloat::from(704),
-                IntegerOrFloat::from(739),
-                IntegerOrFloat::from(749)
-            ])
+            Some(vec![-10., 0., 482., 492., 694., 704., 739., 749.])
         );
-        assert_eq!(
-            font_info.postscript_other_blues,
-            Some(vec![IntegerOrFloat::from(-260), IntegerOrFloat::from(-250)])
-        );
-        assert_eq!(
-            font_info.postscript_family_blues,
-            Some(vec![IntegerOrFloat::from(500.0), IntegerOrFloat::from(510.0)])
-        );
-        assert_eq!(
-            font_info.postscript_family_other_blues,
-            Some(vec![IntegerOrFloat::from(-260), IntegerOrFloat::from(-250)])
-        );
+        assert_eq!(font_info.postscript_other_blues, Some(vec![-260., -250.]));
+        assert_eq!(font_info.postscript_family_blues, Some(vec![500.0, 510.0]));
+        assert_eq!(font_info.postscript_family_other_blues, Some(vec![-260., -250.]));
         assert_eq!(font_info.postscript_force_bold, Some(true));
-        assert_eq!(
-            font_info.postscript_stem_snap_h,
-            Some(vec![IntegerOrFloat::from(100), IntegerOrFloat::from(120)])
-        );
-        assert_eq!(
-            font_info.postscript_stem_snap_v,
-            Some(vec![IntegerOrFloat::from(80), IntegerOrFloat::from(90)])
-        );
+        assert_eq!(font_info.postscript_stem_snap_h, Some(vec![100., 120.]));
+        assert_eq!(font_info.postscript_stem_snap_v, Some(vec![80., 90.]));
 
         assert_eq!(font.lib.keys().collect::<Vec<&String>>(), vec!["org.robofab.testFontLibData"]);
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -748,9 +748,9 @@ mod tests {
         assert_eq!(font.meta.format_version, FormatVersion::V3);
 
         let font_info = font.font_info;
-        assert_eq!(font_info.postscript_blue_fuzz, Some(IntegerOrFloat::from(1)));
+        assert_eq!(font_info.postscript_blue_fuzz, Some(1.));
         assert_eq!(font_info.postscript_blue_scale, Some(0.039625));
-        assert_eq!(font_info.postscript_blue_shift, Some(IntegerOrFloat::from(7)));
+        assert_eq!(font_info.postscript_blue_shift, Some(7.));
         assert_eq!(
             font_info.postscript_blue_values,
             Some(vec![

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -2,14 +2,14 @@
 //!
 //! [`fontinfo.plist`]: https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/
 
-use std::collections::HashSet;
 use std::path::Path;
+use std::{collections::HashSet, convert::TryFrom, ops::Deref};
 
 use serde::de::Deserializer;
 use serde::ser::{SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
 
-use crate::shared_types::{NonNegativeIntegerOrFloat, PUBLIC_OBJECT_LIBS_KEY};
+use crate::shared_types::PUBLIC_OBJECT_LIBS_KEY;
 use crate::{Error, FormatVersion, Guideline, Identifier, Plist};
 
 /// A signed integer.
@@ -23,6 +23,13 @@ pub type NonNegativeInteger = u32;
 /// This is basically an implementation detail: it is more economical to serialize
 /// an integer where possible.
 pub type IntegerOrFloat = f64;
+
+/// A non-negative number.
+///
+/// This is a detail of the spec. If the fractional part of this number is
+/// 0, it will be serialized as an integer, else as a float.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NonNegativeIntegerOrFloat(f64);
 
 /// A floating-point number.
 pub type Float = f64;
@@ -335,24 +342,24 @@ pub struct FontInfo {
 #[serde(deny_unknown_fields)]
 #[allow(non_snake_case)]
 struct FontInfoV2 {
-    ascender: Option<f64>,
-    capHeight: Option<f64>,
+    ascender: Option<IntegerOrFloat>,
+    capHeight: Option<IntegerOrFloat>,
     copyright: Option<String>,
-    descender: Option<f64>,
+    descender: Option<IntegerOrFloat>,
     familyName: Option<String>,
-    italicAngle: Option<f64>,
+    italicAngle: Option<IntegerOrFloat>,
     macintoshFONDFamilyID: Option<Integer>,
     macintoshFONDName: Option<String>,
     note: Option<String>,
     openTypeHeadCreated: Option<String>,
     openTypeHeadFlags: Option<Bitlist>,
-    openTypeHeadLowestRecPPEM: Option<f64>,
-    openTypeHheaAscender: Option<f64>,
-    openTypeHheaCaretOffset: Option<f64>,
+    openTypeHeadLowestRecPPEM: Option<IntegerOrFloat>,
+    openTypeHheaAscender: Option<IntegerOrFloat>,
+    openTypeHheaCaretOffset: Option<IntegerOrFloat>,
     openTypeHheaCaretSlopeRise: Option<Integer>,
     openTypeHheaCaretSlopeRun: Option<Integer>,
-    openTypeHheaDescender: Option<f64>,
-    openTypeHheaLineGap: Option<f64>,
+    openTypeHheaDescender: Option<IntegerOrFloat>,
+    openTypeHheaLineGap: Option<IntegerOrFloat>,
     openTypeNameCompatibleFullName: Option<String>,
     openTypeNameDescription: Option<String>,
     openTypeNameDesigner: Option<String>,
@@ -372,51 +379,51 @@ struct FontInfoV2 {
     openTypeOS2FamilyClass: Option<Os2FamilyClass>,
     openTypeOS2Panose: Option<Os2PanoseV2>,
     openTypeOS2Selection: Option<Bitlist>,
-    openTypeOS2StrikeoutPosition: Option<f64>,
-    openTypeOS2StrikeoutSize: Option<f64>,
-    openTypeOS2SubscriptXOffset: Option<f64>,
-    openTypeOS2SubscriptXSize: Option<f64>,
-    openTypeOS2SubscriptYOffset: Option<f64>,
-    openTypeOS2SubscriptYSize: Option<f64>,
-    openTypeOS2SuperscriptXOffset: Option<f64>,
-    openTypeOS2SuperscriptXSize: Option<f64>,
-    openTypeOS2SuperscriptYOffset: Option<f64>,
-    openTypeOS2SuperscriptYSize: Option<f64>,
+    openTypeOS2StrikeoutPosition: Option<IntegerOrFloat>,
+    openTypeOS2StrikeoutSize: Option<IntegerOrFloat>,
+    openTypeOS2SubscriptXOffset: Option<IntegerOrFloat>,
+    openTypeOS2SubscriptXSize: Option<IntegerOrFloat>,
+    openTypeOS2SubscriptYOffset: Option<IntegerOrFloat>,
+    openTypeOS2SubscriptYSize: Option<IntegerOrFloat>,
+    openTypeOS2SuperscriptXOffset: Option<IntegerOrFloat>,
+    openTypeOS2SuperscriptXSize: Option<IntegerOrFloat>,
+    openTypeOS2SuperscriptYOffset: Option<IntegerOrFloat>,
+    openTypeOS2SuperscriptYSize: Option<IntegerOrFloat>,
     openTypeOS2Type: Option<Bitlist>,
-    openTypeOS2TypoAscender: Option<f64>,
-    openTypeOS2TypoDescender: Option<f64>,
-    openTypeOS2TypoLineGap: Option<f64>,
+    openTypeOS2TypoAscender: Option<IntegerOrFloat>,
+    openTypeOS2TypoDescender: Option<IntegerOrFloat>,
+    openTypeOS2TypoLineGap: Option<IntegerOrFloat>,
     openTypeOS2UnicodeRanges: Option<Bitlist>,
     openTypeOS2VendorID: Option<String>,
     openTypeOS2WeightClass: Option<NonNegativeInteger>,
     openTypeOS2WidthClass: Option<Os2WidthClass>,
-    openTypeOS2WinAscent: Option<f64>,
-    openTypeOS2WinDescent: Option<f64>,
-    openTypeVheaCaretOffset: Option<f64>,
+    openTypeOS2WinAscent: Option<IntegerOrFloat>,
+    openTypeOS2WinDescent: Option<IntegerOrFloat>,
+    openTypeVheaCaretOffset: Option<IntegerOrFloat>,
     openTypeVheaCaretSlopeRise: Option<Integer>,
     openTypeVheaCaretSlopeRun: Option<Integer>,
-    openTypeVheaVertTypoAscender: Option<f64>,
-    openTypeVheaVertTypoDescender: Option<f64>,
-    openTypeVheaVertTypoLineGap: Option<f64>,
-    postscriptBlueFuzz: Option<f64>,
+    openTypeVheaVertTypoAscender: Option<IntegerOrFloat>,
+    openTypeVheaVertTypoDescender: Option<IntegerOrFloat>,
+    openTypeVheaVertTypoLineGap: Option<IntegerOrFloat>,
+    postscriptBlueFuzz: Option<IntegerOrFloat>,
     postscriptBlueScale: Option<Float>,
-    postscriptBlueShift: Option<f64>,
+    postscriptBlueShift: Option<IntegerOrFloat>,
     postscriptBlueValues: Option<Vec<IntegerOrFloat>>,
     postscriptDefaultCharacter: Option<String>,
-    postscriptDefaultWidthX: Option<f64>,
+    postscriptDefaultWidthX: Option<IntegerOrFloat>,
     postscriptFamilyBlues: Option<Vec<IntegerOrFloat>>,
     postscriptFamilyOtherBlues: Option<Vec<IntegerOrFloat>>,
     postscriptFontName: Option<String>,
     postscriptForceBold: Option<bool>,
     postscriptFullName: Option<String>,
     postscriptIsFixedPitch: Option<bool>,
-    postscriptNominalWidthX: Option<f64>,
+    postscriptNominalWidthX: Option<IntegerOrFloat>,
     postscriptOtherBlues: Option<Vec<IntegerOrFloat>>,
-    postscriptSlantAngle: Option<f64>,
+    postscriptSlantAngle: Option<IntegerOrFloat>,
     postscriptStemSnapH: Option<Vec<IntegerOrFloat>>,
     postscriptStemSnapV: Option<Vec<IntegerOrFloat>>,
-    postscriptUnderlinePosition: Option<f64>,
-    postscriptUnderlineThickness: Option<f64>,
+    postscriptUnderlinePosition: Option<IntegerOrFloat>,
+    postscriptUnderlineThickness: Option<IntegerOrFloat>,
     postscriptUniqueID: Option<Integer>,
     postscriptWeightName: Option<String>,
     postscriptWindowsCharacterSet: Option<PostscriptWindowsCharacterSet>,
@@ -424,10 +431,10 @@ struct FontInfoV2 {
     styleMapStyleName: Option<StyleMapStyle>,
     styleName: Option<String>,
     trademark: Option<String>,
-    unitsPerEm: Option<f64>,
+    unitsPerEm: Option<IntegerOrFloat>,
     versionMajor: Option<Integer>,
     versionMinor: Option<Integer>,
-    xHeight: Option<f64>,
+    xHeight: Option<IntegerOrFloat>,
     year: Option<Integer>,
 }
 
@@ -439,12 +446,12 @@ struct FontInfoV2 {
 #[serde(deny_unknown_fields)]
 #[allow(non_snake_case)]
 struct FontInfoV1 {
-    ascender: Option<f64>,
-    capHeight: Option<f64>,
+    ascender: Option<IntegerOrFloat>,
+    capHeight: Option<IntegerOrFloat>,
     copyright: Option<String>,
     createdBy: Option<String>,
-    defaultWidth: Option<f64>,
-    descender: Option<f64>,
+    defaultWidth: Option<IntegerOrFloat>,
+    descender: Option<IntegerOrFloat>,
     designer: Option<String>,
     designerURL: Option<String>,
     familyName: Option<String>,
@@ -453,7 +460,7 @@ struct FontInfoV1 {
     fontName: Option<String>,
     fontStyle: Option<Integer>,
     fullName: Option<String>,
-    italicAngle: Option<f64>,
+    italicAngle: Option<IntegerOrFloat>,
     license: Option<String>,
     licenseURL: Option<String>,
     menuName: Option<String>,
@@ -463,22 +470,22 @@ struct FontInfoV1 {
     otFamilyName: Option<String>,
     otMacName: Option<String>,
     otStyleName: Option<String>,
-    slantAngle: Option<f64>,
+    slantAngle: Option<IntegerOrFloat>,
     styleName: Option<String>,
     trademark: Option<String>,
     ttUniqueID: Option<String>,
     ttVendor: Option<String>,
     ttVersion: Option<String>,
     uniqueID: Option<Integer>,
-    unitsPerEm: Option<f64>,
+    unitsPerEm: Option<IntegerOrFloat>,
     vendorURL: Option<String>,
     versionMajor: Option<Integer>,
     versionMinor: Option<Integer>,
     weightName: Option<String>,
     weightValue: Option<Integer>,
     widthName: Option<String>,
-    xHeight: Option<f64>,  // Does not appear in spec but ufoLib.
-    year: Option<Integer>, // Does not appear in spec but ufoLib.
+    xHeight: Option<IntegerOrFloat>, // Does not appear in spec but ufoLib.
+    year: Option<Integer>,           // Does not appear in spec but ufoLib.
 }
 
 impl FontInfo {
@@ -972,8 +979,86 @@ impl FontInfo {
     }
 }
 
+impl NonNegativeIntegerOrFloat {
+    /// A validating constructor.
+    ///
+    /// Returns a new [`NonNegativeIntegerOrFloat`] with the given `value`,
+    /// or `None` if the value is less than or equal to zero.
+    ///
+    /// In addition to this constructor, this type also implements `TryFrom` for
+    /// `f64`, and `From` for `u32`.
+    pub fn new(value: f64) -> Option<Self> {
+        if value.is_sign_positive() {
+            Some(NonNegativeIntegerOrFloat(value))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the value as an `f64`.
+    pub fn as_f64(&self) -> f64 {
+        self.0
+    }
+
+    /// Returns `true` if the value is an integer.
+    pub(crate) fn is_integer(&self) -> bool {
+        self.0.fract().abs() < std::f64::EPSILON
+    }
+}
+
+impl Deref for NonNegativeIntegerOrFloat {
+    type Target = f64;
+
+    fn deref(&self) -> &f64 {
+        &self.0
+    }
+}
+
+impl TryFrom<f64> for NonNegativeIntegerOrFloat {
+    type Error = Error;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        match NonNegativeIntegerOrFloat::new(value) {
+            Some(v) => Ok(v),
+            _ => Err(Error::ExpectedPositiveValue),
+        }
+    }
+}
+
+impl From<u32> for NonNegativeIntegerOrFloat {
+    fn from(src: u32) -> NonNegativeIntegerOrFloat {
+        NonNegativeIntegerOrFloat(src as f64)
+    }
+}
+
+impl Serialize for NonNegativeIntegerOrFloat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.is_integer() {
+            serializer.serialize_i32(self.0 as i32)
+        } else {
+            serializer.serialize_f64(self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for NonNegativeIntegerOrFloat {
+    fn deserialize<D>(deserializer: D) -> Result<NonNegativeIntegerOrFloat, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value: f64 = Deserialize::deserialize(deserializer)?;
+        match NonNegativeIntegerOrFloat::try_from(value) {
+            Ok(v) => Ok(v),
+            Err(_) => Err(serde::de::Error::custom("Value must be positive.")),
+        }
+    }
+}
+
 mod serde_impls {
-    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{ser::SerializeSeq, Serialize, Serializer};
 
     struct IntegerOrFloat(f64);
 
@@ -987,15 +1072,6 @@ mod serde_impls {
             } else {
                 serializer.serialize_f64(self.0)
             }
-        }
-    }
-
-    impl<'de> Deserialize<'de> for IntegerOrFloat {
-        fn deserialize<D>(deserializer: D) -> Result<IntegerOrFloat, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            f64::deserialize(deserializer).map(IntegerOrFloat)
         }
     }
 
@@ -1800,5 +1876,11 @@ mod tests {
             ),
         ]);
         assert!(fi.validate().is_err());
+    }
+
+    #[test]
+    fn test_positive_int_or_float() {
+        assert!(NonNegativeIntegerOrFloat::try_from(-1.0).is_err());
+        assert!(NonNegativeIntegerOrFloat::try_from(1.0).is_ok());
     }
 }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -9,15 +9,24 @@ use serde::de::Deserializer;
 use serde::ser::{SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
 
-use crate::shared_types::{IntegerOrFloat, NonNegativeIntegerOrFloat, PUBLIC_OBJECT_LIBS_KEY};
+use crate::shared_types::{NonNegativeIntegerOrFloat, PUBLIC_OBJECT_LIBS_KEY};
 use crate::{Error, FormatVersion, Guideline, Identifier, Plist};
 
 /// A signed integer.
 pub type Integer = i32;
+
 /// An unsigned integer.
 pub type NonNegativeInteger = u32;
+
+/// A number that may be be an integer or a float.
+///
+/// This is basically an implementation detail: it is more economical to serialize
+/// an integer where possible.
+pub type IntegerOrFloat = f64;
+
 /// A floating-point number.
 pub type Float = f64;
+
 /// a list of ["bit numbers"].
 ///
 /// ["bit numbers"]: https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#bit-numbers
@@ -34,24 +43,24 @@ pub struct FontInfo {
     // INFO: Keep this struct sorted alphabetically, serde serializes it in the order you see
     // here and Plist files should be sorted.
     /// Ascender value (ascender).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
     pub ascender: Option<f64>,
     /// Cap height value (capHeight).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub cap_height: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub cap_height: Option<IntegerOrFloat>,
     /// Copyright statement (copyright).
     pub copyright: Option<String>,
     /// Descender value (descender).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub descender: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub descender: Option<IntegerOrFloat>,
     /// Family name (familyName).
     pub family_name: Option<String>,
     /// Guideline definitions that apply to all glyphs in
     /// all layers (guidelines).
     pub guidelines: Option<Vec<Guideline>>,
     /// Italic angle in counter-clockwise degrees (italicAngle).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub italic_angle: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub italic_angle: Option<IntegerOrFloat>,
     /// Family ID number (macintoshFONDFamilyID).
     #[serde(rename = "macintoshFONDFamilyID")]
     pub macintosh_fond_family_id: Option<Integer>,
@@ -206,26 +215,29 @@ pub struct FontInfo {
     /// Line gap value (openTypeVheaVertTypoLineGap).
     pub open_type_vhea_vert_typo_line_gap: Option<Integer>,
     /// Postscript BlueFuzz value (postscriptBlueFuzz).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub postscript_blue_fuzz: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub postscript_blue_fuzz: Option<IntegerOrFloat>,
     /// Postscript BlueScale value (postscriptBlueScale).
     pub postscript_blue_scale: Option<Float>,
     /// Postscript BlueShift value (postscriptBlueShift).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub postscript_blue_shift: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub postscript_blue_shift: Option<IntegerOrFloat>,
     /// A collection of values that should be in the
     /// Type 1/CFF BlueValues field (postscriptBlueValues).
+    #[serde(serialize_with = "serde_impls::ser_opt_vec_int_or_float")]
     pub postscript_blue_values: Option<Vec<IntegerOrFloat>>,
     /// Name of default glyph in PFM files (postscriptDefaultCharacter).
     pub postscript_default_character: Option<String>,
     /// Default glyph width (postscriptDefaultWidthX).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub postscript_default_width_x: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub postscript_default_width_x: Option<IntegerOrFloat>,
     /// A collection of values that should be in the Type 1/CFF
     /// FamilyBlues field (postscriptFamilyBlues).
+    #[serde(serialize_with = "serde_impls::ser_opt_vec_int_or_float")]
     pub postscript_family_blues: Option<Vec<IntegerOrFloat>>,
     /// A collection of values that should be in the Type 1/CFF
     /// FamilyOtherBlues field (postscriptFamilyOtherBlues).
+    #[serde(serialize_with = "serde_impls::ser_opt_vec_int_or_float")]
     pub postscript_family_other_blues: Option<Vec<IntegerOrFloat>>,
     /// Type 1/CFF table FontName field (postscriptFontName).
     pub postscript_font_name: Option<String>,
@@ -238,27 +250,30 @@ pub struct FontInfo {
     /// (postscriptIsFixedPitch).
     pub postscript_is_fixed_pitch: Option<bool>,
     /// Glyph nominal width (postscriptNominalWidthX).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub postscript_nominal_width_x: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub postscript_nominal_width_x: Option<IntegerOrFloat>,
     /// A collection of values that should be in the Type 1/CFF
     /// OtherBlues field (postscriptOtherBlues).
+    #[serde(serialize_with = "serde_impls::ser_opt_vec_int_or_float")]
     pub postscript_other_blues: Option<Vec<IntegerOrFloat>>,
     /// Slant angle in counter-clockwise degrees from the vertical
     /// (postscriptSlantAngle).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub postscript_slant_angle: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub postscript_slant_angle: Option<IntegerOrFloat>,
     /// A collection of horizontal stems sorted in the order specified
     /// in the Type 1/CFF specification (postscriptStemSnapH).
+    #[serde(serialize_with = "serde_impls::ser_opt_vec_int_or_float")]
     pub postscript_stem_snap_h: Option<Vec<IntegerOrFloat>>,
     /// A collection of vertical stems sorted in the order specified
     /// in the Type 1/CFF specification (postscriptStemSnapV).
+    #[serde(serialize_with = "serde_impls::ser_opt_vec_int_or_float")]
     pub postscript_stem_snap_v: Option<Vec<IntegerOrFloat>>,
     /// Underline position value (postscriptUnderlinePosition).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub postscript_underline_position: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub postscript_underline_position: Option<IntegerOrFloat>,
     /// Underline thickness value (postscriptUnderlineThickness).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub postscript_underline_thickness: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub postscript_underline_thickness: Option<IntegerOrFloat>,
     /// Unique ID as specified by the Type 1/CFF specification
     /// (postscriptUniqueID).
     #[serde(rename = "postscriptUniqueID")]
@@ -306,8 +321,8 @@ pub struct FontInfo {
     /// Minor version number (woffMinorVersion).
     pub woff_minor_version: Option<NonNegativeInteger>,
     /// x-height value (xHeight).
-    #[serde(default, with = "serde_impls::opt_int_or_float")]
-    pub x_height: Option<f64>,
+    #[serde(serialize_with = "serde_impls::ser_opt_int_or_float")]
+    pub x_height: Option<IntegerOrFloat>,
     /// Year that the font was created (year).
     pub year: Option<Integer>,
 }
@@ -958,7 +973,7 @@ impl FontInfo {
 }
 
 mod serde_impls {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 
     struct IntegerOrFloat(f64);
 
@@ -984,20 +999,26 @@ mod serde_impls {
         }
     }
 
-    pub(crate) mod opt_int_or_float {
-        use super::*;
+    pub(crate) fn ser_opt_int_or_float<S: Serializer>(
+        value: &Option<f64>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        value.map(IntegerOrFloat).serialize(serializer)
+    }
 
-        pub(crate) fn serialize<S: Serializer>(
-            value: &Option<f64>,
-            serializer: S,
-        ) -> Result<S::Ok, S::Error> {
-            value.map(IntegerOrFloat).serialize(serializer)
-        }
-
-        pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
-            deserializer: D,
-        ) -> Result<Option<f64>, D::Error> {
-            Option::<IntegerOrFloat>::deserialize(deserializer).map(|r| r.map(|v| v.0))
+    pub(crate) fn ser_opt_vec_int_or_float<S: Serializer>(
+        value: &Option<Vec<f64>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match value {
+            None => serializer.serialize_none(),
+            Some(items) => {
+                let mut seq = serializer.serialize_seq(Some(items.len()))?;
+                for item in items {
+                    seq.serialize_element(&IntegerOrFloat(*item))?;
+                }
+                seq.end()
+            }
         }
     }
 }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -34,20 +34,24 @@ pub struct FontInfo {
     // INFO: Keep this struct sorted alphabetically, serde serializes it in the order you see
     // here and Plist files should be sorted.
     /// Ascender value (ascender).
-    pub ascender: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub ascender: Option<f64>,
     /// Cap height value (capHeight).
-    pub cap_height: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub cap_height: Option<f64>,
     /// Copyright statement (copyright).
     pub copyright: Option<String>,
     /// Descender value (descender).
-    pub descender: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub descender: Option<f64>,
     /// Family name (familyName).
     pub family_name: Option<String>,
     /// Guideline definitions that apply to all glyphs in
     /// all layers (guidelines).
     pub guidelines: Option<Vec<Guideline>>,
     /// Italic angle in counter-clockwise degrees (italicAngle).
-    pub italic_angle: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub italic_angle: Option<f64>,
     /// Family ID number (macintoshFONDFamilyID).
     #[serde(rename = "macintoshFONDFamilyID")]
     pub macintosh_fond_family_id: Option<Integer>,
@@ -202,18 +206,21 @@ pub struct FontInfo {
     /// Line gap value (openTypeVheaVertTypoLineGap).
     pub open_type_vhea_vert_typo_line_gap: Option<Integer>,
     /// Postscript BlueFuzz value (postscriptBlueFuzz).
-    pub postscript_blue_fuzz: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub postscript_blue_fuzz: Option<f64>,
     /// Postscript BlueScale value (postscriptBlueScale).
     pub postscript_blue_scale: Option<Float>,
     /// Postscript BlueShift value (postscriptBlueShift).
-    pub postscript_blue_shift: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub postscript_blue_shift: Option<f64>,
     /// A collection of values that should be in the
     /// Type 1/CFF BlueValues field (postscriptBlueValues).
     pub postscript_blue_values: Option<Vec<IntegerOrFloat>>,
     /// Name of default glyph in PFM files (postscriptDefaultCharacter).
     pub postscript_default_character: Option<String>,
     /// Default glyph width (postscriptDefaultWidthX).
-    pub postscript_default_width_x: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub postscript_default_width_x: Option<f64>,
     /// A collection of values that should be in the Type 1/CFF
     /// FamilyBlues field (postscriptFamilyBlues).
     pub postscript_family_blues: Option<Vec<IntegerOrFloat>>,
@@ -231,13 +238,15 @@ pub struct FontInfo {
     /// (postscriptIsFixedPitch).
     pub postscript_is_fixed_pitch: Option<bool>,
     /// Glyph nominal width (postscriptNominalWidthX).
-    pub postscript_nominal_width_x: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub postscript_nominal_width_x: Option<f64>,
     /// A collection of values that should be in the Type 1/CFF
     /// OtherBlues field (postscriptOtherBlues).
     pub postscript_other_blues: Option<Vec<IntegerOrFloat>>,
     /// Slant angle in counter-clockwise degrees from the vertical
     /// (postscriptSlantAngle).
-    pub postscript_slant_angle: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub postscript_slant_angle: Option<f64>,
     /// A collection of horizontal stems sorted in the order specified
     /// in the Type 1/CFF specification (postscriptStemSnapH).
     pub postscript_stem_snap_h: Option<Vec<IntegerOrFloat>>,
@@ -245,9 +254,11 @@ pub struct FontInfo {
     /// in the Type 1/CFF specification (postscriptStemSnapV).
     pub postscript_stem_snap_v: Option<Vec<IntegerOrFloat>>,
     /// Underline position value (postscriptUnderlinePosition).
-    pub postscript_underline_position: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub postscript_underline_position: Option<f64>,
     /// Underline thickness value (postscriptUnderlineThickness).
-    pub postscript_underline_thickness: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub postscript_underline_thickness: Option<f64>,
     /// Unique ID as specified by the Type 1/CFF specification
     /// (postscriptUniqueID).
     #[serde(rename = "postscriptUniqueID")]
@@ -295,7 +306,8 @@ pub struct FontInfo {
     /// Minor version number (woffMinorVersion).
     pub woff_minor_version: Option<NonNegativeInteger>,
     /// x-height value (xHeight).
-    pub x_height: Option<IntegerOrFloat>,
+    #[serde(default, with = "serde_impls::opt_int_or_float")]
+    pub x_height: Option<f64>,
     /// Year that the font was created (year).
     pub year: Option<Integer>,
 }
@@ -308,24 +320,24 @@ pub struct FontInfo {
 #[serde(deny_unknown_fields)]
 #[allow(non_snake_case)]
 struct FontInfoV2 {
-    ascender: Option<IntegerOrFloat>,
-    capHeight: Option<IntegerOrFloat>,
+    ascender: Option<f64>,
+    capHeight: Option<f64>,
     copyright: Option<String>,
-    descender: Option<IntegerOrFloat>,
+    descender: Option<f64>,
     familyName: Option<String>,
-    italicAngle: Option<IntegerOrFloat>,
+    italicAngle: Option<f64>,
     macintoshFONDFamilyID: Option<Integer>,
     macintoshFONDName: Option<String>,
     note: Option<String>,
     openTypeHeadCreated: Option<String>,
     openTypeHeadFlags: Option<Bitlist>,
-    openTypeHeadLowestRecPPEM: Option<IntegerOrFloat>,
-    openTypeHheaAscender: Option<IntegerOrFloat>,
-    openTypeHheaCaretOffset: Option<IntegerOrFloat>,
+    openTypeHeadLowestRecPPEM: Option<f64>,
+    openTypeHheaAscender: Option<f64>,
+    openTypeHheaCaretOffset: Option<f64>,
     openTypeHheaCaretSlopeRise: Option<Integer>,
     openTypeHheaCaretSlopeRun: Option<Integer>,
-    openTypeHheaDescender: Option<IntegerOrFloat>,
-    openTypeHheaLineGap: Option<IntegerOrFloat>,
+    openTypeHheaDescender: Option<f64>,
+    openTypeHheaLineGap: Option<f64>,
     openTypeNameCompatibleFullName: Option<String>,
     openTypeNameDescription: Option<String>,
     openTypeNameDesigner: Option<String>,
@@ -345,51 +357,51 @@ struct FontInfoV2 {
     openTypeOS2FamilyClass: Option<Os2FamilyClass>,
     openTypeOS2Panose: Option<Os2PanoseV2>,
     openTypeOS2Selection: Option<Bitlist>,
-    openTypeOS2StrikeoutPosition: Option<IntegerOrFloat>,
-    openTypeOS2StrikeoutSize: Option<IntegerOrFloat>,
-    openTypeOS2SubscriptXOffset: Option<IntegerOrFloat>,
-    openTypeOS2SubscriptXSize: Option<IntegerOrFloat>,
-    openTypeOS2SubscriptYOffset: Option<IntegerOrFloat>,
-    openTypeOS2SubscriptYSize: Option<IntegerOrFloat>,
-    openTypeOS2SuperscriptXOffset: Option<IntegerOrFloat>,
-    openTypeOS2SuperscriptXSize: Option<IntegerOrFloat>,
-    openTypeOS2SuperscriptYOffset: Option<IntegerOrFloat>,
-    openTypeOS2SuperscriptYSize: Option<IntegerOrFloat>,
+    openTypeOS2StrikeoutPosition: Option<f64>,
+    openTypeOS2StrikeoutSize: Option<f64>,
+    openTypeOS2SubscriptXOffset: Option<f64>,
+    openTypeOS2SubscriptXSize: Option<f64>,
+    openTypeOS2SubscriptYOffset: Option<f64>,
+    openTypeOS2SubscriptYSize: Option<f64>,
+    openTypeOS2SuperscriptXOffset: Option<f64>,
+    openTypeOS2SuperscriptXSize: Option<f64>,
+    openTypeOS2SuperscriptYOffset: Option<f64>,
+    openTypeOS2SuperscriptYSize: Option<f64>,
     openTypeOS2Type: Option<Bitlist>,
-    openTypeOS2TypoAscender: Option<IntegerOrFloat>,
-    openTypeOS2TypoDescender: Option<IntegerOrFloat>,
-    openTypeOS2TypoLineGap: Option<IntegerOrFloat>,
+    openTypeOS2TypoAscender: Option<f64>,
+    openTypeOS2TypoDescender: Option<f64>,
+    openTypeOS2TypoLineGap: Option<f64>,
     openTypeOS2UnicodeRanges: Option<Bitlist>,
     openTypeOS2VendorID: Option<String>,
     openTypeOS2WeightClass: Option<NonNegativeInteger>,
     openTypeOS2WidthClass: Option<Os2WidthClass>,
-    openTypeOS2WinAscent: Option<IntegerOrFloat>,
-    openTypeOS2WinDescent: Option<IntegerOrFloat>,
-    openTypeVheaCaretOffset: Option<IntegerOrFloat>,
+    openTypeOS2WinAscent: Option<f64>,
+    openTypeOS2WinDescent: Option<f64>,
+    openTypeVheaCaretOffset: Option<f64>,
     openTypeVheaCaretSlopeRise: Option<Integer>,
     openTypeVheaCaretSlopeRun: Option<Integer>,
-    openTypeVheaVertTypoAscender: Option<IntegerOrFloat>,
-    openTypeVheaVertTypoDescender: Option<IntegerOrFloat>,
-    openTypeVheaVertTypoLineGap: Option<IntegerOrFloat>,
-    postscriptBlueFuzz: Option<IntegerOrFloat>,
+    openTypeVheaVertTypoAscender: Option<f64>,
+    openTypeVheaVertTypoDescender: Option<f64>,
+    openTypeVheaVertTypoLineGap: Option<f64>,
+    postscriptBlueFuzz: Option<f64>,
     postscriptBlueScale: Option<Float>,
-    postscriptBlueShift: Option<IntegerOrFloat>,
+    postscriptBlueShift: Option<f64>,
     postscriptBlueValues: Option<Vec<IntegerOrFloat>>,
     postscriptDefaultCharacter: Option<String>,
-    postscriptDefaultWidthX: Option<IntegerOrFloat>,
+    postscriptDefaultWidthX: Option<f64>,
     postscriptFamilyBlues: Option<Vec<IntegerOrFloat>>,
     postscriptFamilyOtherBlues: Option<Vec<IntegerOrFloat>>,
     postscriptFontName: Option<String>,
     postscriptForceBold: Option<bool>,
     postscriptFullName: Option<String>,
     postscriptIsFixedPitch: Option<bool>,
-    postscriptNominalWidthX: Option<IntegerOrFloat>,
+    postscriptNominalWidthX: Option<f64>,
     postscriptOtherBlues: Option<Vec<IntegerOrFloat>>,
-    postscriptSlantAngle: Option<IntegerOrFloat>,
+    postscriptSlantAngle: Option<f64>,
     postscriptStemSnapH: Option<Vec<IntegerOrFloat>>,
     postscriptStemSnapV: Option<Vec<IntegerOrFloat>>,
-    postscriptUnderlinePosition: Option<IntegerOrFloat>,
-    postscriptUnderlineThickness: Option<IntegerOrFloat>,
+    postscriptUnderlinePosition: Option<f64>,
+    postscriptUnderlineThickness: Option<f64>,
     postscriptUniqueID: Option<Integer>,
     postscriptWeightName: Option<String>,
     postscriptWindowsCharacterSet: Option<PostscriptWindowsCharacterSet>,
@@ -397,10 +409,10 @@ struct FontInfoV2 {
     styleMapStyleName: Option<StyleMapStyle>,
     styleName: Option<String>,
     trademark: Option<String>,
-    unitsPerEm: Option<IntegerOrFloat>,
+    unitsPerEm: Option<f64>,
     versionMajor: Option<Integer>,
     versionMinor: Option<Integer>,
-    xHeight: Option<IntegerOrFloat>,
+    xHeight: Option<f64>,
     year: Option<Integer>,
 }
 
@@ -412,12 +424,12 @@ struct FontInfoV2 {
 #[serde(deny_unknown_fields)]
 #[allow(non_snake_case)]
 struct FontInfoV1 {
-    ascender: Option<IntegerOrFloat>,
-    capHeight: Option<IntegerOrFloat>,
+    ascender: Option<f64>,
+    capHeight: Option<f64>,
     copyright: Option<String>,
     createdBy: Option<String>,
-    defaultWidth: Option<IntegerOrFloat>,
-    descender: Option<IntegerOrFloat>,
+    defaultWidth: Option<f64>,
+    descender: Option<f64>,
     designer: Option<String>,
     designerURL: Option<String>,
     familyName: Option<String>,
@@ -426,7 +438,7 @@ struct FontInfoV1 {
     fontName: Option<String>,
     fontStyle: Option<Integer>,
     fullName: Option<String>,
-    italicAngle: Option<IntegerOrFloat>,
+    italicAngle: Option<f64>,
     license: Option<String>,
     licenseURL: Option<String>,
     menuName: Option<String>,
@@ -436,22 +448,22 @@ struct FontInfoV1 {
     otFamilyName: Option<String>,
     otMacName: Option<String>,
     otStyleName: Option<String>,
-    slantAngle: Option<IntegerOrFloat>,
+    slantAngle: Option<f64>,
     styleName: Option<String>,
     trademark: Option<String>,
     ttUniqueID: Option<String>,
     ttVendor: Option<String>,
     ttVersion: Option<String>,
     uniqueID: Option<Integer>,
-    unitsPerEm: Option<IntegerOrFloat>,
+    unitsPerEm: Option<f64>,
     vendorURL: Option<String>,
     versionMajor: Option<Integer>,
     versionMinor: Option<Integer>,
     weightName: Option<String>,
     weightValue: Option<Integer>,
     widthName: Option<String>,
-    xHeight: Option<IntegerOrFloat>, // Does not appear in spec but ufoLib.
-    year: Option<Integer>,           // Does not appear in spec but ufoLib.
+    xHeight: Option<f64>,  // Does not appear in spec but ufoLib.
+    year: Option<Integer>, // Does not appear in spec but ufoLib.
 }
 
 impl FontInfo {
@@ -942,6 +954,51 @@ impl FontInfo {
         }
 
         object_libs
+    }
+}
+
+mod serde_impls {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    struct IntegerOrFloat(f64);
+
+    impl Serialize for IntegerOrFloat {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            if self.0.fract().abs() <= f64::EPSILON {
+                serializer.serialize_i32(self.0 as i32)
+            } else {
+                serializer.serialize_f64(self.0)
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for IntegerOrFloat {
+        fn deserialize<D>(deserializer: D) -> Result<IntegerOrFloat, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            f64::deserialize(deserializer).map(IntegerOrFloat)
+        }
+    }
+
+    pub(crate) mod opt_int_or_float {
+        use super::*;
+
+        pub(crate) fn serialize<S: Serializer>(
+            value: &Option<f64>,
+            serializer: S,
+        ) -> Result<S::Ok, S::Error> {
+            value.map(IntegerOrFloat).serialize(serializer)
+        }
+
+        pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+            deserializer: D,
+        ) -> Result<Option<f64>, D::Error> {
+            Option::<IntegerOrFloat>::deserialize(deserializer).map(|r| r.map(|v| v.0))
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,5 +101,5 @@ pub use guideline::{Guideline, Line};
 pub use identifier::Identifier;
 pub use kerning::Kerning;
 pub use layer::{Layer, LayerSet};
-pub use shared_types::{Color, IntegerOrFloat, NonNegativeIntegerOrFloat, Plist};
+pub use shared_types::{Color, NonNegativeIntegerOrFloat, Plist};
 pub use write::{QuoteChar, WriteOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,5 +101,5 @@ pub use guideline::{Guideline, Line};
 pub use identifier::Identifier;
 pub use kerning::Kerning;
 pub use layer::{Layer, LayerSet};
-pub use shared_types::{Color, NonNegativeIntegerOrFloat, Plist};
+pub use shared_types::{Color, Plist};
 pub use write::{QuoteChar, WriteOptions};

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -5,7 +5,6 @@ use crate::fontinfo::FontInfo;
 use crate::groups::Groups;
 use crate::kerning::Kerning;
 use crate::names::NameList;
-use crate::shared_types::IntegerOrFloat;
 use crate::Error;
 
 /// Convert kerning groups and pairs from v1 and v2 informal conventions to
@@ -139,13 +138,13 @@ pub(crate) fn upconvert_ufov1_robofab_data(
         blue_fuzz: Option<f64>,
         blue_scale: Option<f64>,
         blue_shift: Option<f64>,
-        blue_values: Option<Vec<Vec<IntegerOrFloat>>>,
-        family_blues: Option<Vec<Vec<IntegerOrFloat>>>,
-        family_other_blues: Option<Vec<Vec<IntegerOrFloat>>>,
+        blue_values: Option<Vec<Vec<f64>>>,
+        family_blues: Option<Vec<Vec<f64>>>,
+        family_other_blues: Option<Vec<Vec<f64>>>,
         force_bold: Option<bool>,
-        other_blues: Option<Vec<Vec<IntegerOrFloat>>>,
-        h_stems: Option<Vec<IntegerOrFloat>>,
-        v_stems: Option<Vec<IntegerOrFloat>>,
+        other_blues: Option<Vec<Vec<f64>>>,
+        h_stems: Option<Vec<f64>>,
+        v_stems: Option<Vec<f64>>,
     }
 
     // Read lib.plist again because it is easier than pulling out the data manually.

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -136,9 +136,9 @@ pub(crate) fn upconvert_ufov1_robofab_data(
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct PsHintingData {
-        blue_fuzz: Option<IntegerOrFloat>,
+        blue_fuzz: Option<f64>,
         blue_scale: Option<f64>,
-        blue_shift: Option<IntegerOrFloat>,
+        blue_shift: Option<f64>,
         blue_values: Option<Vec<Vec<IntegerOrFloat>>>,
         family_blues: Option<Vec<Vec<IntegerOrFloat>>>,
         family_other_blues: Option<Vec<Vec<IntegerOrFloat>>>,


### PR DESCRIPTION
This removes the IntegerOrFloat type. My sense is that this type is really an implementation detail around how certain values should be serialized; so with this we handle fields of this type by using serde's `serialize_with` annotation.

This keeps `NonNegativeIntegerOrFloat`, but moves it into the `fontinfo` module.

