### PR TITLE
Make uuid an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,16 @@ exclude = [
 features = ["kurbo"]
 
 [features]
-default = []
+default = ["object-libs"]
+# allow us to add libs to objects, which requires potentially creating identifiers
+object-libs = ["uuid"]
 kurbo = ["dep:kurbo"]
 rayon = ["dep:rayon"]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-uuid = { version = "1.2", features = ["v4"] }
+uuid = { version = "1.2", features = ["v4"], optional = true }
 [target.'cfg(target_family = "wasm")'.dependencies]
-uuid = { version = "1.2", features = ["v4", "js"] }
+uuid = { version = "1.2", features = ["v4", "js"], optional = true }
 
 [dependencies]
 plist = { version =  "1.4.1", features = ["serde"] }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1024,7 +1024,7 @@ impl FontInfo {
                                 id.as_str().to_string(),
                             )
                         })?;
-                        guideline.replace_lib(lib);
+                        guideline.lib = Some(lib);
                     }
                 }
             }
@@ -1740,21 +1740,14 @@ mod tests {
         assert_eq!(
             font_info.guidelines,
             Some(vec![
-                Guideline::new(
-                    Line::Angle { x: 82.0, y: 720.0, degrees: 90.0 },
-                    None,
-                    None,
-                    None,
-                    None
-                ),
-                Guideline::new(Line::Vertical(372.0), None, None, None, None),
-                Guideline::new(Line::Horizontal(123.0), None, None, None, None),
+                Guideline::new(Line::Angle { x: 82.0, y: 720.0, degrees: 90.0 }, None, None, None,),
+                Guideline::new(Line::Vertical(372.0), None, None, None,),
+                Guideline::new(Line::Horizontal(123.0), None, None, None,),
                 Guideline::new(
                     Line::Angle { x: 1.0, y: 2.0, degrees: 0.0 },
                     Some(Name::new_raw(" [locked]")),
                     Some(Color::new(1.0, 1.0, 1.0, 1.0).unwrap()),
                     Some(Identifier::new_raw("abc")),
-                    None
                 ),
             ])
         );
@@ -1906,38 +1899,14 @@ mod tests {
         assert!(fi.validate().is_ok());
 
         fi.guidelines.replace(vec![
-            Guideline::new(
-                Line::Horizontal(10.0),
-                None,
-                None,
-                Some(Identifier::new_raw("test1")),
-                None,
-            ),
-            Guideline::new(
-                Line::Vertical(20.0),
-                None,
-                None,
-                Some(Identifier::new_raw("test2")),
-                None,
-            ),
+            Guideline::new(Line::Horizontal(10.0), None, None, Some(Identifier::new_raw("test1"))),
+            Guideline::new(Line::Vertical(20.0), None, None, Some(Identifier::new_raw("test2"))),
         ]);
         assert!(fi.validate().is_ok());
 
         fi.guidelines.replace(vec![
-            Guideline::new(
-                Line::Horizontal(10.0),
-                None,
-                None,
-                Some(Identifier::new_raw("test1")),
-                None,
-            ),
-            Guideline::new(
-                Line::Vertical(20.0),
-                None,
-                None,
-                Some(Identifier::new_raw("test1")),
-                None,
-            ),
+            Guideline::new(Line::Horizontal(10.0), None, None, Some(Identifier::new_raw("test1"))),
+            Guideline::new(Line::Vertical(20.0), None, None, Some(Identifier::new_raw("test1"))),
         ]);
         assert!(fi.validate().is_err());
     }

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -52,7 +52,7 @@ impl OutlineBuilder {
         match self.scratch_state {
             OutlineBuilderState::Idle => {
                 self.scratch_state = OutlineBuilderState::Drawing {
-                    scratch_contour: Contour::new(Vec::new(), identifier, None),
+                    scratch_contour: Contour::new(Vec::new(), identifier),
                     number_of_offcurves: 0,
                 };
                 Ok(self)
@@ -113,7 +113,6 @@ impl OutlineBuilder {
                     smooth,
                     name,
                     identifier,
-                    None,
                 ));
                 Ok(self)
             }
@@ -175,7 +174,7 @@ impl OutlineBuilder {
         transform: AffineTransform,
         identifier: Option<Identifier>,
     ) -> &mut Self {
-        self.components.push(Component::new(base, transform, identifier, None));
+        self.components.push(Component::new(base, transform, identifier));
         self
     }
 
@@ -224,9 +223,9 @@ mod tests {
             contours,
             vec![Contour::new(
                 vec![
-                    ContourPoint::new(173.0, 536.0, PointType::Line, false, None, None, None,),
-                    ContourPoint::new(85.0, 536.0, PointType::Line, false, None, None, None,),
-                    ContourPoint::new(85.0, 0.0, PointType::Line, false, None, None, None),
+                    ContourPoint::new(173.0, 536.0, PointType::Line, false, None, None),
+                    ContourPoint::new(85.0, 536.0, PointType::Line, false, None, None),
+                    ContourPoint::new(85.0, 0.0, PointType::Line, false, None, None),
                     ContourPoint::new(
                         173.0,
                         0.0,
@@ -234,11 +233,9 @@ mod tests {
                         false,
                         None,
                         Some(Identifier::new_raw("def")),
-                        None,
                     ),
                 ],
                 Some(Identifier::new_raw("abc")),
-                None,
             )]
         );
 
@@ -255,7 +252,6 @@ mod tests {
                     y_offset: 0.0,
                 },
                 Some(Identifier::new_raw("xyz")),
-                None,
             )]
         );
 

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -173,7 +173,7 @@ impl Glyph {
                         let lib = lib
                             .into_dictionary()
                             .ok_or(GlifLoadError::ObjectLibMustBeDictionary(id.into()))?;
-                        $object.replace_lib(lib);
+                        $object.lib = Some(lib);
                     }
                 }
             };
@@ -463,16 +463,8 @@ impl Anchor {
         name: Option<Name>,
         color: Option<Color>,
         identifier: Option<Identifier>,
-        lib: Option<Plist>,
     ) -> Self {
-        let mut this = Self { x, y, name, color, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
+        Self { x, y, name, color, identifier, lib: None }
     }
 
     /// Returns a reference to the anchor's lib.
@@ -487,6 +479,7 @@ impl Anchor {
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
     /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    #[cfg(feature = "object-libs")]
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
         if self.identifier.is_none() {
             self.identifier.replace(Identifier::from_uuidv4());
@@ -513,19 +506,8 @@ impl Anchor {
 
 impl Contour {
     /// Returns a new [`Contour`] given a vector of contour points.
-    pub fn new(
-        points: Vec<ContourPoint>,
-        identifier: Option<Identifier>,
-        lib: Option<Plist>,
-    ) -> Self {
-        let mut this = Self { points, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
+    pub fn new(points: Vec<ContourPoint>, identifier: Option<Identifier>) -> Self {
+        Self { points, identifier, lib: None }
     }
 
     /// Returns a reference to the contour's lib.
@@ -540,6 +522,7 @@ impl Contour {
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
     /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    #[cfg(feature = "object-libs")]
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
         if self.identifier.is_none() {
             self.identifier.replace(Identifier::from_uuidv4());
@@ -574,16 +557,8 @@ impl ContourPoint {
         smooth: bool,
         name: Option<Name>,
         identifier: Option<Identifier>,
-        lib: Option<Plist>,
     ) -> Self {
-        let mut this = Self { x, y, typ, smooth, name, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
+        Self { x, y, typ, smooth, name, identifier, lib: None }
     }
 
     /// Returns a reference to the contour's lib.
@@ -598,6 +573,7 @@ impl ContourPoint {
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
     /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    #[cfg(feature = "object-libs")]
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
         if self.identifier.is_none() {
             self.identifier.replace(Identifier::from_uuidv4());
@@ -640,20 +616,8 @@ impl Component {
     /// Returns a new [`Component`] given a base glyph name and affine transformation definition.
     ///
     /// The 'name' argument should be taken from an existing glyph in  the same layer.
-    pub fn new(
-        base: Name,
-        transform: AffineTransform,
-        identifier: Option<Identifier>,
-        lib: Option<Plist>,
-    ) -> Self {
-        let mut this = Self { base, transform, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
+    pub fn new(base: Name, transform: AffineTransform, identifier: Option<Identifier>) -> Self {
+        Self { base, transform, identifier, lib: None }
     }
 
     /// Returns a reference to the component's lib.
@@ -668,6 +632,7 @@ impl Component {
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
     /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    #[cfg(feature = "object-libs")]
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
         if self.identifier.is_none() {
             self.identifier.replace(Identifier::from_uuidv4());

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -177,14 +177,8 @@ impl<'names> GlifParser<'names> {
                     && c.points[0].name.is_some()
                 {
                     let anchor_point = c.points.remove(0);
-                    let anchor = Anchor::new(
-                        anchor_point.x,
-                        anchor_point.y,
-                        anchor_point.name,
-                        None,
-                        None,
-                        None,
-                    );
+                    let anchor =
+                        Anchor::new(anchor_point.x, anchor_point.y, anchor_point.name, None, None);
                     self.glyph.anchors.push(anchor);
                 }
             }
@@ -455,7 +449,7 @@ impl<'names> GlifParser<'names> {
 
         match (x, y) {
             (Some(x), Some(y)) => {
-                self.glyph.anchors.push(Anchor::new(x, y, name, color, identifier, None));
+                self.glyph.anchors.push(Anchor::new(x, y, name, color, identifier));
                 Ok(())
             }
             _ => Err(ErrorKind::BadAnchor.into()),
@@ -502,7 +496,7 @@ impl<'names> GlifParser<'names> {
             (Some(x), Some(y), Some(degrees)) => Line::Angle { x, y, degrees },
             _ => return Err(ErrorKind::BadGuideline.into()),
         };
-        self.glyph.guidelines.push(Guideline::new(line, name, color, identifier, None));
+        self.glyph.guidelines.push(Guideline::new(line, name, color, identifier));
 
         Ok(())
     }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -211,10 +211,10 @@ fn parse_v1_upgrade_anchors() {
     assert_eq!(
         glyph.anchors,
         vec![
-            Anchor::new(10.0, 10.0, Some("top".into()), None, None, None),
-            Anchor::new(10.0, 20.0, Some("bottom".into()), None, None, None),
-            Anchor::new(30.0, 20.0, Some("left".into()), None, None, None),
-            Anchor::new(40.0, 20.0, Some("right".into()), None, None, None),
+            Anchor::new(10.0, 10.0, Some("top".into()), None, None,),
+            Anchor::new(10.0, 20.0, Some("bottom".into()), None, None,),
+            Anchor::new(30.0, 20.0, Some("left".into()), None, None,),
+            Anchor::new(40.0, 20.0, Some("right".into()), None, None,),
         ]
     );
     assert_eq!(glyph.guidelines, vec![]);

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -17,7 +17,7 @@ pub struct Guideline {
     /// when a lib is present and should otherwise only be added as needed.
     identifier: Option<Identifier>,
     /// The guideline's lib for arbitrary data.
-    lib: Option<Plist>,
+    pub(crate) lib: Option<Plist>,
 }
 
 /// An infinite line.
@@ -47,16 +47,8 @@ impl Guideline {
         name: Option<Name>,
         color: Option<Color>,
         identifier: Option<Identifier>,
-        lib: Option<Plist>,
     ) -> Self {
-        let mut this = Self { line, name, color, identifier: None, lib: None };
-        if let Some(id) = identifier {
-            this.replace_identifier(id);
-        }
-        if let Some(lib) = lib {
-            this.replace_lib(lib);
-        }
-        this
+        Self { line, name, color, identifier, lib: None }
     }
 
     /// Returns a reference to the Guideline's lib.
@@ -71,6 +63,7 @@ impl Guideline {
 
     /// Replaces the actual lib by the lib given in parameter, returning the old
     /// lib if present. Sets a new UUID v4 identifier if none is set already.
+    #[cfg(feature = "object-libs")]
     pub fn replace_lib(&mut self, lib: Plist) -> Option<Plist> {
         if self.identifier.is_none() {
             self.identifier.replace(Identifier::from_uuidv4());
@@ -170,7 +163,7 @@ impl<'de> Deserialize<'de> for Guideline {
             }
         };
 
-        Ok(Guideline::new(line, guideline.name, guideline.color, guideline.identifier, None))
+        Ok(Guideline::new(line, guideline.name, guideline.color, guideline.identifier))
     }
 }
 
@@ -187,7 +180,6 @@ mod tests {
             Some(Name::new_raw("hello")),
             Some(Color::new(0.0, 0.5, 0.0, 0.5).unwrap()),
             Some(Identifier::new_raw("abcABC123")),
-            None,
         );
         assert_tokens(
             &g1,

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -38,6 +38,7 @@ impl Identifier {
     }
 
     /// Create a new [`Identifier`] from a UUID v4 identifier.
+    #[cfg(feature = "object-libs")]
     pub fn from_uuidv4() -> Self {
         Self::new(uuid::Uuid::new_v4().to_string().as_ref()).unwrap()
     }


### PR DESCRIPTION
We use the uuid crate to generate object identifiers, and we use object identifiers anytime we set a lib object on a type where the lib is stored in the parent (such as contour or guideline).

This adds a new feature, `object-libs`, that brings in `uuid` and gates all the API that is involved in setting the libs on these objects.

This also changes various constructors to not take a `lib` directly, and instead the lib will have to be manually added by the user.