### PR TITLE
Make code for Identifier match Name

### DIFF
--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1750,7 +1750,7 @@ mod tests {
                     Line::Angle { x: 1.0, y: 2.0, degrees: 0.0 },
                     Some(Name::new_raw(" [locked]")),
                     Some(Color::new(1.0, 1.0, 1.0, 1.0).unwrap()),
-                    Some(Identifier::new("abc").unwrap()),
+                    Some(Identifier::new_raw("abc")),
                     None
                 ),
             ])
@@ -1907,14 +1907,14 @@ mod tests {
                 Line::Horizontal(10.0),
                 None,
                 None,
-                Some(Identifier::new("test1").unwrap()),
+                Some(Identifier::new_raw("test1")),
                 None,
             ),
             Guideline::new(
                 Line::Vertical(20.0),
                 None,
                 None,
-                Some(Identifier::new("test2").unwrap()),
+                Some(Identifier::new_raw("test2")),
                 None,
             ),
         ]);
@@ -1925,14 +1925,14 @@ mod tests {
                 Line::Horizontal(10.0),
                 None,
                 None,
-                Some(Identifier::new("test1").unwrap()),
+                Some(Identifier::new_raw("test1")),
                 None,
             ),
             Guideline::new(
                 Line::Vertical(20.0),
                 None,
                 None,
-                Some(Identifier::new("test1").unwrap()),
+                Some(Identifier::new_raw("test1")),
                 None,
             ),
         ]);

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -203,7 +203,7 @@ mod tests {
     fn builder_basic() -> Result<(), ErrorKind> {
         let mut outline_builder = OutlineBuilder::new();
         outline_builder
-            .begin_path(Some(Identifier::new("abc").unwrap()))?
+            .begin_path(Some(Identifier::new_raw("abc")))?
             .add_point((173.0, 536.0), PointType::Line, false, None, None)?
             .add_point((85.0, 536.0), PointType::Line, false, None, None)?
             .add_point((85.0, 0.0), PointType::Line, false, None, None)?
@@ -212,13 +212,13 @@ mod tests {
                 PointType::Line,
                 false,
                 None,
-                Some(Identifier::new("def").unwrap()),
+                Some(Identifier::new_raw("def")),
             )?
             .end_path()?
             .add_component(
                 Name::new_raw("hallo"),
                 AffineTransform::default(),
-                Some(Identifier::new("xyz").unwrap()),
+                Some(Identifier::new_raw("xyz")),
             );
         let (contours, components) = outline_builder.finish()?;
 
@@ -235,11 +235,11 @@ mod tests {
                         PointType::Line,
                         false,
                         None,
-                        Some(Identifier::new("def").unwrap()),
+                        Some(Identifier::new_raw("def")),
                         None,
                     ),
                 ],
-                Some(Identifier::new("abc").unwrap()),
+                Some(Identifier::new_raw("abc")),
                 None,
             )]
         );
@@ -256,7 +256,7 @@ mod tests {
                     x_offset: 0.0,
                     y_offset: 0.0,
                 },
-                Some(Identifier::new("xyz").unwrap()),
+                Some(Identifier::new_raw("xyz")),
                 None,
             )]
         );
@@ -268,7 +268,7 @@ mod tests {
     #[should_panic(expected = "UnfinishedDrawing")]
     fn outline_builder_unfinished_drawing() {
         let mut outline_builder = OutlineBuilder::new();
-        outline_builder.begin_path(Some(Identifier::new("abc").unwrap())).unwrap();
+        outline_builder.begin_path(Some(Identifier::new_raw("abc"))).unwrap();
         outline_builder.finish().unwrap();
     }
 
@@ -276,7 +276,7 @@ mod tests {
     #[should_panic(expected = "UnfinishedDrawing")]
     fn outline_builder_unfinished_drawing2() {
         OutlineBuilder::new()
-            .begin_path(Some(Identifier::new("abc").unwrap()))
+            .begin_path(Some(Identifier::new_raw("abc")))
             .unwrap()
             .begin_path(None)
             .unwrap();

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -186,7 +186,7 @@ mod tests {
             Line::Angle { x: 10.0, y: 20.0, degrees: 360.0 },
             Some(Name::new_raw("hello")),
             Some(Color::new(0.0, 0.5, 0.0, 0.5).unwrap()),
-            Some(Identifier::new("abcABC123").unwrap()),
+            Some(Identifier::new_raw("abcABC123")),
             None,
         );
         assert_tokens(


### PR DESCRIPTION
Both structures are the same, except for the validity criteria.

Leaving the custom `serialize` because we run a debug_assert. Or should we scrap that one?