### PR TITLE
Derive `Copy` where possible

### DIFF
--- a/src/designspace.rs
+++ b/src/designspace.rs
@@ -74,7 +74,7 @@ fn is_false(value: &bool) -> bool {
 }
 
 /// Maps one input value (user space coord) to one output value (design space coord).
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename = "map")]
 pub struct AxisMapping {
     /// user space coordinate
@@ -101,7 +101,7 @@ pub struct Rules {
 
 /// Indicates whether substitution rules should be applied before or after other
 /// glyph substitution features.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RuleProcessing {
     /// Apply before other substitution features.

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1240,7 +1240,7 @@ pub enum Os2WidthClass {
 }
 
 /// Corresponds to [openTypeOS2FamilyClass](http://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#opentype-os2-table-fields).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Copy)]
 pub struct Os2FamilyClass {
     /// Class ID.
     pub class_id: u8,
@@ -1283,7 +1283,7 @@ impl<'de> Deserialize<'de> for Os2FamilyClass {
 }
 
 /// Corresponds to [openTypeOS2Panose](http://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#opentype-os2-table-fields).
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Copy)]
 pub struct Os2Panose {
     /// Panose family type.
     pub family_type: NonNegativeInteger,
@@ -1606,7 +1606,7 @@ pub struct WoffMetadataVendor {
 
 /// Corresponds to the writing direction attribute used in [WOFF Data](http://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#woff-data).
 /// If present, is either "ltr" or "rtl".
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum WoffAttributeDirection {
     /// Left to Right writing direction.
     LeftToRight,
@@ -1643,7 +1643,7 @@ impl<'de> Deserialize<'de> for WoffAttributeDirection {
 /// Corresponds to the `styleMapStyleName` in [Generic Identification Information](http://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#generic-identification-information).
 ///
 /// If present, is either "regular", "italic", "bold" or "bold italic".
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum StyleMapStyle {
     /// Regular style.
     Regular,

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -380,7 +380,7 @@ pub struct ContourPoint {
 }
 
 /// Possible types of points that can exist in a [`Contour`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum PointType {
     /// A point of this type must be the first in a contour. The reverse is not true:
     /// a contour does not necessarily start with a move point. When a contour

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -21,7 +21,7 @@ pub struct Guideline {
 }
 
 /// An infinite line.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub enum Line {
     /// A vertical line, passing through a given `x` coordinate.
     Vertical(f64),

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -12,7 +12,7 @@ pub type Plist = plist::Dictionary;
 /// A color in RGBA (Red-Green-Blue-Alpha) format.
 ///
 /// See <https://unifiedfontobject.org/versions/ufo3/conventions/#colors>.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub struct Color {
     /// Red channel value. Must be in the range 0 to 1, inclusive.
     red: f64,

--- a/src/write.rs
+++ b/src/write.rs
@@ -139,7 +139,7 @@ impl WriteOptions {
 /// The quote character used to write the XML declaration.
 ///
 /// This is exposed to allow the user to match the output of other tools.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum QuoteChar {
     /// Single quotes: 'UTF-8'.
     Single,


### PR DESCRIPTION
Found using `cargo check -- -W missing_copy_implementations`

I left out some private types where it doesn't seem necessary