### PR TITLE
More lenient parsing of glyph points

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -536,6 +536,8 @@ pub enum ErrorKind {
     /// Has an unexpected move definition.
     UnexpectedMove,
     /// Has an unexpected smooth definition.
+    //TODO: no longer used, can be removed next non-patch release
+    #[deprecated(since = "0.18.2", note = "unused, will be removed")]
     UnexpectedSmooth,
     /// Has an unexpected element definition.
     UnexpectedElement,
@@ -606,6 +608,7 @@ impl std::fmt::Display for ErrorKind {
             UnexpectedMove => {
                 write!(f, "unexpected move point, can only occur at start of contour")
             }
+            #[allow(deprecated)]
             UnexpectedSmooth => write!(f, "unexpected smooth attribute on an off-curve point"),
             UnexpectedElement => write!(f, "unexpected element"),
             UnexpectedAttribute => write!(f, "unexpected attribute"),

--- a/src/glyph/builder.rs
+++ b/src/glyph/builder.rs
@@ -65,8 +65,9 @@ impl OutlineBuilder {
     ///
     /// Errors when:
     /// 1. [`Self::begin_path`] wasn't called first.
-    /// 2. the point is an off-curve with the smooth attribute set.
-    /// 3. the point sequence is forbidden by the specification.
+    /// 2. the point sequence is forbidden by the specification.
+    ///
+    /// If an off-curve point has the smooth attribute set, it is logged and ignored.
     ///
     /// On error, it won't add any part of the point, but you can try again with a new
     /// and improved point.
@@ -93,9 +94,6 @@ impl OutlineBuilder {
                         }
                     }
                     PointType::OffCurve => {
-                        if smooth {
-                            return Err(ErrorKind::UnexpectedSmooth);
-                        }
                         *number_of_offcurves = number_of_offcurves.saturating_add(1);
                     }
                     PointType::QCurve => *number_of_offcurves = 0,

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -30,6 +30,7 @@ pub(crate) struct GlifParser<'names> {
     glyph: Glyph,
     version: Version,
     seen_identifiers: HashSet<Identifier>,
+    has_warned_for_smooth_point: bool,
     /// Optional set of glyph names to be reused between glyphs.
     names: Option<&'names NameList>,
 }
@@ -47,7 +48,13 @@ impl<'names> GlifParser<'names> {
 
         let (name, version) = start(&mut reader, &mut buf, names)?;
         let glyph = Glyph::new_impl(name);
-        let parser = GlifParser { glyph, seen_identifiers: Default::default(), names, version };
+        let parser = GlifParser {
+            glyph,
+            seen_identifiers: Default::default(),
+            names,
+            version,
+            has_warned_for_smooth_point: false,
+        };
         parser.parse_body(&mut reader, xml, &mut buf)
     }
 
@@ -325,7 +332,7 @@ impl<'names> GlifParser<'names> {
                 // Instead of failing to parse these files, we prefer to just skip the dicts.
                 self.glyph.lib = dict;
             }
-            Err(e) => log::info!("glyph {} contains invalid lib: '{e}'", self.glyph.name),
+            Err(e) => log::info!("glyph '{}' {e}", self.glyph.name),
         }
 
         Ok(())
@@ -386,6 +393,16 @@ impl<'names> GlifParser<'names> {
 
         match (x, y) {
             (Some(x), Some(y)) => {
+                if typ == PointType::OffCurve && smooth {
+                    if !self.has_warned_for_smooth_point {
+                        log::info!(
+                            "glyph '{}' has off-curve point with 'smooth' attribute set",
+                            self.glyph.name
+                        );
+                    }
+                    self.has_warned_for_smooth_point = true;
+                    smooth = false;
+                }
                 outline_builder.add_point((x, y), typ, smooth, name, identifier)?;
                 Ok(())
             }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -454,8 +454,9 @@ fn unexpected_move() {
 }
 
 #[test]
-#[should_panic(expected = "UnexpectedSmooth")]
-fn unexpected_smooth() {
+fn offcurve_smooth_is_ignored() {
+    // smooth="yes" on an off-curve point is invalid per the spec but we log and ignore it
+    // rather than returning an error.
     let data = r#"
         <?xml version="1.0" encoding="UTF-8"?>
         <glyph name="period" format="2">
@@ -468,7 +469,9 @@ fn unexpected_smooth() {
             </outline>
         </glyph>
   "#;
-    let _ = parse_glyph(data.as_bytes()).unwrap();
+    let glyph = parse_glyph(data.as_bytes()).unwrap();
+    let contour = &glyph.contours[0];
+    assert!(!contour.points[0].smooth);
 }
 
 #[test]


### PR DESCRIPTION
Specifically if an off-curve point has the 'smooth' attribute set, we will now log a warning instead of returning an error.


closes #391 