### PR TITLE
Name type and related API changes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -488,6 +488,8 @@ pub enum ErrorKind {
     BadImage,
     /// Has an invalid identifier.
     BadIdentifier,
+    /// Name is not a valid [`Name`](crate::Name).
+    InvalidName,
     /// Has an invalid lib.
     BadLib,
     /// Has an unexected duplicate value.
@@ -559,6 +561,7 @@ impl std::fmt::Display for ErrorKind {
             BadComponent => write!(f, "bad component"),
             BadImage => write!(f, "bad image"),
             BadIdentifier => write!(f, "an identifier must be at most 100 characters long and contain only ASCII characters in the range 0x20 to 0x7E"),
+            InvalidName => write!(f, "name is empty or contains control characters"),
             BadLib => write!(f, "bad lib"),
             UnexpectedDuplicate => write!(f, "unexpected duplicate"),
             UnexpectedMove => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,11 @@ pub enum NamingError {
     /// An error returned when an expected item is missing.
     #[error("item '{0}' does not exist")]
     Missing(String),
+    /// A name is empty, or contains [control characters].
+    ///
+    /// [control characters]: https://unifiedfontobject.org/versions/ufo3/conventions/#controls
+    #[error("'{0}' is not a valid name")]
+    Invalid(String),
 }
 
 /// An error that occurs while attempting to read a .glif file from disk.

--- a/src/font.rs
+++ b/src/font.rs
@@ -2,18 +2,18 @@
 
 #![deny(rustdoc::broken_intra_doc_links)]
 
-use std::borrow::Borrow;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::datastore::{DataStore, ImageStore};
 use crate::error::{FontLoadError, FontWriteError};
 use crate::fontinfo::FontInfo;
-use crate::glyph::{Glyph, GlyphName};
+use crate::glyph::Glyph;
 use crate::groups::{validate_groups, Groups};
 use crate::guideline::Guideline;
 use crate::kerning::Kerning;
 use crate::layer::{Layer, LayerSet, LAYER_CONTENTS_FILE};
+use crate::name::Name;
 use crate::names::NameList;
 use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
 use crate::upconversion;
@@ -580,27 +580,20 @@ impl Font {
     }
 
     /// Returns an iterator over all the glyph names _in the default layer_.
-    pub fn iter_names(&self) -> impl Iterator<Item = GlyphName> + '_ {
+    pub fn iter_names(&self) -> impl Iterator<Item = Name> + '_ {
+        //FIXME: why not &Name here?
         self.layers.default_layer().glyphs.keys().cloned()
     }
 
     /// Returns a reference to the glyph with the given name _in the default
     /// layer_.
-    pub fn get_glyph<K>(&self, key: &K) -> Option<&Glyph>
-    where
-        GlyphName: Borrow<K>,
-        K: Ord + ?Sized,
-    {
+    pub fn get_glyph(&self, key: &str) -> Option<&Glyph> {
         self.default_layer().get_glyph(key)
     }
 
     /// Returns a mutable reference to the glyph with the given name
     /// _in the default layer_, if it exists.
-    pub fn get_glyph_mut<K>(&mut self, key: &K) -> Option<&mut Glyph>
-    where
-        GlyphName: Borrow<K>,
-        K: Ord + ?Sized,
-    {
+    pub fn get_glyph_mut(&mut self, key: &str) -> Option<&mut Glyph> {
         self.default_layer_mut().get_glyph_mut(key)
     }
 
@@ -707,7 +700,7 @@ mod tests {
             font_obj.lib.get("com.typemytype.robofont.compileSettings.autohint"),
             Some(&plist::Value::Boolean(true))
         );
-        assert_eq!(font_obj.groups.get("public.kern1.@MMK_L_A"), Some(&vec!["A".into()]));
+        assert_eq!(font_obj.groups.get("public.kern1.@MMK_L_A"), Some(&vec![Name::new_raw("A")]));
 
         #[allow(clippy::float_cmp)]
         {

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -10,7 +10,7 @@
 //! [fontTools point pen]: https://fonttools.readthedocs.io/en/latest/pens/basePen.html
 
 use crate::{
-    error::ErrorKind, AffineTransform, Component, Contour, ContourPoint, GlyphName, Identifier,
+    error::ErrorKind, AffineTransform, Component, Contour, ContourPoint, Identifier, Name,
     PointType,
 };
 
@@ -173,7 +173,7 @@ impl OutlineBuilder {
     /// Add a component to the glyph.
     pub(crate) fn add_component(
         &mut self,
-        base: GlyphName,
+        base: Name,
         transform: AffineTransform,
         identifier: Option<Identifier>,
     ) -> &mut Self {
@@ -216,7 +216,7 @@ mod tests {
             )?
             .end_path()?
             .add_component(
-                "hallo".into(),
+                Name::new_raw("hallo"),
                 AffineTransform::default(),
                 Some(Identifier::new("xyz").unwrap()),
             );
@@ -247,7 +247,7 @@ mod tests {
         assert_eq!(
             components,
             vec![Component::new(
-                "hallo".into(),
+                Name::new_raw("hallo"),
                 AffineTransform {
                     x_scale: 1.0,
                     xy_scale: 0.0,

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use super::*;
 use crate::error::{ErrorKind, GlifLoadError};
@@ -250,7 +249,7 @@ impl<'names> GlifParser<'names> {
         start: BytesStart,
         outline_builder: &mut OutlineBuilder,
     ) -> Result<(), GlifLoadError> {
-        let mut base: Option<GlyphName> = None;
+        let mut base: Option<Name> = None;
         let mut identifier: Option<Identifier> = None;
         let mut transform = AffineTransform::default();
 
@@ -270,7 +269,8 @@ impl<'names> GlifParser<'names> {
                     return Err(ErrorKind::ComponentEmptyBase.into());
                 }
                 b"base" => {
-                    let name: Arc<str> = value.into();
+                    //FIXME: error if malformed
+                    let name = Name::new_raw(value);
                     let name = match self.names.as_ref() {
                         Some(names) => names.get(&name),
                         None => name,
@@ -589,7 +589,9 @@ fn start(reader: &mut Reader<&[u8]>, buf: &mut Vec<u8>) -> Result<Glyph, GlifLoa
                     }
                 }
                 if !name.is_empty() && format.is_some() {
-                    return Ok(Glyph::new(name.into(), format.take().unwrap()));
+                    //FIXME: error here
+                    return Ok(Glyph::new(Name::new_raw(&name), format.take().unwrap()));
+                    //return Ok(GlyphBuilder::new(Name::new_raw(&name), format.take().unwrap()));
                 } else {
                     return Err(ErrorKind::WrongFirstElement.into());
                 }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -740,8 +740,8 @@ fn components_load() {
     let bytes = include_bytes!("../../testdata/MutatorSansLightWide.ufo/glyphs/A_dieresis.glif");
     let glyph = parse_glyph(bytes).expect("initial load failed");
     // component order
-    assert_eq!(glyph.components[0].base, std::sync::Arc::<str>::from("A"));
-    assert_eq!(glyph.components[1].base, std::sync::Arc::<str>::from("dieresis"));
+    assert_eq!(glyph.components[0].base, "A");
+    assert_eq!(glyph.components[1].base, "dieresis");
     let error_margin = f64::EPSILON;
     // component affine transforms
     assert!(glyph.components[0].transform.x_scale - 1.0 < error_margin);
@@ -786,8 +786,8 @@ fn get_components_with_base() {
     let bytes = include_bytes!("../../testdata/MutatorSansLightWide.ufo/glyphs/A_dieresis.glif");
     let glyph = parse_glyph(bytes).expect("initial load failed");
 
-    assert_eq!(glyph.components[0].base, std::sync::Arc::<str>::from("A"));
-    assert_eq!(glyph.components[1].base, std::sync::Arc::<str>::from("dieresis"));
+    assert_eq!(glyph.components[0].base, "A");
+    assert_eq!(glyph.components[1].base, "dieresis");
 
     let component_a_vec = glyph.get_components_with_base("A").collect::<Vec<&Component>>();
     assert!(component_a_vec.len() == 1);
@@ -804,9 +804,9 @@ fn get_components_with_base_multiple_same_base_components() {
     let bytes = include_bytes!("../../testdata/MutatorSansLightWide.ufo/glyphs/quotedblbase.glif");
     let glyph = parse_glyph(bytes).expect("initial load failed");
     let error_margin = f64::EPSILON;
-    assert_eq!(glyph.components[0].base, std::sync::Arc::<str>::from("comma"));
+    assert_eq!(glyph.components[0].base, "comma");
     assert!(glyph.components[0].transform.x_offset - 0.0 < error_margin);
-    assert_eq!(glyph.components[1].base, std::sync::Arc::<str>::from("comma"));
+    assert_eq!(glyph.components[1].base, "comma");
     assert!(glyph.components[1].transform.x_offset - 130.0 < error_margin);
 
     let component_comma_vec = glyph.get_components_with_base("comma").collect::<Vec<&Component>>();

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -640,6 +640,22 @@ fn unexpected_line_after_offcurve2() {
 }
 
 #[test]
+#[should_panic(expected = "InvalidName")]
+fn invalid_name() {
+    let data = "
+        <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+        <glyph name=\"\x01\" format=\"2\">
+            <outline>
+                <contour>
+                    <point x=\"572\" y=\"667\"/>
+                    <point x=\"479\" y=\"714\"/>
+                </contour>
+            </outline>
+        </glyph>
+    ";
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+#[test]
 #[should_panic(expected = "UnexpectedPointAfterOffCurve")]
 fn unexpected_line_after_offcurve3() {
     let data = r#"

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,12 +1,12 @@
 use std::collections::{BTreeMap, HashSet};
 
 use crate::error::GroupsValidationError;
-use crate::GlyphName;
+use crate::Name;
 
 /// A map of group name to a list of glyph names.
 ///
 /// We use a [`BTreeMap`] because we need sorting for serialization.
-pub type Groups = BTreeMap<String, Vec<GlyphName>>;
+pub type Groups = BTreeMap<String, Vec<Name>>;
 
 /// Validate the contents of the groups.plist file according to the rules in the
 /// [Unified Font Object v3 specification for groups.plist](http://unifiedfontobject.org/versions/ufo3/groups.plist/#specification).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ mod guideline;
 mod identifier;
 mod kerning;
 mod layer;
+mod name;
 mod names;
 mod shared_types;
 mod upconversion;
@@ -91,9 +92,10 @@ pub use data_request::DataRequest;
 pub use font::{Font, FormatVersion, MetaInfo};
 pub use fontinfo::FontInfo;
 pub use glyph::{
-    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, GlyphName,
-    Image, PointType,
+    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, PointType,
 };
+
+pub use name::Name;
 
 pub use groups::Groups;
 pub use guideline::{Guideline, Line};

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,0 +1,101 @@
+//! Glyph and layer names
+
+use std::sync::Arc;
+
+use crate::error::NamingError;
+
+/// A name used to identify a [`Glyph`] or a [`Layer`].
+///
+/// Layers must be at least one character long, and cannot contain control
+/// characters (`0x00..=0x1F`, `0x7F`, and `0x80..=0x9F`).
+///
+/// The details of how the name is stored may change, but it will always be
+/// cheap to clone (at most a memcopy or a pointer clone) and it will always
+/// deref to a `&str`.
+///
+/// [`Glyph`]: crate::Glyph
+/// [`Layer`]: crate::Layer
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "druid", derive(druid::Data))]
+pub struct Name(Arc<str>);
+
+impl Name {
+    /// Creates a new `Name` if the given value isn't empty and contains no control characters.
+    pub fn new(name: &str) -> Result<Name, NamingError> {
+        if is_valid(name) {
+            Ok(Name(name.into()))
+        } else {
+            Err(NamingError::Invalid(name.into()))
+        }
+    }
+
+    /// Creates a new `Name`, panicking if the given name is invalid.
+    pub(crate) fn new_raw(name: &str) -> Name {
+        assert!(is_valid(name));
+        Name(name.into())
+    }
+
+    /// Returns a string slice containing the name.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+fn is_valid(name: &str) -> bool {
+    !(name.is_empty()
+        || name
+            .bytes()
+            .any(|b| (0x0..=0x1f).contains(&b) || (0x80..=0x9f).contains(&b) || b == 0x7f))
+}
+
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl std::ops::Deref for Name {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+// so that assert_eq! macros work
+impl<'a> PartialEq<&'a str> for Name {
+    fn eq(&self, other: &&'a str) -> bool {
+        self.0.as_ref() == *other
+    }
+}
+
+impl<'a> PartialEq<Name> for &'a str {
+    fn eq(&self, other: &Name) -> bool {
+        other == self
+    }
+}
+
+impl std::fmt::Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::borrow::Borrow<str> for Name {
+    fn borrow(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+//FIXME: custom deserialize that errors
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn assert_eq_str() {
+        assert_eq!(Name::new_raw("hi"), "hi");
+        assert_eq!("hi", Name::new_raw("hi"));
+        assert_eq!(vec![Name::new_raw("a"), Name::new_raw("b")], vec!["a", "b"]);
+        assert_eq!(vec!["a", "b"], vec![Name::new_raw("a"), Name::new_raw("b")]);
+    }
+}

--- a/src/names.rs
+++ b/src/names.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 #[cfg(feature = "rayon")]
 use std::sync::RwLock;
 
-use crate::glyph::GlyphName;
+use crate::Name;
 
 /// Manages interned names
 ///
@@ -28,14 +28,14 @@ pub struct NameList {
 
 #[derive(Debug)]
 #[cfg(feature = "rayon")]
-struct ParNameList(RwLock<HashSet<GlyphName>>);
+struct ParNameList(RwLock<HashSet<Name>>);
 
 #[derive(Debug, Default)]
 #[cfg(not(feature = "rayon"))]
-struct SeqNameList(RefCell<HashSet<GlyphName>>);
+struct SeqNameList(RefCell<HashSet<Name>>);
 
 impl NameList {
-    pub(crate) fn get(&self, name: &GlyphName) -> GlyphName {
+    pub(crate) fn get(&self, name: &Name) -> Name {
         self.inner.get(name)
     }
 
@@ -46,7 +46,7 @@ impl NameList {
 
 #[cfg(feature = "rayon")]
 impl ParNameList {
-    pub(crate) fn get(&self, name: &GlyphName) -> GlyphName {
+    pub(crate) fn get(&self, name: &Name) -> Name {
         let existing = self.0.read().unwrap().get(name).cloned();
         match existing {
             Some(name) => name,
@@ -64,7 +64,7 @@ impl ParNameList {
 
 #[cfg(not(feature = "rayon"))]
 impl SeqNameList {
-    pub(crate) fn get(&self, name: &GlyphName) -> GlyphName {
+    pub(crate) fn get(&self, name: &Name) -> Name {
         let existing = self.0.borrow().get(name).cloned();
         match existing {
             Some(name) => name,
@@ -87,7 +87,7 @@ impl Default for ParNameList {
     }
 }
 
-impl<T: Into<GlyphName>> std::iter::FromIterator<T> for NameList {
+impl<T: Into<Name>> std::iter::FromIterator<T> for NameList {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let names = NameList::default();
 

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -218,9 +218,19 @@ mod tests {
     extern crate maplit;
 
     use super::*;
-    use crate::font::{Font, FormatVersion};
-    use crate::glyph::GlyphName;
+    use crate::{
+        font::{Font, FormatVersion},
+        Name,
+    };
     use maplit::btreemap;
+
+    // we don't want this in the crate because it can fail, but it is useful
+    // for creating test data.
+    impl<'a> From<&'a str> for Name {
+        fn from(src: &str) -> Self {
+            Name::new_raw(src)
+        }
+    }
 
     #[test]
     fn test_upconvert_kerning_just_groups() {
@@ -239,7 +249,8 @@ mod tests {
         let kerning: Kerning = Kerning::new();
         let glyph_set: NameList = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
             .iter()
-            .map(|s| GlyphName::from(*s))
+            .cloned()
+            .map(Name::from)
             .collect();
 
         let (groups_new, kerning_new) = upconvert_kerning(&groups, &kerning, &glyph_set);

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -1,6 +1,6 @@
 //! Testing saving files.
 
-use norad::{Font, FormatVersion, Glyph, Identifier, Plist};
+use norad::{Font, FormatVersion, Glyph, Identifier, Name, Plist};
 use plist::Value;
 
 #[test]
@@ -192,7 +192,7 @@ fn object_libs_reject_existing_key() {
     ufo.lib.remove("public.objectLibs");
 
     let glyph = Glyph {
-        name: "test".into(),
+        name: Name::new("test").unwrap(),
         format: norad::GlifVersion::V2,
         height: 0.,
         width: 0.,


### PR DESCRIPTION
This adds a `Name` type, shared between glyphs and layers. This enforces the constraints on names documented in [the spec](https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#attributes) and also hides the concrete type we use to represent names, leaving us free to change that in future.

This also attempts to standardize the various places where names are used in the API. With this patch, most API that takes a name (for retrieving a glyph or a layer, for instance) now just takes a `&str`. In places where we are creating a glyph, this is converted into a `Name`, and panics if the name is malformed. This is unlikely for the reasons outlined at https://github.com/linebender/norad/issues/191#issuecomment-1006047293. Methods that may panic in this way are all documented.

There are a few exceptions:
- some methods that already return a `NamingError` will return `NamingError::Invalid` if the name is invalid, since it's easy enough and doesn't increase the user burden.
- `Component::new` takes a `Name` directly, because we expect you to take the name from an existing glyph.


There are a few other little tweaks included in this patch, which were related to these changes and would have been annoying to extract.