### PR TITLE
Use Name for glyph parts

### DIFF
--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1685,7 +1685,7 @@ impl<'de> Deserialize<'de> for StyleMapStyle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Color, Identifier, Line};
+    use crate::{Color, Identifier, Line, Name};
     use serde_test::{assert_tokens, Token};
 
     #[test]
@@ -1748,7 +1748,7 @@ mod tests {
                 Guideline::new(Line::Horizontal(123.0), None, None, None, None),
                 Guideline::new(
                     Line::Angle { x: 1.0, y: 2.0, degrees: 0.0 },
-                    Some(" [locked]".to_string()),
+                    Some(Name::new_raw(" [locked]")),
                     Some(Color::new(1.0, 1.0, 1.0, 1.0).unwrap()),
                     Some(Identifier::new("abc").unwrap()),
                     None

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -77,7 +77,7 @@ impl OutlineBuilder {
         (x, y): (f64, f64),
         segment_type: PointType,
         smooth: bool,
-        name: Option<String>,
+        name: Option<Name>,
         identifier: Option<Identifier>,
     ) -> Result<&mut Self, ErrorKind> {
         match &mut self.scratch_state {

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -262,7 +262,7 @@ pub struct Anchor {
     /// Anchor y coordinate value.
     pub y: f64,
     /// Optional arbitrary name for the anchor.
-    pub name: Option<String>,
+    pub name: Option<Name>,
     /// Optional anchor color.
     pub color: Option<Color>,
     /// Optional unique identifier for the anchor within the glyph.
@@ -373,7 +373,7 @@ pub struct ContourPoint {
     /// Whether a smooth curvature should be maintained at this point. Must not be set for off-curve points.
     pub smooth: bool,
     /// Optional contour point name.
-    pub name: Option<String>,
+    pub name: Option<Name>,
     /// Optional unique identifier for the point within the glyph.
     ///
     /// This attribute is only required when a lib is present and should otherwise only be added as needed.
@@ -464,7 +464,7 @@ impl Anchor {
     pub fn new(
         x: f64,
         y: f64,
-        name: Option<String>,
+        name: Option<Name>,
         color: Option<Color>,
         identifier: Option<Identifier>,
         lib: Option<Plist>,
@@ -576,7 +576,7 @@ impl ContourPoint {
         y: f64,
         typ: PointType,
         smooth: bool,
-        name: Option<String>,
+        name: Option<Name>,
         identifier: Option<Identifier>,
         lib: Option<Plist>,
     ) -> Self {

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -343,7 +343,7 @@ impl<'names> GlifParser<'names> {
         data: &BytesStart<'a>,
         outline_builder: &mut OutlineBuilder,
     ) -> Result<(), GlifLoadError> {
-        let mut name: Option<String> = None;
+        let mut name: Option<Name> = None;
         let mut x: Option<f64> = None;
         let mut y: Option<f64> = None;
         let mut typ = PointType::OffCurve;
@@ -361,7 +361,7 @@ impl<'names> GlifParser<'names> {
                 b"y" => {
                     y = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
-                b"name" => name = Some(value.to_string()),
+                b"name" => name = Some(Name::new(value).map_err(|_| ErrorKind::InvalidName)?),
                 b"type" => {
                     typ = value.parse()?;
                 }
@@ -441,7 +441,7 @@ impl<'names> GlifParser<'names> {
     ) -> Result<(), GlifLoadError> {
         let mut x: Option<f64> = None;
         let mut y: Option<f64> = None;
-        let mut name: Option<String> = None;
+        let mut name: Option<Name> = None;
         let mut color: Option<Color> = None;
         let mut identifier: Option<Identifier> = None;
 
@@ -456,7 +456,7 @@ impl<'names> GlifParser<'names> {
                 b"y" => {
                     y = Some(value.parse().map_err(|_| ErrorKind::BadNumber)?);
                 }
-                b"name" => name = Some(value.to_string()),
+                b"name" => name = Some(Name::new(value).map_err(|_| ErrorKind::InvalidName)?),
                 b"color" => color = Some(value.parse().map_err(|_| ErrorKind::BadColor)?),
                 b"identifier" => {
                     identifier = Some(self.parse_identifier(value)?);
@@ -482,7 +482,7 @@ impl<'names> GlifParser<'names> {
         let mut x: Option<f64> = None;
         let mut y: Option<f64> = None;
         let mut angle: Option<f64> = None;
-        let mut name: Option<String> = None;
+        let mut name: Option<Name> = None;
         let mut color: Option<Color> = None;
         let mut identifier: Option<Identifier> = None;
 
@@ -504,7 +504,7 @@ impl<'names> GlifParser<'names> {
                     }
                     angle = Some(angle_value);
                 }
-                b"name" => name = Some(value.to_string()),
+                b"name" => name = Some(Name::new(value).map_err(|_| ErrorKind::InvalidName)?),
                 b"color" => color = Some(value.parse().map_err(|_| ErrorKind::BadColor)?),
                 b"identifier" => {
                     identifier = Some(self.parse_identifier(value)?);

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -2,7 +2,7 @@ use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use serde::{de, ser};
 
-use crate::{Color, Identifier, Plist};
+use crate::{Color, Identifier, Name, Plist};
 
 /// A guideline associated with a glyph.
 #[derive(Debug, Clone, PartialEq)]
@@ -10,7 +10,7 @@ pub struct Guideline {
     /// The line itself.
     pub line: Line,
     /// An arbitrary name for the guideline.
-    pub name: Option<String>,
+    pub name: Option<Name>,
     /// The color of the line.
     pub color: Option<Color>,
     /// Unique identifier for the guideline within the glyph. This attribute is only required
@@ -44,7 +44,7 @@ impl Guideline {
     /// Returns a new [`Guideline`] struct.
     pub fn new(
         line: Line,
-        name: Option<String>,
+        name: Option<Name>,
         color: Option<Color>,
         identifier: Option<Identifier>,
         lib: Option<Plist>,
@@ -101,7 +101,7 @@ struct RawGuideline {
     x: Option<f64>,
     y: Option<f64>,
     angle: Option<f64>,
-    name: Option<String>,
+    name: Option<Name>,
     color: Option<Color>,
     identifier: Option<Identifier>,
 }
@@ -184,7 +184,7 @@ mod tests {
     fn guideline_parsing() {
         let g1 = Guideline::new(
             Line::Angle { x: 10.0, y: 20.0, degrees: 360.0 },
-            Some("hello".to_string()),
+            Some(Name::new_raw("hello")),
             Some(Color::new(0.0, 0.5, 0.0, 0.5).unwrap()),
             Some(Identifier::new("abcABC123").unwrap()),
             None,

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -801,14 +801,14 @@ mod tests {
     fn layer_duplicate_paths() {
         let mut layer = Layer::default();
 
-        layer.insert_glyph(Glyph::new_named("Ab"));
+        layer.insert_glyph(Glyph::new("Ab"));
         assert_eq!(layer.contents.get("Ab").unwrap().as_os_str(), "A_b.glif");
 
-        layer.insert_glyph(Glyph::new_named("a_b"));
+        layer.insert_glyph(Glyph::new("a_b"));
         assert_eq!(layer.contents.get("a_b").unwrap().as_os_str(), "a_b01.glif");
 
         layer.remove_glyph("Ab");
-        layer.insert_glyph(Glyph::new_named("Ab"));
+        layer.insert_glyph(Glyph::new("Ab"));
         assert_eq!(layer.contents.get("Ab").unwrap().as_os_str(), "A_b.glif");
     }
 }

--- a/src/name.rs
+++ b/src/name.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer};
 
 use crate::error::NamingError;
 
@@ -17,7 +17,8 @@ use crate::error::NamingError;
 ///
 /// [`Glyph`]: crate::Glyph
 /// [`Layer`]: crate::Layer
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
 #[cfg_attr(feature = "druid", derive(druid::Data))]
 pub struct Name(Arc<str>);
 
@@ -89,18 +90,6 @@ impl std::fmt::Display for Name {
 impl std::borrow::Borrow<str> for Name {
     fn borrow(&self) -> &str {
         self.0.as_ref()
-    }
-}
-
-// NOTE: This custom function ensures that serde serializes to a `Token::Str`
-// rather than `Token::NewType` that appears with a derived `Serialize`.
-impl Serialize for Name {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        debug_assert!(is_valid(&self.0), "all names are validated on construction");
-        serializer.serialize_str(&self.0)
     }
 }
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::error::NamingError;
 
@@ -17,7 +17,7 @@ use crate::error::NamingError;
 ///
 /// [`Glyph`]: crate::Glyph
 /// [`Layer`]: crate::Layer
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "druid", derive(druid::Data))]
 pub struct Name(Arc<str>);
 
@@ -89,6 +89,18 @@ impl std::fmt::Display for Name {
 impl std::borrow::Borrow<str> for Name {
     fn borrow(&self) -> &str {
         self.0.as_ref()
+    }
+}
+
+// NOTE: This custom function ensures that serde serializes to a `Token::Str`
+// rather than `Token::NewType` that appears with a derived `Serialize`.
+impl Serialize for Name {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        debug_assert!(is_valid(&self.0), "all names are validated on construction");
+        serializer.serialize_str(&self.0)
     }
 }
 


### PR DESCRIPTION
Because no control characters. Found this while skimming the spec. Oops :D But also, these parts don't have a minimum length specified, but empty names make no sense. May need to open a discussion on the spec tracker.

Also, how did we not find the "Glyph::new_named" issue in one of the tests?

Edit: opened issue over at https://github.com/unified-font-object/ufo-spec/issues/206