### PR TITLE
Release version 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "norad"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Colin Rofls <colin@cmyr.net>", "Nikolaus Waxweiler <madigens@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
New major version due to the removal of the `druid` feature, and this version will also ship the speed-ups from `close_already`

@cmyr when you have time if you could release this onto crates.io I'd appreciate it :)