### PR TITLE
Update quick-xml to 0.31.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ uuid = { version = "1.2", features = ["v4"] }
 serde = { version =  "1.0", features = ["rc", "derive"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
-quick-xml = { version = "0.30.0", features = ["serialize"] }
+quick-xml = { version = "0.31.0", features = ["serialize"] }
 rayon = { version = "1.3.0", optional = true }
 kurbo = { version = "0.10.0", optional = true }
 thiserror = "1.0"

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -118,7 +118,7 @@ pub enum RuleProcessing {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Rule {
     /// Name of the rule.
-    #[serde(rename = "@name")]
+    #[serde(rename = "@name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Condition sets. If any condition is true or the condition set is empty,
     /// the rule is applied.
@@ -175,7 +175,7 @@ pub struct Source {
     #[serde(rename = "@stylename", skip_serializing_if = "Option::is_none")]
     pub stylename: Option<String>,
     /// A unique name that can be used to identify this font if it needs to be referenced elsewhere.
-    #[serde(rename = "@name")]
+    #[serde(rename = "@name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// A path to the source file, relative to the root path of this document.
     ///
@@ -206,7 +206,7 @@ pub struct Instance {
     #[serde(rename = "@stylename", skip_serializing_if = "Option::is_none")]
     pub stylename: Option<String>,
     /// A unique name that can be used to identify this font if it needs to be referenced elsewhere.
-    #[serde(rename = "@name")]
+    #[serde(rename = "@name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// A path to the instance file, relative to the root path of this document. The path can be at the same level as the document or lower.
     #[serde(rename = "@filename", skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Something in quick-xml's internals changed in this version in a way that broke our admittedly hacky plist parsing.

Although the journey was long, the fix was easy: we need to explicitly handle the 'dict' key as a field when we are deserializing the lib.

This also includes a few more explicit 'skip_serializing_if' annotations, since once we were working again we were writing out empty strings in places where we hadn't been on the previous quick-xml.

One note on this impl that just occurs to me: it is possible now that deserialization will fail if the <lib> section of some object contains something other than a dict; we can discuss in review whether or not this is a problem.


- closes #330 
- ate six hours of my life