### PR TITLE
Remove `write_plist_value_to_file`

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -466,7 +466,7 @@ impl Font {
         }
         if !lib.is_empty() {
             crate::util::recursive_sort_plist_keys(&mut lib);
-            write::write_plist_value_to_file(&path.join(LIB_FILE), &lib.into(), options)?;
+            write::write_xml_to_file(&path.join(LIB_FILE), &lib, options)?;
         }
 
         if !self.groups.is_empty() {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -314,7 +314,7 @@ impl Layer {
 
         util::recursive_sort_plist_keys(&mut dict);
 
-        crate::write::write_plist_value_to_file(&path.join(LAYER_INFO_FILE), &dict.into(), options)
+        crate::write::write_xml_to_file(&path.join(LAYER_INFO_FILE), &dict, options)
     }
 
     /// Serialize this layer to the given path with the default


### PR DESCRIPTION
And take the remaining code private. The newest plist crate implements `serde::Serialize` for values.