### PR TITLE
Allow design space to contain no instances

### DIFF
--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -22,7 +22,7 @@ pub struct DesignSpaceDocument {
     #[serde(deserialize_with = "serde_impls::deserialize_sources")]
     pub sources: Vec<Source>,
     /// One or more instances.
-    #[serde(deserialize_with = "serde_impls::deserialize_instances")]
+    #[serde(default, deserialize_with = "serde_impls::deserialize_instances")]
     pub instances: Vec<Instance>,
 }
 
@@ -258,5 +258,11 @@ mod tests {
                 .map(|s| (s.filename, s.location))
                 .collect::<Vec<(String, Vec<Dimension>)>>()
         );
+    }
+
+    // <https://github.com/linebender/norad/issues/300>
+    #[test]
+    fn load_with_no_instances() {
+        DesignSpaceDocument::load("testdata/no_instances.designspace").unwrap();
     }
 }

--- a/testdata/no_instances.designspace
+++ b/testdata/no_instances.designspace
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="WghtVar-Regular.ufo" name="WghtVar Regular" familyname="WghtVar" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="WghtVar-Bold.ufo" name="WghtVar Bold" familyname="WghtVar" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>


### PR DESCRIPTION
I could make the 'instances' field optional, but I've opted to just use an empty Vec if the instances are missing, since this is a non-breaking change.

- fixes #300

cc @madig, does this seem reasonable to you?