### PR TITLE
Update quickxml again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ uuid = { version = "1.2", features = ["v4"] }
 serde = { version =  "1.0", features = ["rc", "derive"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
-quick-xml = { version = "0.27.0", features = ["serialize"] }
+quick-xml = { version = "0.28.0", features = ["serialize"] }
 rayon = { version = "1.3.0", optional = true }
 kurbo = { version = "0.9.0", optional = true }
 thiserror = "1.0"

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -55,8 +55,7 @@ pub struct Axis {
     #[serde(rename = "@values")]
     pub values: Option<Vec<f32>>,
     /// Mapping between user space coordinates and design space coordinates.
-    #[serde(default)]
-    pub map: Vec<AxisMapping>,
+    pub map: Option<Vec<AxisMapping>>,
 }
 
 /// Maps one input value (user space coord) to one output value (design space coord).
@@ -233,7 +232,10 @@ mod tests {
         assert_eq!(axis.minimum, Some(400.));
         assert_eq!(axis.maximum, Some(600.));
         assert_eq!(axis.default, 500.);
-        assert_eq!(&vec![AxisMapping { input: 400., output: 100. }], &ds.axes[0].map);
+        assert_eq!(
+            &vec![AxisMapping { input: 400., output: 100. }],
+            ds.axes[0].map.as_ref().unwrap()
+        );
         assert_eq!(1, ds.sources.len());
         let weight_100 = dim_name_xvalue("Weight", 100.);
         assert_eq!(vec![weight_100.clone()], ds.sources[0].location);
@@ -245,7 +247,7 @@ mod tests {
     fn read_wght_variable() {
         let ds = DesignSpaceDocument::load("testdata/wght.designspace").unwrap();
         assert_eq!(1, ds.axes.len());
-        assert!(ds.axes[0].map.is_empty());
+        assert!(ds.axes[0].map.is_none());
         assert_eq!(
             vec![
                 ("TestFamily-Regular.ufo".to_string(), vec![dim_name_xvalue("Weight", 400.)]),

--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -44,11 +44,11 @@ impl Glyph {
         );
         match options.quote_style {
             QuoteChar::Double => writer
-                .inner()
+                .get_mut()
                 .write(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
                 .map_err(GlifWriteError::Buffer)?,
             QuoteChar::Single => writer
-                .inner()
+                .get_mut()
                 .write(b"<?xml version='1.0' encoding='UTF-8'?>\n")
                 .map_err(GlifWriteError::Buffer)?,
         };
@@ -129,8 +129,8 @@ impl Glyph {
         }
 
         writer.write_event(Event::End(BytesEnd::new("glyph"))).map_err(GlifWriteError::Xml)?;
-        writer.inner().write_all("\n".as_bytes()).map_err(GlifWriteError::Buffer)?;
-        writer.inner().flush().map_err(GlifWriteError::Buffer)?;
+        writer.get_mut().write_all("\n".as_bytes()).map_err(GlifWriteError::Buffer)?;
+        writer.get_mut().flush().map_err(GlifWriteError::Buffer)?;
 
         Ok(writer.into_inner().into_inner())
     }
@@ -165,10 +165,10 @@ fn write_lib_section<T: Write>(
 
     writer.write_event(Event::Start(BytesStart::new("lib"))).map_err(GlifWriteError::Xml)?;
     for line in to_write.lines() {
-        writer.inner().write_all("\n".as_bytes()).map_err(GlifWriteError::Buffer)?;
-        options.write_indent(writer.inner()).map_err(GlifWriteError::Buffer)?;
-        options.write_indent(writer.inner()).map_err(GlifWriteError::Buffer)?;
-        writer.inner().write_all(line.as_bytes()).map_err(GlifWriteError::Buffer)?;
+        writer.get_mut().write_all("\n".as_bytes()).map_err(GlifWriteError::Buffer)?;
+        options.write_indent(writer.get_mut()).map_err(GlifWriteError::Buffer)?;
+        options.write_indent(writer.get_mut()).map_err(GlifWriteError::Buffer)?;
+        writer.get_mut().write_all(line.as_bytes()).map_err(GlifWriteError::Buffer)?;
     }
     writer.write_event(Event::End(BytesEnd::new("lib"))).map_err(GlifWriteError::Xml)?;
     Ok(())


### PR DESCRIPTION
This involves one breaking change, which is actually reverting a breaking change made in 0.9. From the relevant commit:

>In the previous version of quick-xml there was an issue that prevented
deserialization of Option<Vec<_>>. We worked around this by changing our
API, but that change was not an improvement, and the issue is fixed in
quick-xml 0.28. Since I intend to yank norad 0.9, we can revert that
change, providing a better upgrade path for our users.