### PR TITLE
Stricter layer renaming handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum NamingError {
     /// [control characters]: https://unifiedfontobject.org/versions/ufo3/conventions/#controls
     #[error("'{0}' is not a valid name")]
     Invalid(String),
+    /// An error returned when the name "public.default" is used for a non-default layer.
+    #[error("only the default layer may be named 'public.default'")]
+    ReservedName,
 }
 
 /// An error that occurs while attempting to read a .glif file from disk.

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -704,10 +704,12 @@ mod tests {
         assert_eq!(layer_set.get("aaa").unwrap().path().as_os_str(), "glyphs.aaa");
 
         layer_set.rename_layer("aaa", "bbb", false).unwrap();
+        assert!(layer_set.get("aaa").is_none());
         assert_eq!(layer_set.get("bbb").unwrap().path().as_os_str(), "glyphs.bbb");
 
         layer_set.rename_layer("bbb", "aaa", false).unwrap();
         assert_eq!(layer_set.get("aaa").unwrap().path().as_os_str(), "glyphs.aaa");
+        assert!(layer_set.get("bbb").is_none());
     }
 
     #[test]

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -195,16 +195,12 @@ impl LayerSet {
             // Dance around the borrow checker by using indices instead of references.
             let layer_pos = self.layers.iter().position(|l| l.name.as_ref() == old).unwrap();
 
-            if layer_pos == 0 {
-                // Default layer: just change the name.
-                let layer = &mut self.layers[layer_pos];
-                layer.name = name;
-            } else {
-                // Non-default layer: change name and path.
-                let layer = &mut self.layers[layer_pos];
+            // Default layer: just change the name. Non-default layer: change name and path.
+            let layer = &mut self.layers[layer_pos];
+            if layer_pos != 0 {
                 layer.path = crate::util::default_file_name_for_layer_name(&name).into();
-                layer.name = name;
             }
+            layer.name = name;
 
             Ok(())
         }


### PR DESCRIPTION
Broken out of #251 to ease reviewing.

1. Layer renaming should assign new paths as well, ...
2. ... except the default layer must always have the default layer path.
3. Protect the default layer name harder, it must only ever be assigned to the default layer.

Closes #253 