### PR TITLE
Add minor version support to GlifVersion

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -435,9 +435,6 @@ pub enum GlifWriteError {
     /// Failed to serialize a glyph to an internal buffer.
     #[error("failed to serialize glyph to an internal buffer")]
     Buffer(#[source] IoError),
-    /// Norad does not currently support downgrading format versions.
-    #[error("downgrading below glyph format version 2 is unsupported")]
-    Downgrade,
     /// When writing out the 'lib' section, we use the plist crate to generate
     /// the plist xml, and then strip the preface and closing </plist> tag.
     ///

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -256,13 +256,29 @@ impl Data for Glyph {
 /// Version of a `.glif` file, per the [UFO spec].
 ///
 /// [UFO spec]: https://unifiedfontobject.org/versions/ufo1/glyphs/glif/#specification
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "druid", derive(Data))]
-pub enum GlifVersion {
-    /// Glif file format version 1. Saving this version is not supported.
-    V1 = 1,
-    /// Glif file format version 2.
-    V2 = 2,
+pub struct GlifVersion {
+    /// The major version
+    pub major: u16,
+    /// The minor version
+    //NOTE: this is in the spec, but 2.0 is the current max version,
+    //so this is ignored for now.
+    pub minor: u16,
+}
+
+impl GlifVersion {
+    /// Version 1.0
+    pub const V1: GlifVersion = GlifVersion { major: 1, minor: 0 };
+    /// Version 2.0
+    pub const V2: GlifVersion = GlifVersion { major: 2, minor: 0 };
+
+    // helper used during parsing
+    pub(crate) const ZEROS: GlifVersion = GlifVersion { major: 0, minor: 0 };
+
+    pub(crate) const fn is_supported(self) -> bool {
+        (self.major == 1 || self.major == 2) && self.minor == 0
+    }
 }
 
 /// A reference position in a glyph, such as for attaching accents.

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -20,8 +20,8 @@ pub(crate) fn parse_glyph(xml: &[u8]) -> Result<Glyph, GlifLoadError> {
 // major, minor
 type Version = (u32, u32);
 
-const VERSION_1: (u32, u32) = (1, 0);
-const VERSION_2: (u32, u32) = (2, 0);
+const VERSION_1: Version = (1, 0);
+const VERSION_2: Version = (2, 0);
 
 pub(crate) struct GlifParser<'names> {
     glyph: Glyph,
@@ -584,7 +584,6 @@ fn start(
                     let attr = attr?;
                     let value = attr.unescaped_value()?;
                     let value = reader.decode(&value)?;
-                    // XXX: support `formatMinor`
                     match attr.key {
                         b"name" => {
                             let value = Name::new(value).map_err(|_| ErrorKind::InvalidName)?;

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -9,8 +9,8 @@ use quick_xml::{
 
 use super::PUBLIC_OBJECT_LIBS_KEY;
 use crate::{
-    util, AffineTransform, Anchor, Color, Component, Contour, ContourPoint, GlifVersion, Glyph,
-    Guideline, Image, Line, Plist, PointType, WriteOptions,
+    util, AffineTransform, Anchor, Color, Component, Contour, ContourPoint, Glyph, Guideline,
+    Image, Line, Plist, PointType, WriteOptions,
 };
 
 use crate::error::GlifWriteError;
@@ -52,8 +52,9 @@ impl Glyph {
         }
         let mut start = BytesStart::borrowed_name(b"glyph");
         start.push_attribute(("name", &*self.name));
-        start.push_attribute(("format", self.format.major_str()));
+        // we always serialize 2.0
         //TODO: write out formatMinor if we start to support glif 2.1?
+        start.push_attribute(("format", "2"));
         writer.write_event(Event::Start(start)).map_err(GlifWriteError::Xml)?;
 
         for codepoint in &self.codepoints {
@@ -177,16 +178,6 @@ fn write_lib_section<T: Write>(
     }
     writer.write_event(Event::End(BytesEnd::borrowed(b"lib"))).map_err(GlifWriteError::Xml)?;
     Ok(())
-}
-
-impl GlifVersion {
-    fn major_str(&self) -> &str {
-        match self.major {
-            1 => "1",
-            2 => "2",
-            n => panic!("unsupported major version {}", n),
-        }
-    }
 }
 
 impl Guideline {

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -52,7 +52,8 @@ impl Glyph {
         }
         let mut start = BytesStart::borrowed_name(b"glyph");
         start.push_attribute(("name", &*self.name));
-        start.push_attribute(("format", self.format.as_str()));
+        start.push_attribute(("format", self.format.major_str()));
+        //TODO: write out formatMinor if we start to support glif 2.1?
         writer.write_event(Event::Start(start)).map_err(GlifWriteError::Xml)?;
 
         for codepoint in &self.codepoints {
@@ -179,10 +180,11 @@ fn write_lib_section<T: Write>(
 }
 
 impl GlifVersion {
-    fn as_str(&self) -> &str {
-        match self {
-            GlifVersion::V1 => "1",
-            GlifVersion::V2 => "2",
+    fn major_str(&self) -> &str {
+        match self.major {
+            1 => "1",
+            2 => "2",
+            n => panic!("unsupported major version {}", n),
         }
     }
 }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -13,7 +13,7 @@ fn transform() {
 
 #[test]
 fn serialize_empty_glyph() {
-    let glyph = Glyph::new_named("a");
+    let glyph = Glyph::new("a");
     let glif = glyph.encode_xml().unwrap();
     let glif = std::str::from_utf8(&glif).unwrap();
     assert_eq!(
@@ -35,20 +35,8 @@ fn parse_format_minor() {
  </glyph>
      "#
     .trim();
-    let glyph = parse_glyph(data.as_bytes()).unwrap();
-    assert_eq!(glyph.format, GlifVersion { major: 2, minor: 0 });
-}
-
-#[test]
-fn parse_format_no_minor() {
-    let data = r#"
- <?xml version="1.0" encoding="UTF-8"?>
- <glyph name="a" format="2">
- </glyph>
-     "#
-    .trim();
-    let glyph = parse_glyph(data.as_bytes()).unwrap();
-    assert_eq!(glyph.format, GlifVersion { major: 2, minor: 0 });
+    // if this doesn't panic life is okay
+    parse_glyph(data.as_bytes()).unwrap();
 }
 
 #[test]
@@ -65,7 +53,7 @@ fn parse_format_unsupported_major() {
 
 #[test]
 fn serialize_empty_glyph_explicit_line_ending_check() {
-    let glyph = Glyph::new_named("a");
+    let glyph = Glyph::new("a");
     let glif = glyph.encode_xml().unwrap();
     let glif = std::str::from_utf8(&glif).unwrap();
     assert_eq!(
@@ -228,7 +216,6 @@ fn parse_v1_upgrade_anchors() {
             Anchor::new(40.0, 20.0, Some("right".into()), None, None, None),
         ]
     );
-    assert_eq!(glyph.format, GlifVersion::V2);
     assert_eq!(glyph.guidelines, vec![]);
     assert_eq!(glyph.image, None);
     assert_eq!(glyph.lib, Plist::new());
@@ -420,7 +407,6 @@ fn save() {
 
     let glyph2 = parse_glyph(buf.as_slice()).expect("re-parse failed");
     assert_eq!(glyph.name, glyph2.name);
-    assert_eq!(glyph.format, glyph2.format);
     assert_eq!(glyph.height, glyph2.height);
     assert_eq!(glyph.width, glyph2.width);
     assert_eq!(glyph.codepoints, glyph2.codepoints);

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -28,6 +28,42 @@ fn serialize_empty_glyph() {
 }
 
 #[test]
+fn parse_format_minor() {
+    let data = r#"
+ <?xml version="1.0" encoding="UTF-8"?>
+ <glyph name="a" format="2" formatMinor="0">
+ </glyph>
+     "#
+    .trim();
+    let glyph = parse_glyph(data.as_bytes()).unwrap();
+    assert_eq!(glyph.format, GlifVersion { major: 2, minor: 0 });
+}
+
+#[test]
+fn parse_format_no_minor() {
+    let data = r#"
+ <?xml version="1.0" encoding="UTF-8"?>
+ <glyph name="a" format="2">
+ </glyph>
+     "#
+    .trim();
+    let glyph = parse_glyph(data.as_bytes()).unwrap();
+    assert_eq!(glyph.format, GlifVersion { major: 2, minor: 0 });
+}
+
+#[test]
+#[should_panic(expected = "UnsupportedGlifVersion")]
+fn parse_format_unsupported_major() {
+    let data = r#"
+ <?xml version="1.0" encoding="UTF-8"?>
+ <glyph name="a" format="3">
+ </glyph>
+     "#
+    .trim();
+    let _ = parse_glyph(data.as_bytes()).unwrap();
+}
+
+#[test]
 fn serialize_empty_glyph_explicit_line_ending_check() {
     let glyph = Glyph::new_named("a");
     let glif = glyph.encode_xml().unwrap();

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -648,7 +648,7 @@ mod tests {
     fn set_glyph() {
         let layer_path = "testdata/MutatorSansLightWide.ufo/glyphs";
         let mut layer = Layer::load(layer_path, DEFAULT_LAYER_NAME).unwrap();
-        let mut glyph = Glyph::new_named("A");
+        let mut glyph = Glyph::new("A");
         glyph.width = 69.;
         layer.insert_glyph(glyph);
         let glyph = layer.get_glyph("A").expect("failed to load glyph 'A'");
@@ -669,7 +669,7 @@ mod tests {
 
         let misc_layer = ufo.layers.get_or_create("misc");
         assert!(misc_layer.is_empty());
-        misc_layer.insert_glyph(Glyph::new_named("A"));
+        misc_layer.insert_glyph(Glyph::new("A"));
 
         assert!(ufo.default_layer().is_empty());
         assert!(ufo.layers.get("background").unwrap().is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub use data_request::DataRequest;
 pub use font::{Font, FormatVersion, MetaInfo};
 pub use fontinfo::FontInfo;
 pub use glyph::{
-    AffineTransform, Anchor, Component, Contour, ContourPoint, GlifVersion, Glyph, Image, PointType,
+    AffineTransform, Anchor, Component, Contour, ContourPoint, Glyph, Image, PointType,
 };
 
 pub use name::Name;

--- a/tests/save.rs
+++ b/tests/save.rs
@@ -23,7 +23,7 @@ fn save_default() {
 #[test]
 fn save_new_file() {
     let mut my_ufo = Font::new();
-    let mut my_glyph = Glyph::new_named("A");
+    let mut my_glyph = Glyph::new("A");
     my_glyph.codepoints = vec!['A'];
     my_glyph.note = Some("I did a glyph!".into());
     let mut plist = Plist::new();
@@ -193,7 +193,6 @@ fn object_libs_reject_existing_key() {
 
     let glyph = Glyph {
         name: Name::new("test").unwrap(),
-        format: norad::GlifVersion::V2,
         height: 0.,
         width: 0.,
         anchors: vec![],


### PR DESCRIPTION
If we find a version other than 1.0 or 2.0 we will error, but we will at
least avoid silently ignoring an unknown version.

This will clash with #240, so I'll fix it up once that is decided on.