### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ uuid = { version = "1.2", features = ["v4"] }
 serde = { version =  "1.0", features = ["rc", "derive"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
-quick-xml = { version = "0.29.0", features = ["serialize"] }
+quick-xml = { version = "0.30.0", features = ["serialize"] }
 rayon = { version = "1.3.0", optional = true }
 kurbo = { version = "0.9.0", optional = true }
 thiserror = "1.0"
-indexmap = {version = "2.0.0", features = ["serde"] }
+indexmap = { version = "2.0.0", features = ["serde"] }
 base64 = "0.21.2"
 
 [dependencies.druid]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "norad"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["Colin Rofls <colin@cmyr.net>", "Nikolaus Waxweiler <madigens@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
Also upgrades `quick-xml` to the latest as it's our only outdated dependency: https://deps.rs/repo/github/linebender/norad. No breakages or further changes required

Would like a new version released so I can make use of #309 :)