### PR TITLE
LayerSet: add retain & remove_empty_layers

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -896,4 +896,54 @@ mod tests {
         let bglayer = layerset.get("background").unwrap();
         assert_eq!(bglayer.len(), 1);
     }
+
+    #[test]
+    fn test_retain() {
+        let mut layers = LayerSet {
+            layers: vec![
+                Layer::default(),
+                Layer::new(Name::new("fizz").unwrap(), PathBuf::new()),
+                Layer::new(Name::new("buzz").unwrap(), PathBuf::new()),
+                Layer::new(Name::new("fizzbuzz").unwrap(), PathBuf::new()),
+            ],
+            ..Default::default()
+        };
+
+        layers.retain(|l| l.name().starts_with("fizz"));
+
+        assert_eq!(layers.len(), 3, "wrong number of layers deleted");
+        let names = layers.iter().map(|l| l.name().as_str()).collect::<Vec<_>>();
+        assert_eq!(names.as_slice(), &[DEFAULT_LAYER_NAME, "fizz", "fizzbuzz"]);
+    }
+
+    #[test]
+    fn test_remove_empty_layers() {
+        let mut layers = LayerSet {
+            layers: vec![
+                Layer::default(),
+                Layer {
+                    name: Name::new("fizz").unwrap(),
+                    glyphs: maplit::btreemap! {
+                        Name::new("a").unwrap() => Glyph::new("a").into(),
+                    },
+                    ..Default::default()
+                },
+                Layer {
+                    name: Name::new("buzz").unwrap(),
+                    glyphs: maplit::btreemap! {
+                        Name::new("b").unwrap() => Glyph::new("b").into(),
+                    },
+                    ..Default::default()
+                },
+                Layer::new(Name::new("fizzbuzz").unwrap(), PathBuf::new()),
+            ],
+            ..Default::default()
+        };
+
+        layers.remove_empty_layers();
+
+        assert_eq!(layers.len(), 3, "wrong number of layers deleted");
+        let names = layers.iter().map(|l| l.name().as_str()).collect::<Vec<_>>();
+        assert_eq!(names.as_slice(), &[DEFAULT_LAYER_NAME, "fizz", "buzz"]);
+    }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -227,6 +227,11 @@ impl LayerSet {
     {
         self.layers.retain(|layer| layer.name == DEFAULT_LAYER_NAME || predicate(layer))
     }
+
+    /// Removes any layers that contain no glyphs
+    pub fn remove_empty_layers(&mut self) {
+        self.retain(|l| !l.is_empty());
+    }
 }
 
 impl Default for LayerSet {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -917,6 +917,8 @@ mod tests {
     }
 
     #[test]
+    // Saves test from failing to compile with druid enabled
+    #[allow(clippy::useless_conversion)]
     fn test_remove_empty_layers() {
         let mut layers = LayerSet {
             layers: vec![

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -213,6 +213,20 @@ impl LayerSet {
             Ok(())
         }
     }
+
+    /// Retains the default layer, and any layers allowed by the predicate.
+    ///
+    /// In other words, remove all layers `l` for which `predicate(&l)` returns `false`.
+    /// This method operates in place, visiting each layer exactly once in the
+    /// original order, and preserves the order of the retained layers.
+    ///
+    /// For more information, see [`Vec::retain`].
+    pub fn retain<F>(&mut self, mut predicate: F)
+    where
+        F: FnMut(&Layer) -> bool,
+    {
+        self.layers.retain(|layer| layer.name == DEFAULT_LAYER_NAME || predicate(layer))
+    }
 }
 
 impl Default for LayerSet {


### PR DESCRIPTION
This is functionality I have a use for and can't implement anywhere except in the library, given `layers` is a private member of `LayerSet`

I don't like that with `retain` I check every layer to see if its name matches the default, but there's no good way (without allocating) to 'skip one and then retain' that I'm aware of

Simple positive test case added for each method