### PR TITLE
Cut down builder

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -469,9 +469,6 @@ pub enum ErrorKind {
     /// Missing a close tag.
     #[error("missing close tag")]
     MissingCloseTag,
-    /// Has an unexpected tag.
-    #[error("unexpected tag")]
-    UnexpectedTag,
     /// Has an invalid hexadecimal value.
     #[error("bad hex value")]
     BadHexValue,

--- a/src/error.rs
+++ b/src/error.rs
@@ -556,6 +556,27 @@ pub enum ErrorKind {
     /// Has an unexpected image field.
     #[error("unexpected image field")]
     UnexpectedImageField,
+    /// An element that can occur just once occured a second time.
+    #[error("there must be only one '{0}' element")]
+    DuplicateElement(&'static str),
+    /// An element that can occur just once occured a second time.
+    #[error("unexpected element in a format 1 glif: {0}")]
+    UnexpectedV1Element(&'static str),
+    /// An element that can occur just once occured a second time.
+    #[error("unexpected attribute in a format 1 glif: {0}")]
+    UnexpectedV1Attribute(&'static str),
+    /// A component had an empty `base` attribute.
+    #[error("a 'component' element has an empty 'base' attribute")]
+    ComponentEmptyBase,
+    /// A component was missing a `base` attribute.
+    #[error("a 'component' element is missing a 'base' attribute")]
+    ComponentMissingBase,
+    /// The glyph 'lib' element must contain a dictionary.
+    #[error("the glyph lib must be a dictionary")]
+    LibMustBeDictionary,
+    /// An angle was out of bounds.
+    #[error("an angle must be between 0 and 360°")]
+    BadAngle,
 }
 
 #[doc(hidden)]

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -84,7 +84,7 @@ impl<'names> GlifParser<'names> {
                         seen_note = true;
                         self.parse_note(reader, buf)?
                     }
-                    _other => return Err(ErrorKind::UnexpectedTag.into()),
+                    _other => return Err(ErrorKind::UnexpectedElement.into()),
                 },
                 // The rest are expected to be empty element tags (exception: outline) with attributes.
                 Event::Empty(start) => match start.name() {
@@ -124,7 +124,7 @@ impl<'names> GlifParser<'names> {
                         seen_image = true;
                         self.parse_image(reader, start)?
                     }
-                    _other => return Err(ErrorKind::UnexpectedTag.into()),
+                    _other => return Err(ErrorKind::UnexpectedElement.into()),
                 },
                 Event::End(ref end) if end.name() == b"glyph" => break,
                 _other => return Err(ErrorKind::MissingCloseTag.into()),
@@ -156,7 +156,7 @@ impl<'names> GlifParser<'names> {
                         b"contour" => {
                             self.parse_contour(start, reader, &mut new_buf, &mut outline_builder)?
                         }
-                        _other => return Err(ErrorKind::UnexpectedTag.into()),
+                        _other => return Err(ErrorKind::UnexpectedElement.into()),
                     }
                 }
                 Event::Empty(start) => {
@@ -165,7 +165,7 @@ impl<'names> GlifParser<'names> {
                         b"component" => {
                             self.parse_component(reader, start, &mut outline_builder)?
                         }
-                        _other => return Err(ErrorKind::UnexpectedTag.into()),
+                        _other => return Err(ErrorKind::UnexpectedElement.into()),
                     }
                 }
                 Event::End(ref end) if end.name() == b"outline" => break,

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::path::PathBuf;
@@ -7,7 +6,7 @@ use std::sync::Arc;
 
 use super::*;
 use crate::error::{ErrorKind, GlifLoadError};
-use crate::glyph::builder::{GlyphBuilder, Outline, OutlineBuilder};
+use crate::glyph::builder::OutlineBuilder;
 use crate::names::NameList;
 
 use quick_xml::{
@@ -21,7 +20,8 @@ pub(crate) fn parse_glyph(xml: &[u8]) -> Result<Glyph, GlifLoadError> {
 }
 
 pub(crate) struct GlifParser<'names> {
-    builder: GlyphBuilder,
+    glyph: Glyph,
+    seen_identifiers: HashSet<Identifier>,
     /// Optional set of glyph names to be reused between glyphs.
     names: Option<&'names NameList>,
 }
@@ -35,8 +35,12 @@ impl<'names> GlifParser<'names> {
         let mut buf = Vec::new();
         reader.trim_text(true);
 
-        start(&mut reader, &mut buf).and_then(|builder| {
-            GlifParser { builder, names }.parse_body(&mut reader, xml, &mut buf)
+        start(&mut reader, &mut buf).and_then(|glyph| {
+            GlifParser { glyph, seen_identifiers: HashSet::new(), names }.parse_body(
+                &mut reader,
+                xml,
+                &mut buf,
+            )
         })
     }
 
@@ -46,43 +50,91 @@ impl<'names> GlifParser<'names> {
         raw_xml: &[u8],
         buf: &mut Vec<u8>,
     ) -> Result<Glyph, GlifLoadError> {
+        let mut seen_advance = false;
+        let mut seen_image = false;
+        let mut seen_lib = false;
+        let mut seen_note = false;
+        let mut seen_outline = false;
+
         loop {
             match reader.read_event(buf)? {
                 // outline, lib and note are expected to be start element tags.
-                Event::Start(start) => {
-                    let tag_name = reader.decode(start.name())?;
-                    match tag_name.borrow() {
-                        "outline" => self.parse_outline(reader, buf)?,
-                        "lib" => self.parse_lib(reader, raw_xml, buf)?, // do this at some point?
-                        "note" => self.parse_note(reader, buf)?,
-                        _other => return Err(ErrorKind::UnexpectedTag.into()),
-                    }
-                }
-                // The rest are expected to be empty element tags (exception: outline) with attributes.
-                Event::Empty(start) => {
-                    let tag_name = reader.decode(start.name())?;
-                    match tag_name.borrow() {
-                        "outline" => {
-                            // ufoLib parses `<outline/>` as an empty outline.
-                            self.builder.outline(Outline::default(), HashSet::new())?;
+                Event::Start(start) => match start.name() {
+                    b"outline" => {
+                        if seen_outline {
+                            return Err(ErrorKind::DuplicateElement("outline").into());
                         }
-                        "advance" => self.parse_advance(reader, start)?,
-                        "unicode" => self.parse_unicode(reader, start)?,
-                        "anchor" => self.parse_anchor(reader, start)?,
-                        "guideline" => self.parse_guideline(reader, start)?,
-                        "image" => self.parse_image(reader, start)?,
-                        _other => return Err(ErrorKind::UnexpectedTag.into()),
+                        seen_outline = true;
+                        self.parse_outline(reader, buf)?
                     }
-                }
+                    b"lib" => {
+                        if seen_lib {
+                            return Err(ErrorKind::DuplicateElement("lib").into());
+                        }
+                        seen_lib = true;
+                        self.parse_lib(reader, raw_xml, buf)?
+                    }
+                    b"note" => {
+                        if self.glyph.format == GlifVersion::V1 {
+                            return Err(ErrorKind::UnexpectedV1Element("note").into());
+                        }
+                        if seen_note {
+                            return Err(ErrorKind::DuplicateElement("note").into());
+                        }
+                        seen_note = true;
+                        self.parse_note(reader, buf)?
+                    }
+                    _other => return Err(ErrorKind::UnexpectedTag.into()),
+                },
+                // The rest are expected to be empty element tags (exception: outline) with attributes.
+                Event::Empty(start) => match start.name() {
+                    b"outline" => {
+                        if seen_outline {
+                            return Err(ErrorKind::DuplicateElement("outline").into());
+                        }
+                        seen_outline = true;
+                    }
+                    b"advance" => {
+                        if seen_advance {
+                            return Err(ErrorKind::DuplicateElement("advance").into());
+                        }
+                        seen_advance = true;
+                        self.parse_advance(reader, start)?
+                    }
+                    b"unicode" => self.parse_unicode(reader, start)?,
+                    b"anchor" => {
+                        if self.glyph.format == GlifVersion::V1 {
+                            return Err(ErrorKind::UnexpectedV1Element("anchor").into());
+                        }
+                        self.parse_anchor(reader, start)?
+                    }
+                    b"guideline" => {
+                        if self.glyph.format == GlifVersion::V1 {
+                            return Err(ErrorKind::UnexpectedV1Element("guideline").into());
+                        }
+                        self.parse_guideline(reader, start)?
+                    }
+                    b"image" => {
+                        if self.glyph.format == GlifVersion::V1 {
+                            return Err(ErrorKind::UnexpectedV1Element("image").into());
+                        }
+                        if seen_image {
+                            return Err(ErrorKind::DuplicateElement("image").into());
+                        }
+                        seen_image = true;
+                        self.parse_image(reader, start)?
+                    }
+                    _other => return Err(ErrorKind::UnexpectedTag.into()),
+                },
                 Event::End(ref end) if end.name() == b"glyph" => break,
                 _other => return Err(ErrorKind::MissingCloseTag.into()),
             }
         }
 
-        let mut glyph = self.builder.finish()?;
-        glyph.load_object_libs()?;
+        self.glyph.load_object_libs()?;
+        self.glyph.format = GlifVersion::V2;
 
-        Ok(glyph)
+        Ok(self.glyph)
     }
 
     fn parse_outline(
@@ -92,25 +144,27 @@ impl<'names> GlifParser<'names> {
     ) -> Result<(), GlifLoadError> {
         let mut outline_builder = OutlineBuilder::new();
 
+        // TODO: Not checking for (the absence of) attributes here because we'd need to
+        // pass through the element data, but that'd clash with the mutable borrow of
+        // buf. Better way?
+
         loop {
             match reader.read_event(buf)? {
                 Event::Start(start) => {
-                    let tag_name = reader.decode(start.name())?;
                     let mut new_buf = Vec::new(); // borrowck :/
-                    match tag_name.borrow() {
-                        "contour" => {
+                    match start.name() {
+                        b"contour" => {
                             self.parse_contour(start, reader, &mut new_buf, &mut outline_builder)?
                         }
                         _other => return Err(ErrorKind::UnexpectedTag.into()),
                     }
                 }
                 Event::Empty(start) => {
-                    let tag_name = reader.decode(start.name())?;
-                    match tag_name.borrow() {
-                        // Skip empty contours as meaningless.
-                        // https://github.com/unified-font-object/ufo-spec/issues/150
-                        "contour" => (),
-                        "component" => self.parse_component(reader, start, &mut outline_builder)?,
+                    match start.name() {
+                        b"contour" => (), // Empty contours are meaningless.
+                        b"component" => {
+                            self.parse_component(reader, start, &mut outline_builder)?
+                        }
                         _other => return Err(ErrorKind::UnexpectedTag.into()),
                     }
                 }
@@ -120,10 +174,49 @@ impl<'names> GlifParser<'names> {
             }
         }
 
-        let (outline, identifiers) = outline_builder.finish()?;
-        self.builder.outline(outline, identifiers)?;
+        let (mut contours, components) = outline_builder.finish()?;
+
+        // Upgrade implicit anchors to explicit ones.
+        if self.glyph.format == GlifVersion::V1 {
+            for c in &mut contours {
+                if c.points.len() == 1
+                    && c.points[0].typ == PointType::Move
+                    && c.points[0].name.is_some()
+                {
+                    let anchor_point = c.points.remove(0);
+                    let anchor = Anchor::new(
+                        anchor_point.x,
+                        anchor_point.y,
+                        anchor_point.name,
+                        None,
+                        None,
+                        None,
+                    );
+                    self.glyph.anchors.push(anchor);
+                }
+            }
+
+            // Clean up now empty contours.
+            contours.retain(|c| !c.points.is_empty());
+        }
+
+        self.glyph.contours.extend(contours);
+        self.glyph.components.extend(components);
 
         Ok(())
+    }
+
+    fn parse_identifier(&mut self, value: &str) -> Result<Identifier, GlifLoadError> {
+        if self.glyph.format == GlifVersion::V1 {
+            return Err(ErrorKind::UnexpectedV1Attribute("identifier").into());
+        }
+
+        let id =
+            Identifier::new(value).map_err(|_| GlifLoadError::Parse(ErrorKind::BadIdentifier))?;
+        if !self.seen_identifiers.insert(id.clone()) {
+            return Err(ErrorKind::DuplicateIdentifier.into());
+        }
+        Ok(id)
     }
 
     fn parse_contour(
@@ -135,15 +228,14 @@ impl<'names> GlifParser<'names> {
     ) -> Result<(), GlifLoadError> {
         let mut identifier = None;
         for attr in data.attributes() {
-            if self.builder.get_format() == &GlifVersion::V1 {
+            if self.glyph.format == GlifVersion::V1 {
                 return Err(ErrorKind::UnexpectedAttribute.into());
             }
             let attr = attr?;
+            let value = attr.unescaped_value()?;
+            let value = reader.decode(&value)?;
             match attr.key {
-                b"identifier" => {
-                    let ident = attr.unescape_and_decode_value(reader)?;
-                    identifier = Some(Identifier::new(ident)?);
-                }
+                b"identifier" => identifier = Some(self.parse_identifier(value)?),
                 _other => return Err(ErrorKind::UnexpectedAttribute.into()),
             }
         }
@@ -187,6 +279,9 @@ impl<'names> GlifParser<'names> {
                 b"xOffset" => transform.x_offset = value.parse().map_err(|_| kind)?,
                 b"yOffset" => transform.y_offset = value.parse().map_err(|_| kind)?,
                 b"base" => {
+                    if value.is_empty() {
+                        return Err(ErrorKind::ComponentEmptyBase.into());
+                    }
                     let name: Arc<str> = value.into();
                     let name = match self.names.as_ref() {
                         Some(names) => names.get(&name),
@@ -195,18 +290,19 @@ impl<'names> GlifParser<'names> {
                     base = Some(name);
                 }
                 b"identifier" => {
-                    identifier = Some(value.parse()?);
+                    identifier = Some(self.parse_identifier(value)?);
                 }
                 _other => return Err(ErrorKind::UnexpectedComponentField.into()),
             }
         }
 
-        if base.is_none() {
-            return Err(ErrorKind::BadComponent.into());
+        match base {
+            Some(base) => {
+                outline_builder.add_component(base, transform, identifier);
+                Ok(())
+            }
+            None => Err(ErrorKind::ComponentMissingBase.into()),
         }
-
-        outline_builder.add_component(base.unwrap(), transform, identifier)?;
-        Ok(())
     }
 
     fn parse_lib(
@@ -215,6 +311,9 @@ impl<'names> GlifParser<'names> {
         raw_xml: &[u8],
         buf: &mut Vec<u8>,
     ) -> Result<(), GlifLoadError> {
+        // The plist crate currently uses a different XML parsing library internally, so
+        // we can't pass over control to it directly. Instead, pass it the precise slice
+        // of the raw buffer to parse.
         let start = reader.buffer_position();
         let mut end = start;
         loop {
@@ -227,10 +326,11 @@ impl<'names> GlifParser<'names> {
 
         let plist_slice = &raw_xml[start..end];
         let dict = plist::Value::from_reader_xml(plist_slice)
-            .ok()
-            .and_then(plist::Value::into_dictionary)
-            .ok_or(ErrorKind::BadLib)?;
-        self.builder.lib(dict)?;
+            .map_err(|_| GlifLoadError::Parse(ErrorKind::BadLib))?
+            .into_dictionary()
+            .ok_or(GlifLoadError::Parse(ErrorKind::LibMustBeDictionary))?;
+
+        self.glyph.lib = dict;
         Ok(())
     }
 
@@ -243,7 +343,7 @@ impl<'names> GlifParser<'names> {
             match reader.read_event(buf)? {
                 Event::End(ref end) if end.name() == b"note" => break,
                 Event::Text(text) => {
-                    self.builder.note(text.unescape_and_decode(reader)?)?;
+                    self.glyph.note = Some(text.unescape_and_decode(reader)?);
                 }
                 Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
                 _other => (),
@@ -282,17 +382,19 @@ impl<'names> GlifParser<'names> {
                 }
                 b"smooth" => smooth = value == "yes",
                 b"identifier" => {
-                    identifier = Some(value.parse()?);
+                    identifier = Some(self.parse_identifier(value)?);
                 }
                 _other => return Err(ErrorKind::UnexpectedPointField.into()),
             }
         }
-        if x.is_none() || y.is_none() {
-            return Err(ErrorKind::BadPoint.into());
-        }
-        outline_builder.add_point((x.unwrap(), y.unwrap()), typ, smooth, name, identifier)?;
 
-        Ok(())
+        match (x, y) {
+            (Some(x), Some(y)) => {
+                outline_builder.add_point((x, y), typ, smooth, name, identifier)?;
+                Ok(())
+            }
+            _ => Err(ErrorKind::BadPoint.into()),
+        }
     }
 
     fn parse_advance<'a>(
@@ -318,7 +420,9 @@ impl<'names> GlifParser<'names> {
                 _other => return Err(ErrorKind::UnexpectedAttribute.into()),
             }
         }
-        self.builder.width(width)?.height(height)?;
+
+        self.glyph.width = width;
+        self.glyph.height = height;
         Ok(())
     }
 
@@ -337,7 +441,7 @@ impl<'names> GlifParser<'names> {
                         .map_err(|_| value.to_string())
                         .and_then(|n| char::try_from(n).map_err(|_| value.to_string()))
                         .map_err(|_| ErrorKind::BadHexValue)?;
-                    self.builder.unicode(chr);
+                    self.glyph.codepoints.push(chr);
                 }
                 _other => return Err(ErrorKind::UnexpectedAttribute.into()),
             }
@@ -370,17 +474,19 @@ impl<'names> GlifParser<'names> {
                 b"name" => name = Some(value.to_string()),
                 b"color" => color = Some(value.parse().map_err(|_| ErrorKind::BadColor)?),
                 b"identifier" => {
-                    identifier = Some(value.parse()?);
+                    identifier = Some(self.parse_identifier(value)?);
                 }
                 _other => return Err(ErrorKind::UnexpectedAnchorField.into()),
             }
         }
 
-        if x.is_none() || y.is_none() {
-            return Err(ErrorKind::BadAnchor.into());
+        match (x, y) {
+            (Some(x), Some(y)) => {
+                self.glyph.anchors.push(Anchor::new(x, y, name, color, identifier, None));
+                Ok(())
+            }
+            _ => Err(ErrorKind::BadAnchor.into()),
         }
-        self.builder.anchor(Anchor::new(x.unwrap(), y.unwrap(), name, color, identifier, None))?;
-        Ok(())
     }
 
     fn parse_guideline<'a>(
@@ -407,12 +513,16 @@ impl<'names> GlifParser<'names> {
                     y = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
                 b"angle" => {
-                    angle = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
+                    let angle_value = value.parse().map_err(|_| ErrorKind::BadNumber)?;
+                    if !(0.0..=360.0).contains(&angle_value) {
+                        return Err(ErrorKind::BadAngle.into());
+                    }
+                    angle = Some(angle_value);
                 }
                 b"name" => name = Some(value.to_string()),
                 b"color" => color = Some(value.parse().map_err(|_| ErrorKind::BadColor)?),
                 b"identifier" => {
-                    identifier = Some(value.parse()?);
+                    identifier = Some(self.parse_identifier(value)?);
                 }
                 _other => return Err(ErrorKind::UnexpectedGuidelineField.into()),
             }
@@ -421,15 +531,10 @@ impl<'names> GlifParser<'names> {
         let line = match (x, y, angle) {
             (Some(x), None, None) => Line::Vertical(x),
             (None, Some(y), None) => Line::Horizontal(y),
-            (Some(x), Some(y), Some(degrees)) => {
-                if !(0.0..=360.0).contains(&degrees) {
-                    return Err(ErrorKind::BadGuideline.into());
-                }
-                Line::Angle { x, y, degrees }
-            }
-            _other => return Err(ErrorKind::BadGuideline.into()),
+            (Some(x), Some(y), Some(degrees)) => Line::Angle { x, y, degrees },
+            _ => return Err(ErrorKind::BadGuideline.into()),
         };
-        self.builder.guideline(Guideline::new(line, name, color, identifier, None))?;
+        self.glyph.guidelines.push(Guideline::new(line, name, color, identifier, None));
 
         Ok(())
     }
@@ -461,17 +566,17 @@ impl<'names> GlifParser<'names> {
             }
         }
 
-        if filename.is_none() {
-            return Err(ErrorKind::BadImage.into());
+        match filename {
+            Some(file_name) => {
+                self.glyph.image = Some(Image { file_name, color, transform });
+                Ok(())
+            }
+            None => Err(ErrorKind::BadImage.into()),
         }
-
-        self.builder.image(Image { file_name: filename.unwrap(), color, transform })?;
-
-        Ok(())
     }
 }
 
-fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<GlyphBuilder, GlifLoadError> {
+fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<Glyph, GlifLoadError> {
     loop {
         match reader.read_event(buf)? {
             Event::Comment(_) => (),
@@ -496,7 +601,7 @@ fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<GlyphBuilder, 
                     }
                 }
                 if !name.is_empty() && format.is_some() {
-                    return Ok(GlyphBuilder::new(name, format.take().unwrap()));
+                    return Ok(Glyph::new(name.into(), format.take().unwrap()));
                 } else {
                     return Err(ErrorKind::WrongFirstElement.into());
                 }

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -51,9 +51,7 @@ impl<'names> GlifParser<'names> {
         buf: &mut Vec<u8>,
     ) -> Result<Glyph, GlifLoadError> {
         let mut seen_advance = false;
-        let mut seen_image = false;
         let mut seen_lib = false;
-        let mut seen_note = false;
         let mut seen_outline = false;
 
         loop {
@@ -78,10 +76,9 @@ impl<'names> GlifParser<'names> {
                         if self.glyph.format == GlifVersion::V1 {
                             return Err(ErrorKind::UnexpectedV1Element("note").into());
                         }
-                        if seen_note {
+                        if self.glyph.note.is_some() {
                             return Err(ErrorKind::DuplicateElement("note").into());
                         }
-                        seen_note = true;
                         self.parse_note(reader, buf)?
                     }
                     _other => return Err(ErrorKind::UnexpectedElement.into()),
@@ -118,10 +115,9 @@ impl<'names> GlifParser<'names> {
                         if self.glyph.format == GlifVersion::V1 {
                             return Err(ErrorKind::UnexpectedV1Element("image").into());
                         }
-                        if seen_image {
+                        if self.glyph.image.is_some() {
                             return Err(ErrorKind::DuplicateElement("image").into());
                         }
-                        seen_image = true;
                         self.parse_image(reader, start)?
                     }
                     _other => return Err(ErrorKind::UnexpectedElement.into()),

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -240,6 +240,132 @@ fn missing_close() {
 }
 
 #[test]
+#[should_panic(expected = "DuplicateElement")]
+fn duplicate_outline() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+  <outline>
+  </outline>
+  <outline/>
+</glyph>
+"#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "ComponentMissingBase")]
+fn component_missing_base() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+  <outline>
+    <component/>
+  </outline>
+</glyph>
+"#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "ComponentEmptyBase")]
+fn component_empty_base() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+  <outline>
+    <component base=""/>
+  </outline>
+</glyph>
+"#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "BadAngle")]
+fn bad_angle() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+  <guideline x="1" y="2" angle="-10"/>
+</glyph>
+"#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "LibMustBeDictionary")]
+fn lib_must_be_dict() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+    <lib>
+        <string>I am a creative professional :)</string>
+    </lib>
+</glyph>
+"#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "PublicObjectLibsMustBeDictionary")]
+fn public_object_libs_must_be_dict() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+    <lib>
+        <dict>
+            <key>public.objectLibs</key>
+            <string>0,1,0,0.5</string>
+        </dict>
+    </lib>
+</glyph>
+"#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "ObjectLibMustBeDictionary")]
+fn object_lib_must_be_dict() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+	<anchor name="top" x="74" y="197" identifier="KN3WZjorob"/>
+    <lib>
+        <dict>
+            <key>public.objectLibs</key>
+            <dict>
+                <key>KN3WZjorob</key>
+                <string>0,1,0,0.5</string>
+            </dict>
+        </dict>
+    </lib>
+</glyph>
+"#;
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
+fn if_no_one_uses_your_lib_is_it_broken() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+    <lib>
+        <dict>
+            <key>public.objectLibs</key>
+            <dict>
+                <key>KN3WZjorob</key>
+                <string>0,1,0,0.5</string>
+            </dict>
+        </dict>
+    </lib>
+</glyph>
+"#;
+    let glyph = parse_glyph(data.as_bytes()).unwrap();
+    assert!(glyph.lib.get("public.objectLibs").is_none());
+}
+
+#[test]
 fn parse_note() {
     let bytes = include_bytes!("../../testdata/note.glif");
     let glyph = parse_glyph(bytes).unwrap();


### PR DESCRIPTION
Reduces OutlineBuilder to the minimum and moves the responsibilities of GlpyhBuilder back into the parser.

Closes https://github.com/linebender/norad/issues/95.