### PR TITLE
Use our errors in custom deserialize functions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -171,6 +171,8 @@ pub enum FontInfoErrorKind {
     InvalidOpenTypeHeadCreatedDate,
     /// The openTypeOS2FamilyClass had out of range values.
     InvalidOs2FamilyClass,
+    /// The openTypeOS2Panose field did not have exactly ten elements.
+    InvalidOs2Panose,
     /// A Postscript data list had more elements than the specification allows.
     InvalidPostscriptListLength {
         /// The name of the property.
@@ -184,47 +186,61 @@ pub enum FontInfoErrorKind {
     UnknownFontStyle(i32),
     /// Unrecognized UFO v1 msCharSet field.
     UnknownMsCharSet(i32),
+    /// Unrecognized styleMapStyleName.
+    UnknownStyleMapStyleName,
     /// Unrecognized openTypeOS2WidthClass.
     UnknownWidthClass(String),
+    /// Unrecognized WOFF writing direction.
+    UnknownWoffDirection,
     /// The openTypeGaspRangeRecords field was unsorted.
     UnsortedGaspEntries,
 }
 
 impl std::fmt::Display for FontInfoErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use FontInfoErrorKind::*;
         match self {
-            FontInfoErrorKind::DisallowedSelectionBits => {
+            DisallowedSelectionBits => {
                 write!(f, "openTypeOS2Selection must not contain bits 0, 5 or 6")
             }
-            FontInfoErrorKind::DuplicateGuidelineIdentifiers => {
+            DuplicateGuidelineIdentifiers => {
                 write!(f, "guideline identifiers must be unique within the fontinfo.plist file")
             }
-            FontInfoErrorKind::EmptyWoffAttribute(s) => {
+            EmptyWoffAttribute(s) => {
                 write!(f, "a '{}' element must not be empty", s)
             }
-            FontInfoErrorKind::InvalidOpenTypeHeadCreatedDate => {
+            InvalidOpenTypeHeadCreatedDate => {
                 write!(f, "openTypeHeadCreated must be of format 'YYYY/MM/DD HH:MM:SS'")
             }
-            FontInfoErrorKind::InvalidOs2FamilyClass => {
+            InvalidOs2FamilyClass => {
                 write!(f, "openTypeOS2FamilyClass must be two numbers in the range 0-14 and 0-15, respectively")
             }
-            FontInfoErrorKind::InvalidPostscriptListLength { name, max_len, len } => {
+            InvalidOs2Panose => {
+                write!(f, "openTypeOS2Panose must have exactly ten elements")
+            }
+            InvalidPostscriptListLength { name, max_len, len } => {
                 write!(
                     f,
                     "the Postscript field '{}' must contain at most {} items but found {}",
                     name, max_len, len
                 )
             }
-            FontInfoErrorKind::UnknownFontStyle(s) => {
+            UnknownFontStyle(s) => {
                 write!(f, "unrecognized fontStyle '{}'", s)
             }
-            FontInfoErrorKind::UnknownMsCharSet(c) => {
+            UnknownMsCharSet(c) => {
                 write!(f, "unrecognized msCharSet '{}'", c)
             }
-            FontInfoErrorKind::UnknownWidthClass(w) => {
+            UnknownStyleMapStyleName => {
+                write!(f, "unknown value for styleMapStyleName")
+            }
+            UnknownWidthClass(w) => {
                 write!(f, "unrecognized OS/2 width class '{}'", w)
             }
-            FontInfoErrorKind::UnsortedGaspEntries => {
+            UnknownWoffDirection => {
+                write!(f, "unknown value for the WOFF direction attribute")
+            }
+            UnsortedGaspEntries => {
                 write!(f, "openTypeGaspRangeRecords must be sorted by their rangeMaxPPEM values")
             }
         }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1104,10 +1104,7 @@ impl<'de> Deserialize<'de> for NonNegativeIntegerOrFloat {
         D: Deserializer<'de>,
     {
         let value: f64 = Deserialize::deserialize(deserializer)?;
-        match NonNegativeIntegerOrFloat::try_from(value) {
-            Ok(v) => Ok(v),
-            Err(_) => Err(serde::de::Error::custom("Value must be positive.")),
-        }
+        NonNegativeIntegerOrFloat::try_from(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -1260,9 +1257,7 @@ impl<'de> Deserialize<'de> for Os2FamilyClass {
     {
         let values: Vec<u8> = Deserialize::deserialize(deserializer)?;
         if values.len() != 2 {
-            return Err(serde::de::Error::custom(
-                "openTypeOS2FamilyClass must have exactly two elements.",
-            ));
+            return Err(serde::de::Error::custom(FontInfoErrorKind::InvalidOs2FamilyClass));
         }
 
         Ok(Os2FamilyClass { class_id: values[0], subclass_id: values[1] })
@@ -1321,9 +1316,7 @@ impl<'de> Deserialize<'de> for Os2Panose {
     {
         let values: Vec<NonNegativeInteger> = Deserialize::deserialize(deserializer)?;
         if values.len() != 10 {
-            return Err(serde::de::Error::custom(
-                "openTypeOS2Panose must have exactly ten elements.",
-            ));
+            return Err(serde::de::Error::custom(FontInfoErrorKind::InvalidOs2Panose));
         }
 
         Ok(Os2Panose {
@@ -1381,9 +1374,7 @@ impl<'de> Deserialize<'de> for Os2PanoseV2 {
     {
         let values: Vec<Integer> = Deserialize::deserialize(deserializer)?;
         if values.len() != 10 {
-            return Err(serde::de::Error::custom(
-                "openTypeOS2Panose must have exactly ten elements.",
-            ));
+            return Err(serde::de::Error::custom(FontInfoErrorKind::InvalidOs2Panose));
         }
 
         Ok(Os2PanoseV2 {
@@ -1626,7 +1617,7 @@ impl<'de> Deserialize<'de> for WoffAttributeDirection {
         match string.as_ref() {
             "ltr" => Ok(WoffAttributeDirection::LeftToRight),
             "rtl" => Ok(WoffAttributeDirection::RightToLeft),
-            _ => Err(serde::de::Error::custom("unknown value for the WOFF direction attribute.")),
+            _ => Err(serde::de::Error::custom(FontInfoErrorKind::UnknownWoffDirection)),
         }
     }
 }
@@ -1670,7 +1661,7 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
             "italic" => Ok(StyleMapStyle::Italic),
             "bold" => Ok(StyleMapStyle::Bold),
             "bold italic" => Ok(StyleMapStyle::BoldItalic),
-            _ => Err(serde::de::Error::custom("unknown value for styleMapStyleName.")),
+            _ => Err(serde::de::Error::custom(FontInfoErrorKind::UnknownStyleMapStyleName)),
         }
     }
 }

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -64,7 +64,7 @@ impl<'de> Deserialize<'de> for Color {
         D: Deserializer<'de>,
     {
         let string = String::deserialize(deserializer)?;
-        Color::from_str(&string).map_err(|_| serde::de::Error::custom("Malformed color string."))
+        Color::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
Closes #212 

Results in errors like:

```
Error: failed to load file

Caused by:
    0: failed to load font info data
    1: failed to parse fontinfo.plist file
    2: Serde("invalid color string 'asbc'")
```

Not good, not bad...