### PR TITLE
Update custom whitespace API

### DIFF
--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -39,8 +39,8 @@ impl Glyph {
     fn encode_xml_impl(&self, options: &WriteOptions) -> Result<Vec<u8>, GlifWriteError> {
         let mut writer = Writer::new_with_indent(
             Cursor::new(Vec::new()),
-            options.whitespace_char,
-            options.whitespace_count,
+            options.indent_char,
+            options.indent_count,
         );
         match options.quote_style {
             QuoteChar::Double => writer
@@ -166,8 +166,8 @@ fn write_lib_section<T: Write>(
     writer.write_event(Event::Start(BytesStart::new("lib"))).map_err(GlifWriteError::Xml)?;
     for line in to_write.lines() {
         writer.inner().write_all("\n".as_bytes()).map_err(GlifWriteError::Buffer)?;
-        writer.inner().write_all(options.indent_str.as_bytes()).map_err(GlifWriteError::Buffer)?;
-        writer.inner().write_all(options.indent_str.as_bytes()).map_err(GlifWriteError::Buffer)?;
+        options.write_indent(writer.inner()).map_err(GlifWriteError::Buffer)?;
+        options.write_indent(writer.inner()).map_err(GlifWriteError::Buffer)?;
         writer.inner().write_all(line.as_bytes()).map_err(GlifWriteError::Buffer)?;
     }
     writer.write_event(Event::End(BytesEnd::new("lib"))).map_err(GlifWriteError::Xml)?;

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -104,7 +104,7 @@ fn serialize_with_default_formatting() {
 fn serialize_with_custom_whitespace() {
     let data = include_str!("../../testdata/small_lib.glif");
     let glyph = parse_glyph(data.as_bytes()).unwrap();
-    let options = WriteOptions::default().whitespace("  ");
+    let options = WriteOptions::default().indent(WriteOptions::SPACE, 2);
     let two_spaces = glyph.encode_xml_with_options(&options).unwrap();
     let two_spaces = std::str::from_utf8(&two_spaces).unwrap();
 
@@ -165,7 +165,8 @@ fn serialize_with_single_quote_style() {
 fn serialize_with_custom_whitespace_and_single_quote_style() {
     let data = include_str!("../../testdata/small_lib.glif");
     let glyph = parse_glyph(data.as_bytes()).unwrap();
-    let options = WriteOptions::default().whitespace("  ").quote_char(QuoteChar::Single);
+    let options =
+        WriteOptions::default().indent(WriteOptions::SPACE, 2).quote_char(QuoteChar::Single);
     let two_spaces = glyph.encode_xml_with_options(&options).unwrap();
     let two_spaces = std::str::from_utf8(&two_spaces).unwrap();
 


### PR DESCRIPTION
The old API was designed to work around the fact that the plist and quick-xml crates had different APIs for specifying custom indent behaviour. The plist crate has since been updated to match the API of quick-xml, which means that we can do the same.