### PR TITLE
If a v1 .glif contains a note field, just drop it

### DIFF
--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -80,7 +80,13 @@ impl<'names> GlifParser<'names> {
                         self.parse_lib(reader, raw_xml, buf)?;
                     }
                     b"note" if self.version == VERSION_1 => {
-                        return Err(ErrorKind::UnexpectedV1Element("note").into());
+                        log::warn!(
+                            "v1 .glif '{}' contains unexpected 'note' field",
+                            self.glyph.name
+                        );
+                        self.parse_note(reader, buf)?;
+                        // drop the note
+                        self.glyph.note = None;
                     }
                     b"note" if self.glyph.note.is_some() => {
                         return Err(ErrorKind::DuplicateElement("note").into());

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -897,3 +897,18 @@ fn bom_glif() {
     let glyph = parse_glyph(bytes).expect("initial load failed");
     assert_eq!(glyph.lib.get("hi").unwrap().as_string(), Some("hello"));
 }
+
+#[test]
+fn v1_glyph_with_note() {
+    // this isn't allowed by the spec; we'll just drop it.
+    let glyph_xml = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bn_e" format="1">
+  <advance width="632"/>
+  <unicode hex="098F"/>
+</glyph>
+"#;
+
+    let glyph = parse_glyph(glyph_xml.as_bytes()).unwrap();
+    assert!(glyph.note.is_none());
+}


### PR DESCRIPTION
Instead of erroring. This exists in a few real-world fonts, and doesn't seem worth failing over.

see https://github.com/BlackFoundryCom/Atma/blob/master/Sources/Mastering/TT/Atma-SemiBold.ufo/glyphs/bn_e.glif

noticed this was a cause of some failed compiles on crater.