### PR TITLE
Only store Arc<Glyph> if 'druid' feature is enabled

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -5,7 +5,6 @@
 use std::borrow::Borrow;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use crate::datastore::{DataStore, ImageStore};
 use crate::error::{FontLoadError, FontWriteError};
@@ -587,7 +586,7 @@ impl Font {
 
     /// Returns a reference to the glyph with the given name _in the default
     /// layer_.
-    pub fn get_glyph<K>(&self, key: &K) -> Option<&Arc<Glyph>>
+    pub fn get_glyph<K>(&self, key: &K) -> Option<&Glyph>
     where
         GlyphName: Borrow<K>,
         K: Ord + ?Sized,


### PR DESCRIPTION
This was motivated by seeing some code where a user (@ctrlcctrlv) was
jumping through hoops to get around the fact that we were using `Arc`.

`Arc` was only used originally because it is important for druid, but
I'm not sure it makes sense as a more general design.

With this patch, we will only use `Arc` if the user enables the 'druid'
feature.

The default API now operates on `Glyph` objects directly; where needed
there are new _raw methods, behind the 'druid' feature, that operaate on
Arc<Glyph>.


Does this makes sense to folks? @chrissimpkins @ctrlcctrlv @simoncozens are your lives improved in any way by this change?