### PR TITLE
Ignore `path_set` when equality testing LayerSet

### DIFF
--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -659,7 +659,7 @@ impl FontInfo {
                         .unitsPerEm
                         .map(|v| NonNegativeIntegerOrFloat::new(v.abs()).unwrap()),
                     version_major: fontinfo_v2.versionMajor,
-                    version_minor: fontinfo_v2.versionMinor.map(|v| v.abs() as NonNegativeInteger),
+                    version_minor: fontinfo_v2.versionMinor.map(|v| v.unsigned_abs()),
                     x_height: fontinfo_v2.xHeight,
                     year: fontinfo_v2.year,
                     ..FontInfo::default()
@@ -696,7 +696,7 @@ impl FontInfo {
                     open_type_os2_weight_class: match fontinfo_v1.weightValue {
                         Some(v) => match v {
                             -1 => None,
-                            _ => Some(v.abs() as NonNegativeInteger),
+                            _ => Some(v.unsigned_abs()),
                         },
                         None => None,
                     },
@@ -780,7 +780,7 @@ impl FontInfo {
                         .unitsPerEm
                         .map(|v| NonNegativeIntegerOrFloat::new(v.abs()).unwrap()),
                     version_major: fontinfo_v1.versionMajor,
-                    version_minor: fontinfo_v1.versionMinor.map(|v| v.abs() as NonNegativeInteger),
+                    version_minor: fontinfo_v1.versionMinor.map(|v| v.unsigned_abs()),
                     x_height: fontinfo_v1.xHeight,
                     year: fontinfo_v1.year,
                     ..FontInfo::default()
@@ -1353,16 +1353,16 @@ impl<'de> Deserialize<'de> for Os2Panose {
 impl From<Os2PanoseV2> for Os2Panose {
     fn from(value: Os2PanoseV2) -> Self {
         Os2Panose {
-            family_type: value.family_type.abs() as NonNegativeInteger,
-            serif_style: value.serif_style.abs() as NonNegativeInteger,
-            weight: value.weight.abs() as NonNegativeInteger,
-            proportion: value.proportion.abs() as NonNegativeInteger,
-            contrast: value.contrast.abs() as NonNegativeInteger,
-            stroke_variation: value.stroke_variation.abs() as NonNegativeInteger,
-            arm_style: value.arm_style.abs() as NonNegativeInteger,
-            letterform: value.letterform.abs() as NonNegativeInteger,
-            midline: value.midline.abs() as NonNegativeInteger,
-            x_height: value.x_height.abs() as NonNegativeInteger,
+            family_type: value.family_type.unsigned_abs(),
+            serif_style: value.serif_style.unsigned_abs(),
+            weight: value.weight.unsigned_abs(),
+            proportion: value.proportion.unsigned_abs(),
+            contrast: value.contrast.unsigned_abs(),
+            stroke_variation: value.stroke_variation.unsigned_abs(),
+            arm_style: value.arm_style.unsigned_abs(),
+            letterform: value.letterform.unsigned_abs(),
+            midline: value.midline.unsigned_abs(),
+            x_height: value.x_height.unsigned_abs(),
         }
     }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -25,7 +25,7 @@ pub(crate) static DEFAULT_GLYPHS_DIRNAME: &str = "glyphs";
 ///
 /// A layer set always includes a default layer, and may also include additional
 /// layers.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct LayerSet {
     /// A collection of [`Layer`]s.  The first [`Layer`] is the default.
     layers: Vec<Layer>,
@@ -33,6 +33,15 @@ pub struct LayerSet {
     /// always unique) for clash detection. This relies on Layer.path being
     /// immutable.
     path_set: HashSet<String>,
+}
+
+impl PartialEq for LayerSet {
+    fn eq(&self, other: &Self) -> bool {
+        // Ignore path_set as an implementation detail. I hope this does not
+        // lead to observable differences in behavior when reading from disk vs.
+        // recreating it in memory...
+        self.layers == other.layers
+    }
 }
 
 #[allow(clippy::len_without_is_empty)] // never empty

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 //! Common utilities.
 
+use std::fmt::Write as _;
 use std::{collections::HashSet, path::PathBuf};
 
 use crate::Name;
@@ -152,7 +153,7 @@ fn user_name_to_file_name(
 
         let mut found_unique = false;
         for counter in 1..100u8 {
-            result.push_str(&format!("{:0>2}", counter));
+            write!(&mut result, "{:0>2}", counter).unwrap();
             result.push_str(suffix);
             if !existing.contains(&result.to_lowercase()) {
                 found_unique = true;


### PR DESCRIPTION
Found this while testing for equality when loading a layer set vs. recreating it manually.