### PR TITLE
Update quick-xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ plist = { version =  "1.4.1", features = ["serde"] }
 serde = { version =  "1.0", features = ["rc", "derive"] }
 serde_derive = "1.0"
 serde_repr = "0.1"
-quick-xml = { version = "0.36.0", features = ["serialize"] }
+quick-xml = { version = "0.37.0", features = ["serialize"] }
 rayon = { version = "1.3.0", optional = true }
 kurbo = { version = "0.11.0", optional = true }
 thiserror = "2.0"

--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -333,7 +333,7 @@ mod serde_impls {
                 where
                     D: ::serde::Deserializer<'de>,
                 {
-                    use ::serde::Deserialize as _;
+                    use serde::Deserialize as _;
                     #[derive(::serde::Deserialize)]
                     struct Helper {
                         $field_name: Vec<$inner>,
@@ -348,7 +348,7 @@ mod serde_impls {
                 where
                     S: ::serde::Serializer,
                 {
-                    use ::serde::Serialize as _;
+                    use serde::Serialize as _;
                     #[derive(::serde::Serialize)]
                     struct Helper<'a> {
                         $field_name: &'a [$inner],

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use plist::Error as PlistError;
 use quick_xml::events::attributes::AttrError;
-use quick_xml::{DeError, Error as XmlError};
+use quick_xml::{DeError, Error as XmlError, SeError};
 use thiserror::Error;
 
 pub use crate::shared_types::ColorError;
@@ -27,6 +27,7 @@ pub enum DesignSpaceLoadError {
 
 /// An error that occurs while attempting to write a designspace file to disk.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DesignSpaceSaveError {
     /// An [`std::io::Error`].
     #[error("failed to open/write designspace file: {0}")]
@@ -34,11 +35,12 @@ pub enum DesignSpaceSaveError {
 
     /// A serialization error.
     #[error("failed to serialize designspace: {0}")]
-    SeError(#[from] DeError),
+    SeError(#[from] SeError),
 }
 
 /// An error representing a failure to (re)name something.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum NamingError {
     /// An error returned when an item is duplicated.
     #[error("item '{0}' already exists")]


### PR DESCRIPTION
This changed some error types in their API so that required some changes on our end.

While I was in here I marked a few additional error types as `#[non_exhaustive]`, so we can add variants in the future without it being a breaking change.