### PR TITLE
Add Designspace v5 fields

### DIFF
--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -25,6 +25,14 @@ pub struct DesignSpaceDocument {
     pub axis_mappings: Option<AxisMappings>,
     /// One or more rules.
     pub rules: Rules,
+    /// Zero or more variable fonts.
+    #[serde(
+        rename = "variable-fonts",
+        with = "serde_impls::variable_fonts",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub variable_fonts: Vec<VariableFont>,
     /// One or more sources.
     pub sources: Vec<Source>,
     /// One or more instances.
@@ -63,9 +71,42 @@ pub struct Axis {
     /// Mapping between user space coordinates and design space coordinates.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub map: Option<Vec<AxisMapping>>,
-    /// Localised UI strings for the axis name.
+    /// ...
     #[serde(rename = "labelname", default, skip_serializing_if = "Vec::is_empty")]
-    pub label_names: Vec<LocalizedString>,
+    pub label_names: Vec<LabelName>,
+    /// ...
+    #[serde(with = "serde_impls::labels", default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<Label>,
+}
+
+
+/// ...
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Label {
+    /// ...
+    #[serde(rename = "@name")]
+    pub name: String,
+    /// ...
+    #[serde(rename = "@elidable", default, skip_serializing_if = "is_false")]
+    pub elidable: bool,
+    /// ...
+    #[serde(rename = "@oldersibling", default, skip_serializing_if = "is_false")]
+    pub older_sibling: bool,
+    /// ...
+    #[serde(rename = "@uservalue")]
+    pub user_value: f32,
+    /// ...
+    #[serde(rename = "@userminimum", default)]
+    pub user_minimum: Option<f32>,
+    /// ...
+    #[serde(rename = "@usermaximum", default)]
+    pub user_maximum: Option<f32>,
+    /// ...
+    #[serde(rename = "@linkeduservalue", default)]
+    pub linked_user_value: Option<f32>,
+    /// ...
+    #[serde(rename = "labelname", default, skip_serializing_if = "Vec::is_empty")]
+    pub names: Vec<LabelName>,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -244,6 +285,53 @@ pub struct Condition {
     /// Upper bounds in design space coordinates.
     #[serde(rename = "@maximum", default, skip_serializing_if = "Option::is_none")]
     pub maximum: Option<f32>,
+}
+
+/// Describes a single variable font.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct VariableFont {
+    /// The name of the variable font.
+    #[serde(rename = "@name")]
+    pub name: String,
+    /// The optional file name of the variable font.
+    #[serde(rename = "@filename", default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// The axis subset the variable font represents.
+    #[serde(rename = "axis-subsets", with = "serde_impls::axis_subsets")]
+    pub axis_subsets: Vec<AxisSubset>,
+    /// Additional arbitrary user data
+    #[serde(default, with = "serde_plist", skip_serializing_if = "Dictionary::is_empty")]
+    pub lib: Dictionary,
+}
+
+/// Describes a single axis subset for a variable font.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AxisSubset {
+    /// Describes a range of an axis.
+    Range {
+        /// The name of the axis under consideration.
+        #[serde(rename = "@name")]
+        name: String,
+        /// Optionally, the lower end of the range, in user coordinates
+        #[serde(rename = "@userminimum", default, skip_serializing_if = "Option::is_none")]
+        user_minimum: Option<f64>,
+        /// Optionally, the upper end of the range, in user coordinates
+        #[serde(rename = "@usermaximum", default, skip_serializing_if = "Option::is_none")]
+        user_maximum: Option<f64>,
+        /// Optionally, the new default value of subset axis, in user coordinates.
+        #[serde(rename = "@userdefault", default, skip_serializing_if = "Option::is_none")]
+        user_default: Option<f64>,
+    },
+    /// Describes a single point of an axis.
+    Discrete {
+        /// The name of the axis under consideration.
+        #[serde(rename = "@name")]
+        name: String,
+        /// The single point of the axis.
+        #[serde(rename = "@uservalue")]
+        user_value: f64,
+    },
 }
 
 /// A [source].
@@ -501,6 +589,7 @@ mod serde_impls {
                 {
                     use serde::Deserialize as _;
                     #[derive(::serde::Deserialize)]
+                    #[serde(rename_all = "kebab-case")]
                     struct Helper {
                         $field_name: Vec<$inner>,
                     }
@@ -516,6 +605,7 @@ mod serde_impls {
                 {
                     use serde::Serialize as _;
                     #[derive(::serde::Serialize)]
+                    #[serde(rename_all = "kebab-case")]
                     struct Helper<'a> {
                         $field_name: &'a [$inner],
                     }
@@ -529,6 +619,9 @@ mod serde_impls {
     serde_from_field!(location, dimension, crate::designspace::Dimension);
     serde_from_field!(instances, instance, crate::designspace::Instance);
     serde_from_field!(sources, source, crate::designspace::Source);
+    serde_from_field!(variable_fonts, variable_font, crate::designspace::VariableFont);
+    serde_from_field!(axis_subsets, axis_subset, crate::designspace::AxisSubset);
+    serde_from_field!(labels, label, crate::designspace::Label);
 }
 
 #[cfg(test)]
@@ -885,5 +978,80 @@ mod tests {
     fn designspace_without_mappings_has_none() {
         let ds = DesignSpaceDocument::load("testdata/wght.designspace").unwrap();
         assert!(ds.axis_mappings.is_none());
+    }
+
+    #[test]
+    fn load_save_round_trip_mutatorsans2() {
+        // Given
+        let dir = TempDir::new().unwrap();
+        let ds_test_save_location = dir.path().join("MutatorSans2.designspace");
+
+        // When
+        let ds_initial = DesignSpaceDocument::load("testdata/MutatorSans2.designspace").unwrap();
+        ds_initial.save(&ds_test_save_location).expect("failed to save designspace");
+        let ds_after = DesignSpaceDocument::load(ds_test_save_location)
+            .expect("failed to load saved designspace");
+
+        let mut vf_lib = Dictionary::new();
+        let mut vf_fontinfo = Dictionary::new();
+        vf_fontinfo.insert("familyName".into(), "My Font Narrow VF".into());
+        vf_fontinfo.insert("styleName".into(), "Regular".into());
+        vf_fontinfo.insert("postscriptFontName".into(), "MyFontNarrVF-Regular".into());
+        vf_fontinfo
+            .insert("trademark".into(), "My Font Narrow VF is a registered trademark...".into());
+        vf_lib.insert("public.fontInfo".into(), vf_fontinfo.into());
+
+        // Then
+        assert_eq!(
+            &ds_after.axes,
+            &[
+                Axis {
+                    name: "width".into(),
+                    tag: "wdth".into(),
+                    default: 0.0,
+                    hidden: false,
+                    minimum: Some(0.0),
+                    maximum: Some(1000.0),
+                    values: None,
+                    map: None,
+                    label_names: vec![],
+                    labels: vec![]
+                },
+                Axis {
+                    name: "weight".into(),
+                    tag: "wght".into(),
+                    default: 0.0,
+                    hidden: false,
+                    minimum: Some(0.0),
+                    maximum: Some(1000.0),
+                    values: None,
+                    map: None,
+                    label_names: vec![
+                        LabelName { lang: "fa-IR".into(), name: "قطر".into() },
+                        LabelName { lang: "en".into(), name: "Wéíght".into() },
+                    ],
+                    labels: vec![]
+                }
+            ]
+        );
+
+        assert_eq!(
+            &ds_after.variable_fonts,
+            &[VariableFont {
+                name: "MyFontNarrVF".into(),
+                filename: None,
+                axis_subsets: vec![
+                    AxisSubset::Range {
+                        name: "Weight".into(),
+                        user_minimum: None,
+                        user_maximum: None,
+                        user_default: None
+                    },
+                    AxisSubset::Discrete { name: "Width".into(), user_value: 75.0 },
+                ],
+                lib: vf_lib
+            }]
+        );
+        assert_eq!(ds_initial, ds_after);
     }
 }

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -424,6 +424,8 @@ pub struct Instance {
     /// Arbitrary data about this instance
     #[serde(default, with = "serde_plist", skip_serializing_if = "Dictionary::is_empty")]
     pub lib: Dictionary,
+    #[serde(rename = "@location", skip_serializing_if = "Option::is_none")]
+    pub named_location: Option<String>,
 }
 
 /// A design space dimension.

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -23,6 +23,8 @@ pub struct DesignSpaceDocument {
     pub axes: Vec<Axis>,
     /// Optional avar2-style axis mappings.
     pub axis_mappings: Option<AxisMappings>,
+    /// Optional freestanding location labels.
+    pub location_labels: Vec<LocationLabel>,
     /// One or more rules.
     pub rules: Rules,
     /// Zero or more variable fonts.
@@ -71,18 +73,27 @@ pub struct Axis {
     /// Mapping between user space coordinates and design space coordinates.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub map: Option<Vec<AxisMapping>>,
-    /// ...
+    /// Localised UI strings for the axis name.
     #[serde(rename = "labelname", default, skip_serializing_if = "Vec::is_empty")]
-    pub label_names: Vec<LabelName>,
-    /// ...
-    #[serde(with = "serde_impls::labels", default, skip_serializing_if = "Vec::is_empty")]
-    pub labels: Vec<Label>,
+    pub label_names: Vec<LocalizedString>,
+    /// UI strings for axis stops.
+    // TODO: Get rid of AxisLabels and hoist content into this struct.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<AxisLabels>,
 }
-
 
 /// ...
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
-pub struct Label {
+pub struct AxisLabels {
+    #[serde(rename = "ordering", default, skip_serializing_if = "Option::is_none")]
+    pub axis_ordering: Option<u32>,
+    #[serde(with = "serde_impls::axis_label", default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<AxisLabel>,
+}
+
+/// ...
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct AxisLabel {
     /// ...
     #[serde(rename = "@name")]
     pub name: String,
@@ -106,9 +117,22 @@ pub struct Label {
     pub linked_user_value: Option<f32>,
     /// ...
     #[serde(rename = "labelname", default, skip_serializing_if = "Vec::is_empty")]
-    pub names: Vec<LabelName>,
+    pub label_names: Vec<LocalizedString>,
 }
 
+/// ...
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct LocationLabel {
+    /// ...
+    #[serde(rename = "@name")]
+    pub name: String,
+    /// ...
+    #[serde(rename = "labelname", default, skip_serializing_if = "Vec::is_empty")]
+    pub label_names: Vec<LocalizedString>,
+    /// ...
+    #[serde(with = "serde_impls::location")]
+    pub location: Vec<Dimension>,
+}
 fn is_false(value: &bool) -> bool {
     !(*value)
 }
@@ -362,6 +386,8 @@ pub struct Source {
     /// Location in designspace coordinates.
     #[serde(with = "serde_impls::location")]
     pub location: Vec<Dimension>,
+    #[serde(rename = "familyname", skip_serializing_if = "Vec::is_empty")]
+    pub localised_familynames: Vec<LocalizedString>,
 }
 
 /// An [instance].
@@ -476,6 +502,8 @@ struct RawDesignSpaceDocument {
     format: f32,
     #[serde(default, skip_serializing_if = "RawAxes::is_empty")]
     axes: RawAxes,
+    #[serde(default, with = "serde_impls::location_labels", skip_serializing_if = "Vec::is_empty")]
+    location_labels: Vec<LocationLabel>,
     #[serde(default, skip_serializing_if = "Rules::is_empty")]
     rules: Rules,
     #[serde(default, with = "serde_impls::sources", skip_serializing_if = "Vec::is_empty")]
@@ -489,6 +517,8 @@ struct RawDesignSpaceDocument {
 /// Internal container for axes and their optional mappings.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 struct RawAxes {
+    #[serde(default, rename = "elidedfallbackname", skip_serializing_if = "Option::is_none")]
+    elided_fallback_name: Option<String>,
     #[serde(default, rename = "axis")]
     axis: Vec<Axis>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -621,7 +651,9 @@ mod serde_impls {
     serde_from_field!(sources, source, crate::designspace::Source);
     serde_from_field!(variable_fonts, variable_font, crate::designspace::VariableFont);
     serde_from_field!(axis_subsets, axis_subset, crate::designspace::AxisSubset);
-    serde_from_field!(labels, label, crate::designspace::Label);
+    serde_from_field!(labels, label, crate::designspace::AxisLabels);
+    serde_from_field!(axis_label, label, crate::designspace::AxisLabel);
+    serde_from_field!(location_labels, label, crate::designspace::LocationLabel);
 }
 
 #[cfg(test)]

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -490,6 +490,8 @@ struct FontInfoV1 {
     year: Option<Integer>,           // Does not appear in spec but ufoLib.
 }
 
+// TODO: add from_bytes method for loading fontinfo from designspace libs
+
 impl FontInfo {
     pub(crate) fn from_bytes(
         data: &[u8],

--- a/testdata/v5.designspace
+++ b/testdata/v5.designspace
@@ -1,0 +1,366 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes elidedfallbackname="Regular">
+    <axis tag="wght" name="Weight" minimum="200" maximum="1000" default="200">
+      <labelname xml:lang="en">Wéíght</labelname>
+      <labelname xml:lang="fa-IR">قطر</labelname>
+      <map input="200" output="0"/>
+      <map input="300" output="100"/>
+      <map input="400" output="368"/>
+      <map input="600" output="600"/>
+      <map input="700" output="824"/>
+      <map input="900" output="1000"/>
+      <!-- All axes provide STAT information with the "labels" element. -->
+      <labels>
+        <label uservalue="200" userminimum="200" usermaximum="250" name="Extra Light">
+          <labelname xml:lang="de">Extraleicht</labelname>
+          <labelname xml:lang="fr">Extra léger</labelname>
+        </label>
+        <label uservalue="300" userminimum="250" usermaximum="350" name="Light"/>
+        <label uservalue="400" userminimum="350" usermaximum="450" name="Regular" elidable="true"/>
+        <label uservalue="600" userminimum="450" usermaximum="650" name="Semi Bold"/>
+        <label uservalue="700" userminimum="650" usermaximum="850" name="Bold"/>
+        <label uservalue="900" userminimum="850" usermaximum="900" name="Black"/>
+        <!--
+          Add "recursive" linked user values, see:
+          https://github.com/fonttools/fonttools/issues/2852
+          https://github.com/fonttools/fonttools/discussions/2790
+        -->
+        <label uservalue="400" name="Regular" elidable="true" linkeduservalue="700"/>
+        <label uservalue="700" name="Bold" linkeduservalue="400"/>
+      </labels>
+
+    </axis>
+
+    <axis tag="wdth" name="Width" minimum="50" maximum="150" default="100" hidden="1">
+      <labelname xml:lang="fr">Chasse</labelname>
+      <map input="50" output="10"/>
+      <map input="100" output="20"/>
+      <map input="125" output="66"/>
+      <map input="150" output="990"/>
+      <labels ordering="1">
+        <label uservalue="50" name="Condensed"/>
+        <label uservalue="100" name="Normal" elidable="true" oldersibling="true"/>
+        <label uservalue="125" name="Wide"/>
+        <!-- Allow specifying only one end of the range, the other is assumed to
+          be infinity as does otlLib buildStatTable -->
+        <label uservalue="150" userminimum="150" name="Extra Wide"/>
+      </labels>
+    </axis>
+
+    <!--
+      Discrete axes provide a list of discrete values.
+      No interpolation is allowed between these.
+    -->
+    <axis tag="ital" name="Italic" values="0 1" default="0">
+      <labels>
+        <!-- Discrete axes also provide STAT information. -->
+        <label uservalue="0" name="Roman" elidable="true" linkeduservalue="1"/>
+        <label uservalue="1" name="Italic"/>
+      </labels>
+    </axis>
+
+    <!-- avar2 stuff. -->
+    <mappings>
+      <mapping description="hello">
+        <input>
+          <dimension name="Weight" xvalue="900"/>
+          <dimension name="Width" xvalue="150"/>
+        </input>
+        <output>
+          <dimension name="Weight" xvalue="870"/>
+        </output>
+      </mapping>
+    </mappings>
+  </axes>
+
+  <!-- Freestanding labels are analogues of STAT format 4 entries.
+        They give names to freestyle locations. -->
+  <labels>
+    <label name="Some Style">
+      <labelname xml:lang="fr">Un Style</labelname>
+      <location>
+        <dimension name="Weight" uservalue="300"/>
+        <dimension name="Width" uservalue="50"/>
+        <dimension name="Italic" uservalue="0"/>
+      </location>
+    </label>
+    <label name="Other">
+      <location>
+        <dimension name="Weight" uservalue="700"/>
+        <dimension name="Width" uservalue="100"/>
+        <dimension name="Italic" uservalue="1"/>
+      </location>
+    </label>
+  </labels>
+
+  <rules processing="last">
+    <rule name="named.rule.1">
+      <conditionset>
+        <condition name="axisName_a" minimum="0" maximum="1"/>
+        <condition name="axisName_b" minimum="2" maximum="3"/>
+      </conditionset>
+      <sub name="a" with="a.alt"/>
+    </rule>
+  </rules>
+
+  <sources>
+    <source filename="masterTest1.ufo" name="master.ufo1" familyname="MasterFamilyName" stylename="MasterStyleNameOne">
+      <familyname xml:lang="fr">Montserrat</familyname>
+      <familyname xml:lang="ja">モンセラート</familyname>
+      <lib copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <glyph name="A" mute="1"/>
+      <glyph name="Z" mute="1"/>
+      <location>
+        <dimension name="Weight" xvalue="0"/>
+        <dimension name="Width" xvalue="20"/>
+        <dimension name="Italic" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="masterTest2.ufo" name="master.ufo2" familyname="MasterFamilyName" stylename="MasterStyleNameTwo">
+      <kerning mute="1"/>
+      <location>
+        <dimension name="Weight" xvalue="1000"/>
+        <dimension name="Width" xvalue="20"/>
+        <dimension name="Italic" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="masterTest2.ufo" name="master.ufo2" familyname="MasterFamilyName" stylename="Supports" layer="supports">
+      <location>
+        <dimension name="Weight" xvalue="1000"/>
+        <dimension name="Width" xvalue="20"/>
+        <dimension name="Italic" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="masterTest2.ufo" name="master.ufo3" familyname="MasterFamilyName" stylename="FauxItalic">
+      <location>
+        <dimension name="Weight" xvalue="0"/>
+        <dimension name="Width" xvalue="100"/>
+        <dimension name="Italic" xvalue="1"/>
+      </location>
+    </source>
+  </sources>
+
+  <variable-fonts>
+    <!--
+      If this element is present, all output targets must be listed within it.
+      If it is not present, the full Designspace is the output, like in version 4.x.
+
+      Continuous axes can be included either:
+        * in full,
+        * or only on a reduced interval (different minimum-maximum),
+        * or only at 1 discrete location
+      Dicrete axes cannot be included in full, and we must specify a value
+      (or the compiler should assume the default value).
+    -->
+    <variable-font name="Test_WghtWdth" filename="Test_WghtWdth_different_from_name.ttf">
+      <!-- This one is the Roman (default location along ital),
+           with full range for the Weight axis. -->
+      <axis-subsets>
+        <axis-subset name="Weight"/>
+        <axis-subset name="Width"/>
+      </axis-subsets>
+      <lib>
+        <dict>
+          <key>com.vtt.source</key>
+          <string>sources/vtt/Test_WghtWdth.vtt</string>
+          <key>public.fontInfo</key>
+          <dict>
+            <key>familyName</key>
+            <string>My Font Narrow VF</string>
+            <key>styleName</key>
+            <string>Regular</string>
+            <key>postscriptFontName</key>
+            <string>MyFontNarrVF-Regular</string>
+            <key>trademark</key>
+            <string>My Font Narrow VF is a registered trademark...</string>
+          </dict>
+        </dict>
+      </lib>
+    </variable-font>
+    <variable-font name="Test_Wght">
+      <!-- This one is the Roman (default location along ital),
+           with full range for the Weight axis. -->
+      <axis-subsets>
+        <axis-subset name="Weight"/>
+      </axis-subsets>
+      <lib>
+        <dict>
+          <key>com.vtt.source</key>
+          <string>sources/vtt/Test_Wght.vtt</string>
+        </dict>
+      </lib>
+    </variable-font>
+    <variable-font name="TestCd_Wght">
+      <!-- This one is the Roman (default location along ital),
+           with full range for the Weight axis. -->
+      <axis-subsets>
+        <axis-subset name="Weight"/>
+        <axis-subset name="Width" uservalue="0"/>
+      </axis-subsets>
+    </variable-font>
+    <variable-font name="TestWd_Wght">
+      <!-- This one is the Roman (default location along ital),
+           with full range for the Weight axis. -->
+      <axis-subsets>
+        <axis-subset name="Weight"/>
+        <axis-subset name="Width" uservalue="1000"/>
+      </axis-subsets>
+    </variable-font>
+    <variable-font name="TestItalic_Wght">
+      <!-- This one is the Italic, with full range for the Weight axis. -->
+      <axis-subsets>
+        <axis-subset name="Weight"/>
+        <axis-subset name="Italic" uservalue="1"/>
+      </axis-subsets>
+    </variable-font>
+    <variable-font name="TestRB_Wght">
+      <!-- As an example, this would be the Roman with a reduced range. -->
+      <axis-subsets>
+        <axis-subset name="Weight" userminimum="400" usermaximum="700" userdefault="400"/>
+        <axis-subset name="Italic" uservalue="0"/>
+      </axis-subsets>
+    </variable-font>
+  </variable-fonts>
+
+  <instances>
+    <instance name="instance.ufo1" familyname="InstanceFamilyName" stylename="InstanceStyleName" filename="instances/instanceTest1.ufo" postscriptfontname="InstancePostscriptName" stylemapfamilyname="InstanceStyleMapFamilyName" stylemapstylename="InstanceStyleMapStyleName">
+      <stylename xml:lang="fr">Demigras</stylename>
+      <stylename xml:lang="ja">半ば</stylename>
+      <familyname xml:lang="fr">Montserrat</familyname>
+      <familyname xml:lang="ja">モンセラート</familyname>
+      <stylemapstylename xml:lang="de">Standard</stylemapstylename>
+      <stylemapfamilyname xml:lang="de">Montserrat Halbfett</stylemapfamilyname>
+      <stylemapfamilyname xml:lang="ja">モンセラート SemiBold</stylemapfamilyname>
+      <location>
+        <dimension name="Weight" xvalue="500"/>
+        <dimension name="Width" xvalue="20"/>
+      </location>
+
+      <!-- The following elements are deprecated in v5.0. They can still be
+           read, but they won't be written out again (they don't roundtrip). -->
+      <!-- ROUNDTRIP_TEST_REMOVE_ME_BEGIN -->
+      <glyphs>
+        <glyph mute="1" unicode="0x123 0x124 0x125" name="arrow"/>
+      </glyphs>
+      <kerning/>
+      <info/>
+      <!-- ROUNDTRIP_TEST_REMOVE_ME_END -->
+
+      <lib>
+        <dict>
+          <key>com.coolDesignspaceApp.binaryData</key>
+          <data>
+          PGJpbmFyeSBndW5rPg==
+          </data>
+          <key>com.coolDesignspaceApp.specimenText</key>
+          <string>Hamburgerwhatever</string>
+        </dict>
+      </lib>
+    </instance>
+    <instance name="instance.ufo2" familyname="InstanceFamilyName" stylename="InstanceStyleName" filename="instances/instanceTest2.ufo" postscriptfontname="InstancePostscriptName" stylemapfamilyname="InstanceStyleMapFamilyName" stylemapstylename="InstanceStyleMapStyleName">
+      <location>
+        <dimension name="Weight" xvalue="500"/>
+        <dimension name="Width" xvalue="400" yvalue="300"/>
+      </location>
+      <!-- ROUNDTRIP_TEST_REMOVE_ME_BEGIN -->
+      <glyphs>
+        <glyph unicode="0x65 0xc9 0x12d" name="arrow">
+          <location>
+            <dimension name="Weight" xvalue="120"/>
+            <dimension name="Width" xvalue="100"/>
+          </location>
+          <note>A note about this glyph</note>
+          <masters>
+            <master glyphname="BB" source="master.ufo1">
+              <location>
+                <dimension name="Weight" xvalue="20"/>
+                <dimension name="Width" xvalue="20"/>
+              </location>
+            </master>
+            <master glyphname="CC" source="master.ufo2">
+              <location>
+                <dimension name="Weight" xvalue="900"/>
+                <dimension name="Width" xvalue="900"/>
+              </location>
+            </master>
+          </masters>
+        </glyph>
+        <glyph name="arrow2"/>
+      </glyphs>
+      <kerning/>
+      <info/>
+      <!-- ROUNDTRIP_TEST_REMOVE_ME_END -->
+    </instance>
+
+    <!--
+      These instances will derive all their data from the data above.
+
+      Instances can specify their location either:
+        - using the name of a location label
+        - with design coordinates (xvalue="")
+        - with user coordinates (uservalue="")
+        - with a mix of both coordinate systems
+    -->
+    <instance location="Some Style"/>
+    <instance>
+      <location>
+        <dimension name="Weight" xvalue="600"/>
+        <dimension name="Width" xvalue="401" yvalue="420"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="Weight" xvalue="10"/>
+        <dimension name="Width" uservalue="100"/>
+        <dimension name="Italic" xvalue="0"/>
+      </location>
+    </instance>
+    <instance>
+      <location>
+        <dimension name="Weight" uservalue="300"/>
+        <dimension name="Width" uservalue="130"/>
+        <dimension name="Italic" uservalue="1"/>
+      </location>
+      <lib>
+        <dict>
+          <key>public.fontInfo</key>
+          <dict>
+              <key>openTypeNameWWSFamilyName</key>
+              <string>My Font Text</string>
+              <key>openTypeNameWWSSubfamilyName</key>
+              <string>Light</string>
+              <key>openTypeOS2WeightClass</key>
+              <integer>300</integer>
+              <key>trademark</key>
+              <string>My Font Text Light is a registered trademark...</string>
+              <key>openTypeNameRecords</key>
+              <array>
+                  <dict>
+                      <key>encodingID</key>
+                      <integer>1</integer>
+                      <key>languageID</key>
+                      <integer>1031</integer>
+                      <key>nameID</key>
+                      <integer>7</integer>
+                      <key>platformID</key>
+                      <integer>3</integer>
+                      <key>string</key>
+                      <string>Meine Schrift Text Leicht ist eine registrierte Marke...</string>
+                  </dict>
+              </array>
+          </dict>
+        </dict>
+      </lib>
+    </instance>
+  </instances>
+
+  <lib>
+    <dict>
+      <key>com.coolDesignspaceApp.previewSize</key>
+      <integer>30</integer>
+    </dict>
+  </lib>
+</designspace>

--- a/testdata/v5.designspace
+++ b/testdata/v5.designspace
@@ -29,7 +29,6 @@
         <label uservalue="400" name="Regular" elidable="true" linkeduservalue="700"/>
         <label uservalue="700" name="Bold" linkeduservalue="400"/>
       </labels>
-
     </axis>
 
     <axis tag="wdth" name="Width" minimum="50" maximum="150" default="100" hidden="1">


### PR DESCRIPTION
Todo:
- [ ] Add all the stuff in https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html
    - Listed at https://github.com/linebender/norad/issues/416 
- [ ] Figure out how to deal with hyphens in element/field names
- [ ] Figure out how to deal with the axis-subset enum