### PR TITLE
Add `LayerSet::get_or_create_layer`

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -749,6 +749,32 @@ mod tests {
     }
 
     #[test]
+    fn layer_get_or_create() {
+        let mut ufo = crate::Font::load("testdata/MutatorSansLightWide.ufo").unwrap();
+        assert_eq!(
+            ufo.layers.len(),
+            2,
+            "number of layers in test data MutatorSansLightWide changed"
+        );
+
+        let result = ufo.layers.get_or_create_layer("background");
+        assert!(result.is_ok());
+        assert_eq!(ufo.layers.len(), 2);
+
+        let result = ufo.layers.get_or_create_layer("middleground");
+        assert!(result.is_ok());
+        assert_eq!(ufo.layers.len(), 3, "new layer wasn't created");
+        assert!(
+            ufo.layers.layers.iter().any(|layer| layer.name().as_str() == "foreground"),
+            "new layer was created with the wrong name"
+        );
+
+        let result = ufo.layers.get_or_create_layer("\t");
+        assert!(matches!(result, Err(NamingError::Invalid(_))));
+        assert_eq!(ufo.layers.len(), 3);
+    }
+
+    #[test]
     fn rename_layer() {
         let mut layer_set = LayerSet::default();
 


### PR DESCRIPTION
This one's a pain to do intuitively because of the borrow checker

You want to do something like:

```rust
match ufo.layers.get_mut("foobar") {
    Some(layer) => layer,
    None => ufo.layers.create_layer("foobar")?,
}
```

But the borrow checker won't let you because of multiple mutable borrows (which is arguably incorrect since `None` shouldn't be considered tied to `ufo.layers`, but improving the borrow checker is beyond my skill)

So what I've implemented is accepted by the borrow checker and doesn't iterate through `layers` multiple times. I've pulled out the happy path of `new_layer` to avoid the code duplication, hence the creation of the private function `create_layer`. Bikeshedding the naming is welcome because it's definitely not amazing, but I just wanted to get the PR out there and worry about naming later