### PR TITLE
Drop uuid dependency to simplify wasm use

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,3 +82,19 @@ jobs:
 
       - name: check typos
         uses: crate-ci/typos@v1.25.0
+
+  # We use `cargo build` here because `cargo check` doesn't pick up all
+  # warnings / errors. Notably, it misses `arithmetic_overflow`.
+  check-wasm:
+    name: cargo check wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+
+      - name: build fontdrasil for wasm32-unknown-unknown
+        run: cargo build --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "norad"
-version = "0.14.2"
+version = "0.15.2"
 authors = ["Colin Rofls <colin@cmyr.net>", "Nikolaus Waxweiler <madigens@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -21,11 +21,6 @@ features = ["kurbo"]
 default = []
 kurbo = ["dep:kurbo"]
 rayon = ["dep:rayon"]
-
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-uuid = { version = "1.2", features = ["v4"] }
-[target.'cfg(target_family = "wasm")'.dependencies]
-uuid = { version = "1.2", features = ["v4", "js"] }
 
 [dependencies]
 plist = { version =  "1.4.1", features = ["serde"] }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -486,11 +486,8 @@ impl Anchor {
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    /// lib if present.
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
         self.lib.replace(lib)
     }
 
@@ -539,11 +536,8 @@ impl Contour {
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    /// lib if present.
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
         self.lib.replace(lib)
     }
 
@@ -597,11 +591,8 @@ impl ContourPoint {
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    /// lib if present.
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
         self.lib.replace(lib)
     }
 
@@ -667,11 +658,8 @@ impl Component {
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    /// lib if present.
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
         self.lib.replace(lib)
     }
 

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -70,11 +70,8 @@ impl Guideline {
     }
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
-    /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    /// lib if present.
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
-        if self.identifier.is_none() {
-            self.identifier.replace(Identifier::from_uuidv4());
-        }
         self.lib.replace(lib)
     }
 

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -37,11 +37,6 @@ impl Identifier {
         Self(string.into())
     }
 
-    /// Create a new [`Identifier`] from a UUID v4 identifier.
-    pub fn from_uuidv4() -> Self {
-        Self::new(uuid::Uuid::new_v4().to_string().as_ref()).unwrap()
-    }
-
     /// Return the raw identifier, as a `&str`.
     pub fn as_str(&self) -> &str {
         self.as_ref()

--- a/src/write.rs
+++ b/src/write.rs
@@ -163,7 +163,10 @@ pub(crate) fn write_xml_to_file(
 }
 
 /// Write XML declarations with custom quote formatting options.
-fn write_quote_style(file: &File, options: &WriteOptions) -> Result<(), std::io::Error> {
+fn write_quote_style(
+    #[allow(unused)] file: &File,
+    options: &WriteOptions,
+) -> Result<(), std::io::Error> {
     // Optionally modify the XML declaration quote style
     match options.quote_style {
         QuoteChar::Single => {


### PR DESCRIPTION
`uuid` pulls in getrandom and thus bumps fontc directly into https://docs.rs/getrandom/#webassembly-support.

https://github.com/linebender/norad/commit/d50b59ccfacd3284e8e81782bbfbd37f886fb64c approaches this by pulling in more features, this PR proposes to simply drop the uuid dependency. This is consistent with https://unifiedfontobject.org/versions/ufo3/conventions/#identifiers: there is no general identifier algorithm, only the consumer of norad knows what they want.

If we really really want auto-uuid identifiers I suggest we make that an opt-in feature.

If I point to the updated norad locally `cargo build -p ufo2fontir --target wasm32-unknown-unknown` now passes, which in turn means the `fontc` build does too, as requested in https://github.com/googlefonts/fontc/issues/1215.

Add the usual wasm check to rust.yml.

Bump the patch version of norad to reflect the break in compatibility.