### PR TITLE
Wrap file writes with `close_already` (perf increase on Windows)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ kurbo = { version = "0.10.0", optional = true }
 thiserror = "1.0"
 indexmap = { version = "2.0.0", features = ["serde"] }
 base64 = "0.21.2"
+close_already = "0.3"
 
 [dev-dependencies]
 failure = "0.1.6"

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -3,7 +3,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 use serde::Serialize;
-use std::{fs, fs::File, io::BufReader, path::Path};
+use std::{fs::File, io::BufReader, path::Path};
 
 use plist::Dictionary;
 
@@ -262,7 +262,7 @@ impl DesignSpaceDocument {
         xml_writer.indent(' ', 2);
         self.serialize(xml_writer)?;
         buf.push('\n'); // trailing newline
-        fs::write(path, buf)?;
+        close_already::fs::write(path, buf)?;
         Ok(())
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -496,10 +496,10 @@ impl Font {
             // This is consistent with the line endings serialized in glif and plist files
             let feature_file_path = path.join(FEATURES_FILE);
             if self.features.as_bytes().contains(&b'\r') {
-                fs::write(&feature_file_path, self.features.replace("\r\n", "\n"))
+                close_already::fs::write(&feature_file_path, self.features.replace("\r\n", "\n"))
                     .map_err(FontWriteError::FeatureFile)?;
             } else {
-                fs::write(&feature_file_path, &self.features)
+                close_already::fs::write(&feature_file_path, &self.features)
                     .map_err(FontWriteError::FeatureFile)?;
             }
         }
@@ -529,7 +529,7 @@ impl Font {
                 fs::create_dir_all(destination_parent).map_err(|source| {
                     FontWriteError::CreateStoreDir { path: destination_parent.into(), source }
                 })?;
-                fs::write(&destination, &*data)
+                close_already::fs::write(&destination, &*data)
                     .map_err(|source| FontWriteError::Data { path: destination, source })?;
             }
         }
@@ -544,7 +544,7 @@ impl Font {
             for (image_path, contents) in self.images.iter() {
                 let data = contents.expect("internal error: should have been checked");
                 let destination = images_dir.join(image_path);
-                fs::write(&destination, &*data)
+                close_already::fs::write(&destination, &*data)
                     .map_err(|source| FontWriteError::Image { path: destination, source })?;
             }
         }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -99,7 +99,7 @@ impl Glyph {
         }
 
         let data = self.encode_xml_with_options(opts)?;
-        std::fs::write(path, data).map_err(GlifWriteError::Io)?;
+        close_already::fs::write(path, data).map_err(GlifWriteError::Io)?;
 
         Ok(())
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -5,6 +5,7 @@ use std::{borrow::Cow, fs::File, io::BufWriter, path::Path};
 #[cfg(target_family = "unix")]
 use std::os::unix::prelude::FileExt;
 
+use close_already::FastCloseable;
 #[cfg(target_family = "windows")]
 use std::os::windows::prelude::*;
 
@@ -152,7 +153,7 @@ pub(crate) fn write_xml_to_file(
     value: &impl serde::Serialize,
     options: &WriteOptions,
 ) -> Result<(), CustomSerializationError> {
-    let mut file = File::create(path).map_err(CustomSerializationError::CreateFile)?;
+    let mut file = File::create(path).map_err(CustomSerializationError::CreateFile)?.fast_close();
     let buf_writer = BufWriter::new(&mut file);
     plist::to_writer_xml_with_options(buf_writer, value, options.xml_options())
         .map_err(CustomSerializationError::SerializePlist)?;


### PR DESCRIPTION
Per the benchmark results from my machine [here](https://github.com/linebender/norad/issues/334#issuecomment-1808503148), we see a 5% decrease in write time with `rayon` enabled, and **50%** decrease in write time with default features

If we don't want the benchmark/Roboto in-tree, let me know and I can remove it. The Roboto is the latest from the repo, with most/all lib keys removed from glyphs

Let me know if there are any writes I've missed wrapping!

If you want to read more and/or audit the new dependency: [alpha-tango-kilo/close_already](https://github.com/alpha-tango-kilo/close_already)

Will close #334 