### PR TITLE
Add nice to have methods

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{btree_map, BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -474,6 +474,11 @@ impl Layer {
     /// about it, if you like.
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Gets the given key's corresponding entry in the map for in-place manipulation.
+    pub fn entry(&mut self, glyph: Name) -> btree_map::Entry<Name, Glyph> {
+        self.glyphs.entry(glyph)
     }
 
     /// Returns a reference to the glyph with the given name, if it exists.

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -611,6 +611,14 @@ impl Layer {
         self.glyphs.values_mut()
     }
 
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` for which `f(&k, &mut v)` returns `false`.
+    /// The elements are visited in unsorted (and unspecified) order.
+    pub fn retain(&mut self, f: impl FnMut(&Name, &mut Glyph) -> bool) {
+        self.glyphs.retain(f);
+    }
+
     /// Returns the path to the .glif file of a given glyph `name`.
     ///
     /// The returned path is relative to the path of the current layer.

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,4 +1,4 @@
-use std::collections::{btree_map, BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -477,7 +477,8 @@ impl Layer {
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
-    pub fn entry(&mut self, glyph: Name) -> btree_map::Entry<Name, Glyph> {
+    #[cfg(not(feature = "druid"))]
+    pub fn entry(&mut self, glyph: Name) -> std::collections::btree_map::Entry<Name, Glyph> {
         self.glyphs.entry(glyph)
     }
 
@@ -620,6 +621,7 @@ impl Layer {
     ///
     /// In other words, remove all pairs `(k, v)` for which `f(&k, &mut v)` returns `false`.
     /// The elements are visited in unsorted (and unspecified) order.
+    #[cfg(not(feature = "druid"))]
     pub fn retain(&mut self, f: impl FnMut(&Name, &mut Glyph) -> bool) {
         self.glyphs.retain(f);
     }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -131,6 +131,11 @@ impl LayerSet {
         self.layers.iter()
     }
 
+    /// Returns a mutable iterator over all layers.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Layer> {
+        self.layers.iter_mut()
+    }
+
     /// Returns an iterator over the names of all layers.
     pub fn names(&self) -> impl Iterator<Item = &Name> {
         self.layers.iter().map(|l| &l.name)


### PR DESCRIPTION
Will close #298, merry Christmas @madig! 😛 

Since these were all just delegating to inner types that already have the functions, hopefully this shouldn't prove too controversial. I only spent 10 minutes on it lol.

I chose to expose `Layer::entry` instead of creating a `Layer::get_or_create_glyph` as I think it's a more versatile interface.

Documentation is copied from the standard library.

Supporting the `druid` feature makes this slightly less pleasant. I can either copy paste the `entry` method (plus documentation) to change the return type, or we can use the type alias I made (bikeshedding welcome): `MaybeArcGlyph`. I don't know of a way to `#[cfg]` change just the return type