### PR TITLE
Strip BOM from glif xml if present

### DIFF
--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -23,6 +23,9 @@ type Version = (u32, u32);
 const VERSION_1: Version = (1, 0);
 const VERSION_2: Version = (2, 0);
 
+// https://en.wikipedia.org/wiki/Byte_order_mark
+const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
+
 pub(crate) struct GlifParser<'names> {
     glyph: Glyph,
     version: Version,
@@ -36,6 +39,8 @@ impl<'names> GlifParser<'names> {
         xml: &[u8],
         names: Option<&'names NameList>,
     ) -> Result<Glyph, GlifLoadError> {
+        // optional but allowed for utf-8.
+        let xml = xml.strip_prefix(UTF8_BOM).unwrap_or(xml);
         let mut reader = Reader::from_reader(xml);
         let mut buf = Vec::new();
         reader.trim_text(true);

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -888,3 +888,10 @@ fn deduplicate_unicodes2() {
 "#;
     assert_eq!(data2, data2_expected);
 }
+
+#[test]
+fn bom_glif() {
+    let bytes = include_bytes!("../../testdata/bom_glif.glif");
+    let glyph = parse_glyph(bytes).expect("initial load failed");
+    assert_eq!(glyph.lib.get("hi").unwrap().as_string(), Some("hello"));
+}

--- a/testdata/bom_glif.glif
+++ b/testdata/bom_glif.glif
@@ -1,0 +1,25 @@
+﻿<!-- this includes a byte order mark (https://en.wikipedia.org/wiki/Byte_order_mark)-->
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name=".notdef" format="2">
+  <advance width="600" height="1000"/>
+  <outline>
+    <contour>
+      <point x="145" y="51" type="line"/>
+      <point x="145" y="663" type="line"/>
+      <point x="454" y="663" type="line"/>
+      <point x="454" y="51" type="line"/>
+    </contour>
+    <contour>
+      <point x="94" y="0" type="line"/>
+      <point x="505" y="0" type="line"/>
+      <point x="505" y="714" type="line"/>
+      <point x="94" y="714" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>hi</key>
+      <string>hello</string>
+    </dict>
+  </lib>
+</glyph>


### PR DESCRIPTION
TIL that utf-8 even _has_ a byte order mark 🚑 