### PR TITLE
Clear buf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ pretty_assertions = "1.0"
 expect-test = "1.4.1"
 criterion = "0.5"
 
+# https://github.com/bheisler/criterion.rs/issues/193
+# Make it possible to save baseline, e.g. cargo bench -- --save-baseline master
+[lib]
+bench = false
+
 [[bench]]
 name = "glif_parse"
 harness = false

--- a/benches/glif_parse.rs
+++ b/benches/glif_parse.rs
@@ -24,7 +24,6 @@ where
 fn load_all(dir: &str) -> Vec<(PathBuf, Vec<u8>)> {
     std::fs::read_dir(dir)
         .unwrap()
-        .into_iter()
         .map(|e| e.unwrap())
         .filter_map(
             |e| if e.path().is_file() { Some((e.path(), load_bytes(e.path()))) } else { None },
@@ -66,7 +65,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let glyphs = load_all(MUTATOR_SANS_GLYPHS_DIR);
         b.iter(|| {
             for (_, glyph_bytes) in glyphs.iter().filter(|(p, _)| p.ends_with(".glif")) {
-                Glyph::parse_raw(black_box(&glyph_bytes)).unwrap();
+                Glyph::parse_raw(black_box(glyph_bytes)).unwrap();
             }
         })
     });

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -119,6 +119,7 @@ impl<'names> GlifParser<'names> {
                 Event::End(ref end) if end.name().as_ref() == b"glyph" => break,
                 _other => return Err(ErrorKind::MissingCloseTag.into()),
             }
+            buf.clear();
         }
 
         self.glyph.load_object_libs()?;
@@ -158,6 +159,7 @@ impl<'names> GlifParser<'names> {
                 Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
                 _other => return Err(ErrorKind::UnexpectedElement.into()),
             }
+            buf.clear();
         }
 
         let (mut contours, components) = outline_builder.finish()?;
@@ -235,6 +237,7 @@ impl<'names> GlifParser<'names> {
                 Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
                 _other => return Err(ErrorKind::UnexpectedElement.into()),
             }
+            buf.clear();
         }
         outline_builder.end_path()?;
 
@@ -302,6 +305,7 @@ impl<'names> GlifParser<'names> {
                 Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
                 _other => end = reader.buffer_position(),
             }
+            buf.clear();
         }
 
         let plist_slice = &raw_xml[start..end];
@@ -328,6 +332,7 @@ impl<'names> GlifParser<'names> {
                 Event::Eof => return Err(ErrorKind::UnexpectedEof.into()),
                 _other => (),
             }
+            buf.clear();
         }
         Ok(())
     }
@@ -576,5 +581,6 @@ fn start(
             }
             _other => return Err(ErrorKind::WrongFirstElement.into()),
         }
+        buf.clear();
     }
 }


### PR DESCRIPTION
https://docs.rs/quick-xml/latest/quick_xml/reader/struct.Reader.html suggests "if we don't keep a borrow elsewhere, we can clear the buffer to keep memory usage low." We build data structures with copies so as far as I can tell we can clear buf in all the read event into loops.

While we're here, add magic incantation to Cargo.toml make `cargo bench -- --save-benchmark` work so one can compare against a baseline taken on master. `$ cargo bench -- --baseline master` generally tells me things are more better than worse. The results of reruns are not stunningly consistent but it mostly tells me a couple of things are faster and occasionally that one is slower.

Feel free to close as not convincing enough or merge as you see fit :)

![image](https://github.com/linebender/norad/assets/6466432/80e01373-f352-4540-911b-25821c22576a)


