### PR TITLE
Protect Image.file_name

### DIFF
--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -552,7 +552,10 @@ impl<'names> GlifParser<'names> {
 
         match filename {
             Some(file_name) => {
-                self.glyph.image = Some(Image { file_name, color, transform });
+                self.glyph.image = Some(
+                    Image::new(file_name, color, transform)
+                        .map_err(|_| GlifLoadError::Parse(ErrorKind::BadImage))?,
+                );
                 Ok(())
             }
             None => Err(ErrorKind::BadImage.into()),

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -347,7 +347,7 @@ impl Color {
 impl Image {
     fn to_event(&self) -> Event {
         let mut start = BytesStart::borrowed_name(b"image");
-        start.push_attribute(("fileName", self.file_name.to_str().unwrap_or("missing path")));
+        start.push_attribute(("fileName", self.file_name.to_str().expect("missing path")));
 
         write_transform_attributes(&mut start, &self.transform);
 


### PR DESCRIPTION
It must ensure some invariants.

Closes #203.