### PR TITLE
Add a basic designspace parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ features = ["kurbo"]
 [dependencies]
 plist = { version =  "1.3.1", features = ["serde"] }
 uuid = { version = "1.2", features = ["v4"] }
-serde = { version =  "1.0", features = ["rc"] }
+serde = { version =  "1.0", features = ["rc", "derive"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
 quick-xml = { version = "0.26.0", features = ["serialize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ uuid = { version = "1.2", features = ["v4"] }
 serde = { version =  "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
-quick-xml = "0.26.0"
+quick-xml = { version = "0.26.0", features = ["serialize"] }
 rayon = { version = "1.3.0", optional = true }
 kurbo = { version = "0.8.1", optional = true }
 thiserror = "1.0"

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -79,8 +79,9 @@ pub struct Instances {
 /// [instance]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#instance-element
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 pub struct Instance {
-    pub familyname: String,
-    pub stylename: String,
+    // per @anthrotype, contrary to spec, familyname and stylename are optional
+    pub familyname: Option<String>,
+    pub stylename: Option<String>,
     pub name: String,
     pub filename: String,
     pub postscriptfontname: Option<String>,

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -44,7 +44,8 @@ pub struct Axis {
     /// The default value for this axis, in user space coordinates.
     pub default: f32,
     /// Records whether this axis needs to be hidden in interfaces.
-    pub hidden: Option<bool>,
+    #[serde(default)]
+    pub hidden: bool,
     /// The minimum value for a continuous axis, in user space coordinates.
     pub minimum: Option<f32>,
     /// The maximum value for a continuous axis, in user space coordinates.
@@ -106,7 +107,7 @@ pub struct Instances {
 /// [instance]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#instance-element
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 pub struct Instance {
-    // per @anthrotype, contrary to spec, familyname and stylename are optional
+    // per @anthrotype, contrary to spec, filename, familyname and stylename are optional
     /// The family name of the instance font. Corresponds with font.info.familyName
     pub familyname: Option<String>,
     /// The style name of the instance font. Corresponds with font.info.styleName
@@ -114,7 +115,7 @@ pub struct Instance {
     /// A unique name that can be used to identify this font if it needs to be referenced elsewhere.
     pub name: String,
     /// A path to the instance file, relative to the root path of this document. The path can be at the same level as the document or lower.
-    pub filename: String,
+    pub filename: Option<String>,
     /// Corresponds with font.info.postscriptFontName
     pub postscriptfontname: Option<String>,
     /// Corresponds with styleMapFamilyName

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -1,0 +1,144 @@
+//! Reading and writing designspace files.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+use quick_xml::de::from_reader;
+use std::{fs::File, io::BufReader, path::Path};
+
+use crate::error::DesignSpaceLoadError;
+
+/// A [designspace]].
+///
+/// [designspace]: https://fonttools.readthedocs.io/en/latest/designspaceLib/index.html
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[serde(rename = "designspace")]
+pub struct DesignSpaceDocument {
+    pub format: f32,
+    pub axes: Axes,
+    pub sources: Sources,
+    pub instances: Instances,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[serde(rename = "axes")]
+pub struct Axes {
+    pub axis: Vec<Axis>,
+}
+
+/// A [axis]].
+///
+/// [axis]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#axis-element
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[serde(rename = "axis")]
+pub struct Axis {
+    pub name: String,
+    pub tag: String,
+    pub default: f32,
+    pub hidden: Option<bool>,
+    pub minimum: Option<f32>,
+    pub maximum: Option<f32>,
+    pub values: Option<Vec<f32>>,
+    pub map: Vec<AxisMapping>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[serde(rename = "map")]
+pub struct AxisMapping {
+    pub input: f32,
+    pub output: f32,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[serde(rename = "sources")]
+pub struct Sources {
+    pub source: Vec<Source>,
+}
+
+/// A [source]].
+///
+/// [source]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#id25
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[serde(rename = "source")]
+pub struct Source {
+    pub familyname: Option<String>,
+    pub stylename: Option<String>,
+    pub name: String,
+    pub filename: String,
+    pub layer: Option<String>,
+    pub location: Location,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+#[serde(rename = "instances")]
+pub struct Instances {
+    pub instance: Vec<Instance>,
+}
+
+/// An [instance]].
+///
+/// [instance]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#instance-element
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+pub struct Instance {
+    pub familyname: String,
+    pub stylename: String,
+    pub name: String,
+    pub filename: String,
+    pub postscriptfontname: Option<String>,
+    pub stylemapfamilyname: Option<String>,
+    pub stylemapstylename: Option<String>,
+    pub location: Location,
+}
+
+/// A [design space location]].
+///
+/// [design space location]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#location-element-source
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+pub struct Location {
+    pub dimension: Vec<Dimension>,
+}
+
+/// A [design space dimension]].
+///
+/// [design space location]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#location-element-source
+#[derive(Clone, Debug, Default, PartialEq, Deserialize)]
+pub struct Dimension {
+    pub name: String,
+    pub uservalue: Option<f32>,
+    pub xvalue: Option<f32>,
+    pub yvalue: Option<f32>,
+}
+
+impl DesignSpaceDocument {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<DesignSpaceDocument, DesignSpaceLoadError> {
+        let reader = BufReader::new(File::open(path).map_err(DesignSpaceLoadError::Io)?);
+        Ok(from_reader(reader).map_err(DesignSpaceLoadError::DeError)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use pretty_assertions::assert_eq;
+
+    use crate::designspace::{AxisMapping, Dimension};
+
+    use super::DesignSpaceDocument;
+
+    #[test]
+    fn read_single_wght() {
+        let ds = DesignSpaceDocument::load(Path::new("testdata/single_wght.designspace")).unwrap();
+        assert_eq!(1, ds.axes.axis.len());
+        assert_eq!(vec![AxisMapping { input: 400., output: 100. }], ds.axes.axis[0].map);
+        assert_eq!(1, ds.sources.source.len());
+        let weight_100 = Dimension {
+            name: "Weight".to_string(),
+            uservalue: None,
+            xvalue: Some(100.),
+            yvalue: None,
+        };
+        assert_eq!(vec![weight_100.clone()], ds.sources.source[0].location.dimension);
+        assert_eq!(1, ds.instances.instance.len());
+        assert_eq!(vec![weight_100], ds.instances.instance[0].location.dimension);
+    }
+}

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn read_wght_variable() {
-        let ds = DesignSpaceDocument::load(Path::new("testdata/wght.designspace")).unwrap();
+        let ds = DesignSpaceDocument::load("testdata/wght.designspace").unwrap();
         assert_eq!(1, ds.axes.len());
         assert!(ds.axes[0].map.is_none());
         assert_eq!(

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -13,15 +13,21 @@ use crate::error::DesignSpaceLoadError;
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(rename = "designspace")]
 pub struct DesignSpaceDocument {
+    /// Design space format version.
     pub format: f32,
+    /// One or more axes.
     pub axes: Axes,
+    /// One or more sources.
     pub sources: Sources,
+    /// One or more instances.
     pub instances: Instances,
 }
 
+/// https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#axes-element
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(rename = "axes")]
 pub struct Axes {
+    /// One or more axis definitions.
     pub axis: Vec<Axis>,
 }
 
@@ -31,26 +37,39 @@ pub struct Axes {
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(rename = "axis")]
 pub struct Axis {
+    /// Name of the axis that is used in the location elements.
     pub name: String,
+    /// 4 letters. Some axis tags are registered in the OpenType Specification.
     pub tag: String,
+    /// The default value for this axis, in user space coordinates.
     pub default: f32,
+    /// Records whether this axis needs to be hidden in interfaces.
     pub hidden: Option<bool>,
+    /// The minimum value for a continuous axis, in user space coordinates.
     pub minimum: Option<f32>,
+    /// The maximum value for a continuous axis, in user space coordinates.
     pub maximum: Option<f32>,
+    /// The possible values for a discrete axis, in user space coordinates.
     pub values: Option<Vec<f32>>,
+    /// Mapping between user space coordinates and design space coordinates.
     pub map: Option<Vec<AxisMapping>>,
 }
 
+/// Maps one input value (user space coord) to one output value (design space coord).
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(rename = "map")]
 pub struct AxisMapping {
+    /// user space coordinate
     pub input: f32,
+    /// designspace coordinate
     pub output: f32,
 }
 
+/// https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#sources-element
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(rename = "sources")]
 pub struct Sources {
+    /// One or more sources.
     pub source: Vec<Source>,
 }
 
@@ -60,17 +79,25 @@ pub struct Sources {
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(rename = "source")]
 pub struct Source {
+    /// The family name of the source font.
     pub familyname: Option<String>,
+    /// The style name of the source font.
     pub stylename: Option<String>,
+    /// A unique name that can be used to identify this font if it needs to be referenced elsewhere.
     pub name: String,
+    /// A path to the source file, relative to the root path of this document. The path can be at the same level as the document or lower.
     pub filename: String,
+    /// The name of the layer in the source file. If no layer attribute is given assume the foreground layer should be used.
     pub layer: Option<String>,
+    /// Location in designspace coordinates.
     pub location: Location,
 }
 
+/// https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#instances-element
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(rename = "instances")]
 pub struct Instances {
+    /// One or more instances located somewhere in designspace.
     pub instance: Vec<Instance>,
 }
 
@@ -80,13 +107,21 @@ pub struct Instances {
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 pub struct Instance {
     // per @anthrotype, contrary to spec, familyname and stylename are optional
+    /// The family name of the instance font. Corresponds with font.info.familyName
     pub familyname: Option<String>,
+    /// The style name of the instance font. Corresponds with font.info.styleName
     pub stylename: Option<String>,
+    /// A unique name that can be used to identify this font if it needs to be referenced elsewhere.
     pub name: String,
+    /// A path to the instance file, relative to the root path of this document. The path can be at the same level as the document or lower.
     pub filename: String,
+    /// Corresponds with font.info.postscriptFontName
     pub postscriptfontname: Option<String>,
+    /// Corresponds with styleMapFamilyName
     pub stylemapfamilyname: Option<String>,
+    /// Corresponds with styleMapStyleName
     pub stylemapstylename: Option<String>,
+    /// Location in designspace.
     pub location: Location,
 }
 
@@ -95,6 +130,7 @@ pub struct Instance {
 /// [design space location]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#location-element-source
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 pub struct Location {
+    /// Should contain one Dimension for each axis in the designspace.
     pub dimension: Vec<Dimension>,
 }
 
@@ -103,13 +139,18 @@ pub struct Location {
 /// [design space location]: https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#location-element-source
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 pub struct Dimension {
+    /// Name of the axis, e.g. Weight.
     pub name: String,
+    /// Value on the axis in user coordinates.
     pub uservalue: Option<f32>,
+    /// Value on the axis in designcoordinates.
     pub xvalue: Option<f32>,
+    /// Separate value for anisotropic interpolations.
     pub yvalue: Option<f32>,
 }
 
 impl DesignSpaceDocument {
+    /// Load a designspace.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<DesignSpaceDocument, DesignSpaceLoadError> {
         let reader = BufReader::new(File::open(path).map_err(DesignSpaceLoadError::Io)?);
         from_reader(reader).map_err(DesignSpaceLoadError::DeError)

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -2,7 +2,6 @@
 
 #![deny(rustdoc::broken_intra_doc_links)]
 
-use quick_xml::de::from_reader;
 use std::{fs::File, io::BufReader, path::Path};
 
 use crate::error::DesignSpaceLoadError;
@@ -154,7 +153,7 @@ impl DesignSpaceDocument {
     /// Load a designspace.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<DesignSpaceDocument, DesignSpaceLoadError> {
         let reader = BufReader::new(File::open(path).map_err(DesignSpaceLoadError::Io)?);
-        from_reader(reader).map_err(DesignSpaceLoadError::DeError)
+        quick_xml::de::from_reader(reader).map_err(DesignSpaceLoadError::DeError)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,12 +5,25 @@ use std::path::PathBuf;
 
 use plist::Error as PlistError;
 use quick_xml::events::attributes::AttrError;
-use quick_xml::Error as XmlError;
+use quick_xml::{DeError, Error as XmlError};
 use thiserror::Error;
 
 pub use crate::shared_types::ColorError;
 use crate::write::CustomSerializationError;
 use crate::Name;
+
+/// An error that occurs while attempting to read a UFO package from disk.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum DesignSpaceLoadError {
+    /// An [`std::io::Error`].
+    #[error("failed to read file")]
+    Io(#[from] IoError),
+
+    /// A parse error.
+    #[error("failed to deserialize")]
+    DeError(#[from] DeError),
+}
 
 /// An error representing a failure to (re)name something.
 #[derive(Debug, Error)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub use crate::shared_types::ColorError;
 use crate::write::CustomSerializationError;
 use crate::Name;
 
-/// An error that occurs while attempting to read a UFO package from disk.
+/// An error that occurs while attempting to read a designspace file from disk.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum DesignSpaceLoadError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ extern crate serde_repr;
 
 mod data_request;
 pub mod datastore;
+mod designspace;
 pub mod error;
 mod font;
 pub mod fontinfo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ extern crate serde_repr;
 
 mod data_request;
 pub mod datastore;
-mod designspace;
+pub mod designspace;
 pub mod error;
 mod font;
 pub mod fontinfo;

--- a/testdata/single_wght.designspace
+++ b/testdata/single_wght.designspace
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="400" default="400">
+      <map input="400" output="100"/>
+    </axis>
+  </axes>
+  <sources>
+    <source filename="Demo-Regular.ufo" name="Demo Regular" familyname="Demo" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="100"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance name="Demo Regular" familyname="Demo" stylename="Regular" filename="../instance_ufo/Demo-Regular.ufo" postscriptfontname="Demo" stylemapfamilyname="Demo" stylemapstylename="regular">
+      <location>
+        <dimension name="Weight" xvalue="100"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>

--- a/testdata/wght.designspace
+++ b/testdata/wght.designspace
@@ -1,0 +1,117 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="TestFamily-Regular.ufo" name="Test Family Regular" familyname="Test Family" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="TestFamily-Bold.ufo" name="Test Family Bold" familyname="Test Family" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance name="Test Family Regular" familyname="Test Family" stylename="Regular" filename="instance_ufos/TestFamily-Regular.ufo" stylemapfamilyname="Test Family" stylemapstylename="regular">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+      <kerning/>
+      <info/>
+      <lib>
+        <dict>
+          <key>com.schriftgestaltung.customParameters</key>
+          <array>
+            <array>
+              <string>xHeight</string>
+              <string>536</string>
+            </array>
+            <array>
+              <string>panose</string>
+              <array>
+                <integer>2</integer>
+                <integer>2</integer>
+                <integer>5</integer>
+                <integer>2</integer>
+                <integer>6</integer>
+                <integer>5</integer>
+                <integer>5</integer>
+                <integer>2</integer>
+                <integer>2</integer>
+                <integer>4</integer>
+              </array>
+            </array>
+          </array>
+        </dict>
+      </lib>
+
+    </instance>
+    <instance name="Test Family Bold" familyname="Test Family" stylename="Bold" filename="instance_ufos/TestFamily-Bold.ufo" stylemapfamilyname="Test Family" stylemapstylename="bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+      <kerning/>
+      <info/>
+      <lib>
+        <dict>
+          <key>com.schriftgestaltung.customParameters</key>
+          <array>
+            <array>
+              <string>xHeight</string>
+              <string>536</string>
+            </array>
+            <array>
+              <string>panose</string>
+              <array>
+                <integer>2</integer>
+                <integer>2</integer>
+                <integer>5</integer>
+                <integer>2</integer>
+                <integer>6</integer>
+                <integer>5</integer>
+                <integer>5</integer>
+                <integer>2</integer>
+                <integer>2</integer>
+                <integer>4</integer>
+              </array>
+            </array>
+          </array>
+        </dict>
+      </lib>
+    </instance>
+  </instances>
+  <lib>
+    <dict>
+      <key>com.github.googlei18n.ufo2ft.featureWriters</key>
+      <array>
+        <dict>
+          <key>class</key>
+          <string>KernFeatureWriter</string>
+          <key>options</key>
+          <dict>
+            <key>mode</key>
+            <string>append</string>
+          </dict>
+        </dict>
+        <dict>
+          <key>class</key>
+          <string>MarkFeatureWriter</string>
+          <key>options</key>
+          <dict>
+            <key>mode</key>
+            <string>skip</string>
+          </dict>
+        </dict>
+      </array>      
+    </dict>
+  </lib>
+
+</designspace>


### PR DESCRIPTION
Intended for use by Rust compiler so it can use norad to read designspace+ufo(s) to produce IR.

Serde xml seems slightly limited in ability to do things like flatten pointless container elements. If we want more control we might need to parse w/o using it.

