### PR TITLE
Rename `LayerSet` to `LayerContents` & clarify ordering

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -13,7 +13,7 @@ use crate::glyph::Glyph;
 use crate::groups::{validate_groups, Groups};
 use crate::guideline::Guideline;
 use crate::kerning::Kerning;
-use crate::layer::{Layer, LayerSet, LAYER_CONTENTS_FILE};
+use crate::layer::{Layer, LayerContents, LAYER_CONTENTS_FILE};
 use crate::name::Name;
 use crate::names::NameList;
 use crate::shared_types::{Plist, PUBLIC_OBJECT_LIBS_KEY};
@@ -55,7 +55,7 @@ pub struct Font {
     ///  [glyph directory][] on disk.
     ///
     ///  [glyph directory]: https://unifiedfontobject.org/versions/ufo3/glyphs/
-    pub layers: LayerSet,
+    pub layers: LayerContents,
     /// Arbitrary user-supplied data.
     ///
     /// This corresponds to the [`lib.plist`][l] file on disk. This file is
@@ -643,12 +643,12 @@ fn load_layer_set(
     meta: &MetaInfo,
     glyph_names: &NameList,
     filter: &LayerFilter,
-) -> Result<LayerSet, FontLoadError> {
+) -> Result<LayerContents, FontLoadError> {
     let layercontents_path = ufo_path.join(LAYER_CONTENTS_FILE);
     if meta.format_version == FormatVersion::V3 && !layercontents_path.exists() {
         return Err(FontLoadError::MissingLayerContentsFile);
     }
-    LayerSet::load(ufo_path, glyph_names, filter)
+    LayerContents::load(ufo_path, glyph_names, filter)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub use groups::Groups;
 pub use guideline::{Guideline, Line};
 pub use identifier::Identifier;
 pub use kerning::Kerning;
-pub use layer::{Layer, LayerSet};
+pub use layer::{Layer, LayerContents};
 pub use shared_types::{Color, Plist};
 pub use util::user_name_to_file_name;
 pub use write::{QuoteChar, WriteOptions};


### PR DESCRIPTION
Will close #326 

Documentation also now explicitly states the layers are ordered

---

If we were interested in maintaining backwards compatibility, we could do a re-export under the old name:

```rs
#[deprecated(
    note = "old naming convention, switch to LayerContents instead",
    since = "0.12.2",
)]
pub use LayerContents as LayerSet;
```