### PR TITLE
Implement kerning lookups

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -15,7 +15,7 @@ use crate::fontinfo::FontInfo;
 use crate::glyph::Glyph;
 use crate::groups::{validate_groups, Groups};
 use crate::guideline::Guideline;
-use crate::kerning::Kerning;
+use crate::kerning::{Kerning, ReverseGroupsLookup};
 use crate::layer::{Layer, LayerContents, LAYER_CONTENTS_FILE};
 use crate::name::Name;
 use crate::names::NameList;
@@ -604,14 +604,47 @@ impl Font {
     pub fn guidelines_mut(&mut self) -> &mut Vec<Guideline> {
         self.font_info.guidelines.get_or_insert_with(Default::default)
     }
+    
+    #[inline]
+    pub fn get_reverse_groups_lookup(&self) -> ReverseGroupsLookup {
+        ReverseGroupsLookup::from(&self.groups)
+    }
+
+    pub fn kerning_lookup(&self, lookup: &ReverseGroupsLookup, first: &str, second: &str) -> Option<f64> {
+        // glyph name glyph name
+        if let Some(kern) = self.kerning_lookup_dumb(first, second) {
+            return Some(kern);
+        }
+
+        // group name glyph name
+        let first_group = lookup.get_first(first);
+        if let Some(first_group) = &first_group {
+            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
+                return Some(kern);
+            }
+        }
+
+        // glyph name group name
+        let second_group = lookup.get_second(second);
+        if let Some(second_group) = &second_group {
+            if let Some(kern) = self.kerning_lookup_dumb(first, second_group.as_str()) {
+                return Some(kern);
+            }
+        }
+
+        // group name group name
+        if let Some((first_group, second_group)) = first_group.zip(second_group) {
+            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second_group.as_str()) {
+                return Some(kern);
+            }
+        }
+
+        None
+    }
 
     pub fn kerning_lookup_slow(&self, first: &str, second: &str) -> Option<f64> {
-        let basic_lookup = |first: &str, second: &str| {
-            self.kerning.get(first).and_then(|first| first.get(second)).copied()
-        };
-
         // glyph name glyph name
-        if let Some(kern) = basic_lookup(first, second) {
+        if let Some(kern) = self.kerning_lookup_dumb(first, second) {
             return Some(kern);
         }
 
@@ -623,7 +656,7 @@ impl Font {
                 },
             );
         if let Some(first_group) = first_group {
-            if let Some(kern) = basic_lookup(first_group.as_str(), second) {
+            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
                 return Some(kern);
             }
         }
@@ -636,19 +669,23 @@ impl Font {
                 },
             );
         if let Some(second_group) = second_group {
-            if let Some(kern) = basic_lookup(first, second_group.as_str()) {
+            if let Some(kern) = self.kerning_lookup_dumb(first, second_group.as_str()) {
                 return Some(kern);
             }
         }
 
         // group name group name
         if let Some((first_group, second_group)) = first_group.zip(second_group) {
-            if let Some(kern) = basic_lookup(first_group.as_str(), second_group.as_str()) {
+            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second_group.as_str()) {
                 return Some(kern);
             }
         }
 
         None
+    }
+
+    fn kerning_lookup_dumb(&self, first: &str, second: &str) -> Option<f64> {
+        self.kerning.get(first).and_then(|first| first.get(second)).copied()
     }
 }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -620,7 +620,7 @@ impl Font {
 
     /// Retrieve the kerning value (if any) between a pair of elements.
     ///
-    /// The elments can be either individual glyphs (by name) or kerning groups
+    /// The elements can be either individual glyphs (by name) or kerning groups
     /// (by name), or any combination of the two.
     //  ^ note: this works without any special consideration in the code
     //          because glyph names are forbidden from using the group prefix,
@@ -673,7 +673,7 @@ impl Font {
 
     /// Retrieve the kerning value (if any) between a pair of elements.
     ///
-    /// The elments can be either individual glyphs (by name) or kerning groups
+    /// The elements can be either individual glyphs (by name) or kerning groups
     /// (by name), or any combination of the two.
     //  ^ note: this works without any special consideration in the code
     //          because glyph names are forbidden from using the group prefix,

--- a/src/font.rs
+++ b/src/font.rs
@@ -604,6 +604,52 @@ impl Font {
     pub fn guidelines_mut(&mut self) -> &mut Vec<Guideline> {
         self.font_info.guidelines.get_or_insert_with(Default::default)
     }
+
+    pub fn kerning_lookup_slow(&self, first: &str, second: &str) -> Option<f64> {
+        let basic_lookup = |first: &str, second: &str| {
+            self.kerning.get(first).and_then(|first| first.get(second)).copied()
+        };
+
+        // glyph name glyph name
+        if let Some(kern) = basic_lookup(first, second) {
+            return Some(kern);
+        }
+
+        // group name glyph name
+        let first_group =
+            self.groups.iter().filter(|(name, _)| name.starts_with("public.kern1.")).find_map(
+                |(name, members)| {
+                    members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
+                },
+            );
+        if let Some(first_group) = first_group {
+            if let Some(kern) = basic_lookup(first_group.as_str(), second) {
+                return Some(kern);
+            }
+        }
+
+        // glyph name group name
+        let second_group =
+            self.groups.iter().filter(|(name, _)| name.starts_with("public.kern2.")).find_map(
+                |(name, members)| {
+                    members.iter().any(|glyph_name| glyph_name.as_str() == second).then_some(name)
+                },
+            );
+        if let Some(second_group) = second_group {
+            if let Some(kern) = basic_lookup(first, second_group.as_str()) {
+                return Some(kern);
+            }
+        }
+
+        // group name group name
+        if let Some((first_group, second_group)) = first_group.zip(second_group) {
+            if let Some(kern) = basic_lookup(first_group.as_str(), second_group.as_str()) {
+                return Some(kern);
+            }
+        }
+
+        None
+    }
 }
 
 fn load_lib(lib_path: &Path) -> Result<plist::Dictionary, FontLoadError> {

--- a/src/font.rs
+++ b/src/font.rs
@@ -13,11 +13,9 @@ use crate::datastore::{DataStore, ImageStore};
 use crate::error::{FontLoadError, FontWriteError};
 use crate::fontinfo::FontInfo;
 use crate::glyph::Glyph;
-use crate::groups::{
-    validate_groups, Groups, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX,
-};
+use crate::groups::{validate_groups, Groups};
 use crate::guideline::Guideline;
-use crate::kerning::{Kerning, ReverseGroupsLookup};
+use crate::kerning::{Kerning, ReverseGroups};
 use crate::layer::{Layer, LayerContents, LAYER_CONTENTS_FILE};
 use crate::name::Name;
 use crate::names::NameList;
@@ -607,15 +605,15 @@ impl Font {
         self.font_info.guidelines.get_or_insert_with(Default::default)
     }
 
-    /// Builds a [`ReverseGroupsLookup`], used to determine what group a glyph
+    /// Builds a [`ReverseGroups`], used to determine what group a glyph
     /// is in.
     ///
     /// Effectively the inverse of `groups.plist`.
     ///
     /// Used by [`Font::kerning_lookup`].
     #[inline]
-    pub fn get_reverse_groups_lookup(&self) -> ReverseGroupsLookup {
-        ReverseGroupsLookup::from(&self.groups)
+    pub fn get_reverse_groups_lookup(&'_ self) -> ReverseGroups<'_> {
+        ReverseGroups::from(&self.groups)
     }
 
     /// Retrieve the kerning value (if any) between a pair of elements.
@@ -627,114 +625,47 @@ impl Font {
     //          thus meaning the group name lookup will always fail if a group
     //          was passed in
     ///
-    /// This method is accelerated by the [`ReverseGroupsLookup`], which can be
-    /// obtained from [`Font::get_reverse_groups_lookup`]. Using it is highly
-    /// recommended if doing numerous lookups, but if not you can use
-    /// [`Font::kerning_lookup_slow`], which is the same method without needing
-    /// the pre-computed groups lookup.
+    /// This method is requires a [`ReverseGroups`], which can be obtained from
+    /// [`Font::get_reverse_groups_lookup`].
     pub fn kerning_lookup(
         &self,
-        lookup: &ReverseGroupsLookup,
+        resolver: &ReverseGroups,
         first: &str,
         second: &str,
     ) -> Option<f64> {
+        let kerning_lookup = |first: &str, second: &str| {
+            self.kerning.get(first).and_then(|first| first.get(second)).copied()
+        };
+
         // glyph name glyph name
-        if let Some(kern) = self.kerning_lookup_dumb(first, second) {
+        if let Some(kern) = kerning_lookup(first, second) {
             return Some(kern);
         }
 
         // glyph name group name
-        let second_group = lookup.get_second(second);
+        let second_group = resolver.get_second(second);
         if let Some(second_group) = &second_group {
-            if let Some(kern) = self.kerning_lookup_dumb(first, second_group.as_str()) {
+            if let Some(kern) = kerning_lookup(first, second_group.as_str()) {
                 return Some(kern);
             }
         }
 
         // group name glyph name
-        let first_group = lookup.get_first(first);
+        let first_group = resolver.get_first(first);
         if let Some(first_group) = &first_group {
-            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
+            if let Some(kern) = kerning_lookup(first_group.as_str(), second) {
                 return Some(kern);
             }
         }
 
         // group name group name
         if let Some((first_group, second_group)) = first_group.zip(second_group) {
-            if let Some(kern) =
-                self.kerning_lookup_dumb(first_group.as_str(), second_group.as_str())
-            {
+            if let Some(kern) = kerning_lookup(first_group.as_str(), second_group.as_str()) {
                 return Some(kern);
             }
         }
 
         None
-    }
-
-    /// Retrieve the kerning value (if any) between a pair of elements.
-    ///
-    /// The elements can be either individual glyphs (by name) or kerning groups
-    /// (by name), or any combination of the two.
-    ///
-    /// ⚠️ This method forgoes pre-computing a reverse glyph groups lookup for the
-    /// use case where you're only after a couple of kerns and the overhead of
-    /// generating the lookup is not worth it. But in cases where you're
-    /// querying many kerns, you should definitely be using
-    /// [`Font::kerning_lookup`] over this method.
-    pub fn kerning_lookup_slow(&self, first: &str, second: &str) -> Option<f64> {
-        // glyph name glyph name
-        if let Some(kern) = self.kerning_lookup_dumb(first, second) {
-            return Some(kern);
-        }
-
-        // glyph name group name
-        let second_group = if second.starts_with(SECOND_KERNING_GROUP_PREFIX) {
-            Some(second)
-        } else {
-            self.groups
-                .iter()
-                .filter(|(name, _)| name.starts_with(SECOND_KERNING_GROUP_PREFIX))
-                .find_map(|(name, members)| {
-                    members.iter().any(|glyph_name| glyph_name.as_str() == second).then_some(name)
-                })
-                .map(Name::as_str)
-        };
-        if let Some(second_group) = second_group {
-            if let Some(kern) = self.kerning_lookup_dumb(first, second_group) {
-                return Some(kern);
-            }
-        }
-
-        // group name glyph name
-        let first_group = if first.starts_with(FIRST_KERNING_GROUP_PREFIX) {
-            Some(first)
-        } else {
-            self.groups
-                .iter()
-                .filter(|(name, _)| name.starts_with(FIRST_KERNING_GROUP_PREFIX))
-                .find_map(|(name, members)| {
-                    members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
-                })
-                .map(Name::as_str)
-        };
-        if let Some(first_group) = first_group {
-            if let Some(kern) = self.kerning_lookup_dumb(first_group, second) {
-                return Some(kern);
-            }
-        }
-
-        // group name group name
-        if let Some((first_group, second_group)) = first_group.zip(second_group) {
-            if let Some(kern) = self.kerning_lookup_dumb(first_group, second_group) {
-                return Some(kern);
-            }
-        }
-
-        None
-    }
-
-    fn kerning_lookup_dumb(&self, first: &str, second: &str) -> Option<f64> {
-        self.kerning.get(first).and_then(|first| first.get(second)).copied()
     }
 }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -607,11 +607,31 @@ impl Font {
         self.font_info.guidelines.get_or_insert_with(Default::default)
     }
 
+    /// Builds a [`ReverseGroupsLookup`], used to determine what group a glyph
+    /// is in.
+    ///
+    /// Effectively the inverse of `groups.plist`.
+    ///
+    /// Used by [`Font::kerning_lookup`].
     #[inline]
     pub fn get_reverse_groups_lookup(&self) -> ReverseGroupsLookup {
         ReverseGroupsLookup::from(&self.groups)
     }
 
+    /// Retrieve the kerning value (if any) between a pair of elements.
+    ///
+    /// The elments can be either individual glyphs (by name) or kerning groups
+    /// (by name), or any combination of the two.
+    //  ^ note: this works without any special consideration in the code
+    //          because glyph names are forbidden from using the group prefix,
+    //          thus meaning the group name lookup will always fail if a group
+    //          was passed in
+    ///
+    /// This method is accelerated by the [`ReverseGroupsLookup`], which can be
+    /// obtained from [`Font::get_reverse_groups_lookup`]. Using it is highly
+    /// recommended if doing numerous lookups, but if not you can use
+    /// [`Font::kerning_lookup_slow`], which is the same method without needing
+    /// the pre-computed groups lookup.
     pub fn kerning_lookup(
         &self,
         lookup: &ReverseGroupsLookup,
@@ -651,6 +671,20 @@ impl Font {
         None
     }
 
+    /// Retrieve the kerning value (if any) between a pair of elements.
+    ///
+    /// The elments can be either individual glyphs (by name) or kerning groups
+    /// (by name), or any combination of the two.
+    //  ^ note: this works without any special consideration in the code
+    //          because glyph names are forbidden from using the group prefix,
+    //          thus meaning the group name lookup will always fail if a group
+    //          was passed in
+    ///
+    /// ⚠️ This method forgoes pre-computing a reverse glyph groups lookup for the
+    /// use case where you're only after a couple of kerns and the overhead of
+    /// generating the lookup is not worth it. But in cases where you're
+    /// querying many kerns, you should definitely be using
+    /// [`Font::kerning_lookup`] over this method.
     pub fn kerning_lookup_slow(&self, first: &str, second: &str) -> Option<f64> {
         // glyph name glyph name
         if let Some(kern) = self.kerning_lookup_dumb(first, second) {

--- a/src/font.rs
+++ b/src/font.rs
@@ -675,10 +675,6 @@ impl Font {
     ///
     /// The elements can be either individual glyphs (by name) or kerning groups
     /// (by name), or any combination of the two.
-    //  ^ note: this works without any special consideration in the code
-    //          because glyph names are forbidden from using the group prefix,
-    //          thus meaning the group name lookup will always fail if a group
-    //          was passed in
     ///
     /// ⚠️ This method forgoes pre-computing a reverse glyph groups lookup for the
     /// use case where you're only after a couple of kerns and the overhead of
@@ -692,38 +688,44 @@ impl Font {
         }
 
         // glyph name group name
-        let second_group = self
-            .groups
-            .iter()
-            .filter(|(name, _)| name.starts_with(SECOND_KERNING_GROUP_PREFIX))
-            .find_map(|(name, members)| {
-                members.iter().any(|glyph_name| glyph_name.as_str() == second).then_some(name)
-            });
+        let second_group = if second.starts_with(SECOND_KERNING_GROUP_PREFIX) {
+            Some(second)
+        } else {
+            self.groups
+                .iter()
+                .filter(|(name, _)| name.starts_with(SECOND_KERNING_GROUP_PREFIX))
+                .find_map(|(name, members)| {
+                    members.iter().any(|glyph_name| glyph_name.as_str() == second).then_some(name)
+                })
+                .map(Name::as_str)
+        };
         if let Some(second_group) = second_group {
-            if let Some(kern) = self.kerning_lookup_dumb(first, second_group.as_str()) {
+            if let Some(kern) = self.kerning_lookup_dumb(first, second_group) {
                 return Some(kern);
             }
         }
 
         // group name glyph name
-        let first_group = self
-            .groups
-            .iter()
-            .filter(|(name, _)| name.starts_with(FIRST_KERNING_GROUP_PREFIX))
-            .find_map(|(name, members)| {
-                members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
-            });
+        let first_group = if first.starts_with(FIRST_KERNING_GROUP_PREFIX) {
+            Some(first)
+        } else {
+            self.groups
+                .iter()
+                .filter(|(name, _)| name.starts_with(FIRST_KERNING_GROUP_PREFIX))
+                .find_map(|(name, members)| {
+                    members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
+                })
+                .map(Name::as_str)
+        };
         if let Some(first_group) = first_group {
-            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
+            if let Some(kern) = self.kerning_lookup_dumb(first_group, second) {
                 return Some(kern);
             }
         }
 
         // group name group name
         if let Some((first_group, second_group)) = first_group.zip(second_group) {
-            if let Some(kern) =
-                self.kerning_lookup_dumb(first_group.as_str(), second_group.as_str())
-            {
+            if let Some(kern) = self.kerning_lookup_dumb(first_group, second_group) {
                 return Some(kern);
             }
         }

--- a/src/font.rs
+++ b/src/font.rs
@@ -613,6 +613,28 @@ impl Font {
     ///
     /// Note: creating a [`KerningResolver`] will prevent you from mutating
     /// the font until it is dropped.
+    ///
+    /// ```
+    /// # use norad::{Font, Name};
+    /// use maplit::btreemap;
+    ///
+    /// let mut font = Font::new();
+    /// font.groups = btreemap! {
+    ///     Name::new("public.kern1.A").unwrap() => vec![
+    ///         Name::new("A").unwrap(),
+    ///     ],
+    /// };
+    /// font.kerning = btreemap! {
+    ///     Name::new("public.kern1.A").unwrap() => btreemap! {
+    ///         Name::new("V").unwrap() => -15.0,
+    ///     },
+    /// };
+    /// let resolver = font.kerning_resolver();
+    /// assert_eq!(
+    ///     resolver.get("A", "V"),
+    ///     Some(-15.0),
+    /// );
+    /// ```
     pub fn kerning_resolver(&'_ self) -> KerningResolver<'_> {
         self.groups.iter().fold(
             KerningResolver {

--- a/src/font.rs
+++ b/src/font.rs
@@ -15,7 +15,9 @@ use crate::fontinfo::FontInfo;
 use crate::glyph::Glyph;
 use crate::groups::{validate_groups, Groups};
 use crate::guideline::Guideline;
-use crate::kerning::{Kerning, ReverseGroupsLookup, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
+use crate::kerning::{
+    Kerning, ReverseGroupsLookup, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX,
+};
 use crate::layer::{Layer, LayerContents, LAYER_CONTENTS_FILE};
 use crate::name::Name;
 use crate::names::NameList;
@@ -610,7 +612,12 @@ impl Font {
         ReverseGroupsLookup::from(&self.groups)
     }
 
-    pub fn kerning_lookup(&self, lookup: &ReverseGroupsLookup, first: &str, second: &str) -> Option<f64> {
+    pub fn kerning_lookup(
+        &self,
+        lookup: &ReverseGroupsLookup,
+        first: &str,
+        second: &str,
+    ) -> Option<f64> {
         // glyph name glyph name
         if let Some(kern) = self.kerning_lookup_dumb(first, second) {
             return Some(kern);
@@ -634,7 +641,9 @@ impl Font {
 
         // group name group name
         if let Some((first_group, second_group)) = first_group.zip(second_group) {
-            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second_group.as_str()) {
+            if let Some(kern) =
+                self.kerning_lookup_dumb(first_group.as_str(), second_group.as_str())
+            {
                 return Some(kern);
             }
         }
@@ -649,12 +658,13 @@ impl Font {
         }
 
         // group name glyph name
-        let first_group =
-            self.groups.iter().filter(|(name, _)| name.starts_with(FIRST_KERNING_GROUP_PREFIX)).find_map(
-                |(name, members)| {
-                    members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
-                },
-            );
+        let first_group = self
+            .groups
+            .iter()
+            .filter(|(name, _)| name.starts_with(FIRST_KERNING_GROUP_PREFIX))
+            .find_map(|(name, members)| {
+                members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
+            });
         if let Some(first_group) = first_group {
             if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
                 return Some(kern);
@@ -662,12 +672,13 @@ impl Font {
         }
 
         // glyph name group name
-        let second_group =
-            self.groups.iter().filter(|(name, _)| name.starts_with(SECOND_KERNING_GROUP_PREFIX)).find_map(
-                |(name, members)| {
-                    members.iter().any(|glyph_name| glyph_name.as_str() == second).then_some(name)
-                },
-            );
+        let second_group = self
+            .groups
+            .iter()
+            .filter(|(name, _)| name.starts_with(SECOND_KERNING_GROUP_PREFIX))
+            .find_map(|(name, members)| {
+                members.iter().any(|glyph_name| glyph_name.as_str() == second).then_some(name)
+            });
         if let Some(second_group) = second_group {
             if let Some(kern) = self.kerning_lookup_dumb(first, second_group.as_str()) {
                 return Some(kern);
@@ -676,7 +687,9 @@ impl Font {
 
         // group name group name
         if let Some((first_group, second_group)) = first_group.zip(second_group) {
-            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second_group.as_str()) {
+            if let Some(kern) =
+                self.kerning_lookup_dumb(first_group.as_str(), second_group.as_str())
+            {
                 return Some(kern);
             }
         }

--- a/src/font.rs
+++ b/src/font.rs
@@ -15,7 +15,7 @@ use crate::fontinfo::FontInfo;
 use crate::glyph::Glyph;
 use crate::groups::{validate_groups, Groups};
 use crate::guideline::Guideline;
-use crate::kerning::{Kerning, ReverseGroupsLookup};
+use crate::kerning::{Kerning, ReverseGroupsLookup, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
 use crate::layer::{Layer, LayerContents, LAYER_CONTENTS_FILE};
 use crate::name::Name;
 use crate::names::NameList;
@@ -604,7 +604,7 @@ impl Font {
     pub fn guidelines_mut(&mut self) -> &mut Vec<Guideline> {
         self.font_info.guidelines.get_or_insert_with(Default::default)
     }
-    
+
     #[inline]
     pub fn get_reverse_groups_lookup(&self) -> ReverseGroupsLookup {
         ReverseGroupsLookup::from(&self.groups)
@@ -650,7 +650,7 @@ impl Font {
 
         // group name glyph name
         let first_group =
-            self.groups.iter().filter(|(name, _)| name.starts_with("public.kern1.")).find_map(
+            self.groups.iter().filter(|(name, _)| name.starts_with(FIRST_KERNING_GROUP_PREFIX)).find_map(
                 |(name, members)| {
                     members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
                 },
@@ -663,7 +663,7 @@ impl Font {
 
         // glyph name group name
         let second_group =
-            self.groups.iter().filter(|(name, _)| name.starts_with("public.kern2.")).find_map(
+            self.groups.iter().filter(|(name, _)| name.starts_with(SECOND_KERNING_GROUP_PREFIX)).find_map(
                 |(name, members)| {
                     members.iter().any(|glyph_name| glyph_name.as_str() == second).then_some(name)
                 },

--- a/src/font.rs
+++ b/src/font.rs
@@ -623,18 +623,18 @@ impl Font {
             return Some(kern);
         }
 
-        // group name glyph name
-        let first_group = lookup.get_first(first);
-        if let Some(first_group) = &first_group {
-            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
-                return Some(kern);
-            }
-        }
-
         // glyph name group name
         let second_group = lookup.get_second(second);
         if let Some(second_group) = &second_group {
             if let Some(kern) = self.kerning_lookup_dumb(first, second_group.as_str()) {
+                return Some(kern);
+            }
+        }
+
+        // group name glyph name
+        let first_group = lookup.get_first(first);
+        if let Some(first_group) = &first_group {
+            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
                 return Some(kern);
             }
         }
@@ -657,20 +657,6 @@ impl Font {
             return Some(kern);
         }
 
-        // group name glyph name
-        let first_group = self
-            .groups
-            .iter()
-            .filter(|(name, _)| name.starts_with(FIRST_KERNING_GROUP_PREFIX))
-            .find_map(|(name, members)| {
-                members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
-            });
-        if let Some(first_group) = first_group {
-            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
-                return Some(kern);
-            }
-        }
-
         // glyph name group name
         let second_group = self
             .groups
@@ -681,6 +667,20 @@ impl Font {
             });
         if let Some(second_group) = second_group {
             if let Some(kern) = self.kerning_lookup_dumb(first, second_group.as_str()) {
+                return Some(kern);
+            }
+        }
+
+        // group name glyph name
+        let first_group = self
+            .groups
+            .iter()
+            .filter(|(name, _)| name.starts_with(FIRST_KERNING_GROUP_PREFIX))
+            .find_map(|(name, members)| {
+                members.iter().any(|glyph_name| glyph_name.as_str() == first).then_some(name)
+            });
+        if let Some(first_group) = first_group {
+            if let Some(kern) = self.kerning_lookup_dumb(first_group.as_str(), second) {
                 return Some(kern);
             }
         }

--- a/src/font.rs
+++ b/src/font.rs
@@ -13,11 +13,11 @@ use crate::datastore::{DataStore, ImageStore};
 use crate::error::{FontLoadError, FontWriteError};
 use crate::fontinfo::FontInfo;
 use crate::glyph::Glyph;
-use crate::groups::{validate_groups, Groups};
-use crate::guideline::Guideline;
-use crate::kerning::{
-    Kerning, ReverseGroupsLookup, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX,
+use crate::groups::{
+    validate_groups, Groups, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX,
 };
+use crate::guideline::Guideline;
+use crate::kerning::{Kerning, ReverseGroupsLookup};
 use crate::layer::{Layer, LayerContents, LAYER_CONTENTS_FILE};
 use crate::name::Name;
 use crate::names::NameList;

--- a/src/font.rs
+++ b/src/font.rs
@@ -2,8 +2,9 @@
 
 #![deny(rustdoc::broken_intra_doc_links)]
 
-use std::fs;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::{fs, iter};
 
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -13,9 +14,11 @@ use crate::datastore::{DataStore, ImageStore};
 use crate::error::{FontLoadError, FontWriteError};
 use crate::fontinfo::FontInfo;
 use crate::glyph::Glyph;
-use crate::groups::{validate_groups, Groups};
+use crate::groups::{
+    validate_groups, Groups, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX,
+};
 use crate::guideline::Guideline;
-use crate::kerning::{Kerning, ReverseGroups};
+use crate::kerning::{Kerning, KerningResolver};
 use crate::layer::{Layer, LayerContents, LAYER_CONTENTS_FILE};
 use crate::name::Name;
 use crate::names::NameList;
@@ -605,67 +608,28 @@ impl Font {
         self.font_info.guidelines.get_or_insert_with(Default::default)
     }
 
-    /// Builds a [`ReverseGroups`], used to determine what group a glyph
-    /// is in.
+    /// Builds a [`KerningResolver`], which can do full kerning lookups,
+    /// including group resolution.
     ///
-    /// Effectively the inverse of `groups.plist`.
-    ///
-    /// Used by [`Font::kerning_lookup`].
-    #[inline]
-    pub fn get_reverse_groups_lookup(&'_ self) -> ReverseGroups<'_> {
-        ReverseGroups::from(&self.groups)
-    }
-
-    /// Retrieve the kerning value (if any) between a pair of elements.
-    ///
-    /// The elements can be either individual glyphs (by name) or kerning groups
-    /// (by name), or any combination of the two.
-    //  ^ note: this works without any special consideration in the code
-    //          because glyph names are forbidden from using the group prefix,
-    //          thus meaning the group name lookup will always fail if a group
-    //          was passed in
-    ///
-    /// This method is requires a [`ReverseGroups`], which can be obtained from
-    /// [`Font::get_reverse_groups_lookup`].
-    pub fn kerning_lookup(
-        &self,
-        resolver: &ReverseGroups,
-        first: &str,
-        second: &str,
-    ) -> Option<f64> {
-        let kerning_lookup = |first: &str, second: &str| {
-            self.kerning.get(first).and_then(|first| first.get(second)).copied()
-        };
-
-        // glyph name glyph name
-        if let Some(kern) = kerning_lookup(first, second) {
-            return Some(kern);
-        }
-
-        // glyph name group name
-        let second_group = resolver.get_second(second);
-        if let Some(second_group) = &second_group {
-            if let Some(kern) = kerning_lookup(first, second_group.as_str()) {
-                return Some(kern);
-            }
-        }
-
-        // group name glyph name
-        let first_group = resolver.get_first(first);
-        if let Some(first_group) = &first_group {
-            if let Some(kern) = kerning_lookup(first_group.as_str(), second) {
-                return Some(kern);
-            }
-        }
-
-        // group name group name
-        if let Some((first_group, second_group)) = first_group.zip(second_group) {
-            if let Some(kern) = kerning_lookup(first_group.as_str(), second_group.as_str()) {
-                return Some(kern);
-            }
-        }
-
-        None
+    /// Note: creating a [`KerningResolver`] will prevent you from mutating
+    /// the font until it is dropped.
+    pub fn kerning_resolver(&'_ self) -> KerningResolver<'_> {
+        self.groups.iter().fold(
+            KerningResolver {
+                kerning: &self.kerning,
+                first: HashMap::new(),
+                second: HashMap::new(),
+            },
+            |mut kr, (group_name, members)| {
+                let inverted = members.iter().cloned().zip(iter::repeat(group_name.clone()));
+                if group_name.starts_with(FIRST_KERNING_GROUP_PREFIX) {
+                    kr.first.extend(inverted);
+                } else if group_name.starts_with(SECOND_KERNING_GROUP_PREFIX) {
+                    kr.second.extend(inverted);
+                }
+                kr
+            },
+        )
     }
 }
 

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use crate::error::GroupsValidationError;
+use crate::kerning::{FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
 use crate::Name;
 
 /// A map of group name to a list of glyph names.
@@ -18,7 +19,7 @@ pub(crate) fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidatio
             return Err(GroupsValidationError::InvalidName);
         }
 
-        if group_name.starts_with("public.kern1.") {
+        if group_name.starts_with(FIRST_KERNING_GROUP_PREFIX) {
             if group_name.len() == 13 {
                 // Prefix but no actual name.
                 return Err(GroupsValidationError::InvalidName);
@@ -31,7 +32,7 @@ pub(crate) fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidatio
                     });
                 }
             }
-        } else if group_name.starts_with("public.kern2.") {
+        } else if group_name.starts_with(SECOND_KERNING_GROUP_PREFIX) {
             if group_name.len() == 13 {
                 // Prefix but no actual name.
                 return Err(GroupsValidationError::InvalidName);

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -20,7 +20,7 @@ pub(crate) fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidatio
         }
 
         if group_name.starts_with(FIRST_KERNING_GROUP_PREFIX) {
-            if group_name.len() == 13 {
+            if group_name.len() == FIRST_KERNING_GROUP_PREFIX.len() {
                 // Prefix but no actual name.
                 return Err(GroupsValidationError::InvalidName);
             }
@@ -33,7 +33,7 @@ pub(crate) fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidatio
                 }
             }
         } else if group_name.starts_with(SECOND_KERNING_GROUP_PREFIX) {
-            if group_name.len() == 13 {
+            if group_name.len() == SECOND_KERNING_GROUP_PREFIX.len() {
                 // Prefix but no actual name.
                 return Err(GroupsValidationError::InvalidName);
             }

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,8 +1,14 @@
+//! Helper types & constants for working with groups.
+
 use std::collections::{BTreeMap, HashSet};
 
 use crate::error::GroupsValidationError;
-use crate::kerning::{FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
 use crate::Name;
+
+/// The UFO standard group prefix for kerns in the first position.
+pub const FIRST_KERNING_GROUP_PREFIX: &str = "public.kern1.";
+/// The UFO standard group prefix for kerns in the second position.
+pub const SECOND_KERNING_GROUP_PREFIX: &str = "public.kern2.";
 
 /// A map of group name to a list of glyph names.
 ///

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -1,3 +1,5 @@
+//! Helper types & constants for working with groups & kerning.
+
 use std::collections::{BTreeMap, HashMap};
 
 use serde::ser::{SerializeMap, Serializer};
@@ -5,7 +7,9 @@ use serde::Serialize;
 
 use crate::{Groups, Name};
 
+/// The UFO standard group prefix for kerns in the first position.
 pub const FIRST_KERNING_GROUP_PREFIX: &str = "public.kern1.";
+/// The UFO standard group prefix for kerns in the second position.
 pub const SECOND_KERNING_GROUP_PREFIX: &str = "public.kern2.";
 
 /// A map of kerning pairs.
@@ -17,6 +21,7 @@ pub const SECOND_KERNING_GROUP_PREFIX: &str = "public.kern2.";
 /// We use a [`BTreeMap`] because we need sorting for serialization.
 pub type Kerning = BTreeMap<Name, BTreeMap<Name, f64>>;
 
+/// Maps glyph names to group names; the inverse of a `groups.plist` file.
 #[derive(Debug)]
 pub struct ReverseGroupsLookup {
     first: HashMap<Name, Name>,
@@ -24,11 +29,15 @@ pub struct ReverseGroupsLookup {
 }
 
 impl ReverseGroupsLookup {
+    /// Get the group (if any) for the glyph name when it's first in a kerning
+    /// pair.
     #[inline]
     pub fn get_first(&self, glyph_name: &str) -> Option<Name> {
         self.first.get(glyph_name).cloned()
     }
 
+    /// Get the group (if any) for the glyph name when it's second in a
+    /// kerning pair.
     #[inline]
     pub fn get_second(&self, glyph_name: &str) -> Option<Name> {
         self.second.get(glyph_name).cloned()

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -8,7 +8,6 @@ use crate::{Groups, Name};
 pub const FIRST_KERNING_GROUP_PREFIX: &str = "public.kern1.";
 pub const SECOND_KERNING_GROUP_PREFIX: &str = "public.kern2.";
 
-
 /// A map of kerning pairs.
 ///
 /// This is represented as a map of first half of a kerning pair (glyph name or group name)
@@ -42,18 +41,14 @@ impl From<&Groups> for ReverseGroupsLookup {
             .iter()
             .filter(|(group_name, _)| group_name.starts_with(FIRST_KERNING_GROUP_PREFIX))
             .flat_map(|(group_name, members)| {
-                members
-                    .iter()
-                    .map(|member| (member.clone(), group_name.clone()))
+                members.iter().map(|member| (member.clone(), group_name.clone()))
             })
             .collect();
         let second = groups
             .iter()
             .filter(|(group_name, _)| group_name.starts_with(SECOND_KERNING_GROUP_PREFIX))
             .flat_map(|(group_name, members)| {
-                members
-                    .iter()
-                    .map(|member| (member.clone(), group_name.clone()))
+                members.iter().map(|member| (member.clone(), group_name.clone()))
             })
             .collect();
         Self { first, second }

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -1,16 +1,12 @@
-//! Helper types & constants for working with groups & kerning.
+//! Helper types for working with kerning.
 
 use std::collections::{BTreeMap, HashMap};
 
 use serde::ser::{SerializeMap, Serializer};
 use serde::Serialize;
 
+use crate::groups::{FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
 use crate::{Groups, Name};
-
-/// The UFO standard group prefix for kerns in the first position.
-pub const FIRST_KERNING_GROUP_PREFIX: &str = "public.kern1.";
-/// The UFO standard group prefix for kerns in the second position.
-pub const SECOND_KERNING_GROUP_PREFIX: &str = "public.kern2.";
 
 /// A map of kerning pairs.
 ///

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -102,6 +102,7 @@ impl Serialize for KerningInnerSerializer<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Font;
     use maplit::btreemap;
     use serde_test::{assert_ser_tokens, Token};
 
@@ -135,5 +136,57 @@ mod tests {
                 Token::MapEnd,
             ],
         );
+    }
+
+    #[test]
+    fn test_kerning_resolution() {
+        // Test data taken from https://unifiedfontobject.org/versions/ufo3/kerning.plist/#exceptions
+        let font = Font {
+            groups: btreemap! {
+                Name::new_raw("public.kern1.O") => vec![
+                    Name::new_raw("O"),
+                    Name::new_raw("D"),
+                    Name::new_raw("Q"),
+                ],
+                Name::new_raw("public.kern2.E") => vec![
+                    Name::new_raw("E"),
+                    Name::new_raw("F"),
+                ],
+            },
+            kerning: btreemap! {
+                Name::new_raw("public.kern1.O") => btreemap! {
+                    Name::new_raw("public.kern2.E") => -100f64,
+                    Name::new_raw("F") => -200f64,
+                },
+                Name::new_raw("Q") => btreemap! {
+                    Name::new_raw("public.kern2.E") => -250f64,
+                },
+                Name::new_raw("D") => btreemap! {
+                    Name::new_raw("F") => -300f64,
+                },
+            },
+            ..Default::default()
+        };
+
+        let lookup = font.get_reverse_groups_lookup();
+        for (left, right, expected) in [
+            ("O", "E", -100f64),
+            ("O", "F", -200f64),
+            ("D", "E", -100f64),
+            ("D", "F", -300f64),
+            ("Q", "E", -250f64),
+            ("Q", "F", -250f64),
+        ] {
+            assert_eq!(
+                font.kerning_lookup(&lookup, left, right),
+                Some(expected),
+                "kerning_lookup incorrect for /{left}/{right}"
+            );
+            assert_eq!(
+                font.kerning_lookup_slow(left, right),
+                Some(expected),
+                "kerning_lookup_slow incorrect for /{left}/{right}"
+            );
+        }
     }
 }

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::ser::{SerializeMap, Serializer};
 use serde::Serialize;
 
-use crate::Name;
+use crate::{Groups, Name};
 
 /// A map of kerning pairs.
 ///
@@ -13,6 +13,48 @@ use crate::Name;
 ///
 /// We use a [`BTreeMap`] because we need sorting for serialization.
 pub type Kerning = BTreeMap<Name, BTreeMap<Name, f64>>;
+
+#[derive(Debug)]
+pub struct ReverseGroupsLookup {
+    first: HashMap<Name, Name>,
+    second: HashMap<Name, Name>,
+}
+
+impl ReverseGroupsLookup {
+    #[inline]
+    pub fn get_first(&self, glyph_name: &str) -> Option<Name> {
+        self.first.get(glyph_name).cloned()
+    }
+
+    #[inline]
+    pub fn get_second(&self, glyph_name: &str) -> Option<Name> {
+        self.second.get(glyph_name).cloned()
+    }
+}
+
+impl From<&Groups> for ReverseGroupsLookup {
+    fn from(groups: &Groups) -> Self {
+        let first = groups
+            .iter()
+            .filter(|(group_name, _)| group_name.starts_with("public.kern1."))
+            .flat_map(|(group_name, members)| {
+                members
+                    .iter()
+                    .map(|member| (member.clone(), group_name.clone()))
+            })
+            .collect();
+        let second = groups
+            .iter()
+            .filter(|(group_name, _)| group_name.starts_with("public.kern2."))
+            .flat_map(|(group_name, members)| {
+                members
+                    .iter()
+                    .map(|member| (member.clone(), group_name.clone()))
+            })
+            .collect();
+        Self { first, second }
+    }
+}
 
 /// A helper for serializing kerning values.
 ///

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -42,21 +42,17 @@ impl ReverseGroupsLookup {
 
 impl From<&Groups> for ReverseGroupsLookup {
     fn from(groups: &Groups) -> Self {
-        let first = groups
-            .iter()
-            .filter(|(group_name, _)| group_name.starts_with(FIRST_KERNING_GROUP_PREFIX))
-            .flat_map(|(group_name, members)| {
-                members.iter().map(|member| (member.clone(), group_name.clone()))
-            })
-            .collect();
-        let second = groups
-            .iter()
-            .filter(|(group_name, _)| group_name.starts_with(SECOND_KERNING_GROUP_PREFIX))
-            .flat_map(|(group_name, members)| {
-                members.iter().map(|member| (member.clone(), group_name.clone()))
-            })
-            .collect();
-        Self { first, second }
+        groups.iter().fold(ReverseGroupsLookup { first: HashMap::new(), second: HashMap::new() }, |mut rgl, (group_name, members)| {
+            let inverted = members.iter().map(|member| (member.clone(), group_name.clone()));
+            if group_name.starts_with(FIRST_KERNING_GROUP_PREFIX) {
+                rgl.first.extend(inverted);
+            } else if group_name.starts_with(SECOND_KERNING_GROUP_PREFIX) {
+                rgl.second.extend(inverted);
+            } else {
+                unreachable!("group didn't start with {FIRST_KERNING_GROUP_PREFIX} or {SECOND_KERNING_GROUP_PREFIX}");
+            }
+            rgl
+        })
     }
 }
 

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -42,17 +42,18 @@ impl ReverseGroupsLookup {
 
 impl From<&Groups> for ReverseGroupsLookup {
     fn from(groups: &Groups) -> Self {
-        groups.iter().fold(ReverseGroupsLookup { first: HashMap::new(), second: HashMap::new() }, |mut rgl, (group_name, members)| {
-            let inverted = members.iter().map(|member| (member.clone(), group_name.clone()));
-            if group_name.starts_with(FIRST_KERNING_GROUP_PREFIX) {
-                rgl.first.extend(inverted);
-            } else if group_name.starts_with(SECOND_KERNING_GROUP_PREFIX) {
-                rgl.second.extend(inverted);
-            } else {
-                unreachable!("group didn't start with {FIRST_KERNING_GROUP_PREFIX} or {SECOND_KERNING_GROUP_PREFIX}");
-            }
-            rgl
-        })
+        groups.iter().fold(
+            ReverseGroupsLookup { first: HashMap::new(), second: HashMap::new() },
+            |mut rgl, (group_name, members)| {
+                let inverted = members.iter().map(|member| (member.clone(), group_name.clone()));
+                if group_name.starts_with(FIRST_KERNING_GROUP_PREFIX) {
+                    rgl.first.extend(inverted);
+                } else if group_name.starts_with(SECOND_KERNING_GROUP_PREFIX) {
+                    rgl.second.extend(inverted);
+                }
+                rgl
+            },
+        )
     }
 }
 

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -5,6 +5,10 @@ use serde::Serialize;
 
 use crate::{Groups, Name};
 
+pub const FIRST_KERNING_GROUP_PREFIX: &str = "public.kern1.";
+pub const SECOND_KERNING_GROUP_PREFIX: &str = "public.kern2.";
+
+
 /// A map of kerning pairs.
 ///
 /// This is represented as a map of first half of a kerning pair (glyph name or group name)
@@ -36,7 +40,7 @@ impl From<&Groups> for ReverseGroupsLookup {
     fn from(groups: &Groups) -> Self {
         let first = groups
             .iter()
-            .filter(|(group_name, _)| group_name.starts_with("public.kern1."))
+            .filter(|(group_name, _)| group_name.starts_with(FIRST_KERNING_GROUP_PREFIX))
             .flat_map(|(group_name, members)| {
                 members
                     .iter()
@@ -45,7 +49,7 @@ impl From<&Groups> for ReverseGroupsLookup {
             .collect();
         let second = groups
             .iter()
-            .filter(|(group_name, _)| group_name.starts_with("public.kern2."))
+            .filter(|(group_name, _)| group_name.starts_with(SECOND_KERNING_GROUP_PREFIX))
             .flat_map(|(group_name, members)| {
                 members
                     .iter()

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -1,4 +1,6 @@
 //! Helper types for working with kerning.
+//!
+//! To find the kerning value for a glyph/group pair, see [`Font::kerning_lookup`](crate::Font::kerning_lookup).
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -2,10 +2,10 @@
 //!
 //! To find the kerning value for a glyph/group pair, see [`Font::kerning_lookup`](crate::Font::kerning_lookup).
 
-use std::collections::{BTreeMap, HashMap};
-
 use serde::ser::{SerializeMap, Serializer};
 use serde::Serialize;
+use std::collections::{BTreeMap, HashMap};
+use std::iter;
 
 use crate::groups::{FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
 use crate::{Groups, Name};
@@ -21,33 +21,33 @@ pub type Kerning = BTreeMap<Name, BTreeMap<Name, f64>>;
 
 /// Maps glyph names to group names; the inverse of a `groups.plist` file.
 #[derive(Debug)]
-pub struct ReverseGroupsLookup {
-    first: HashMap<Name, Name>,
-    second: HashMap<Name, Name>,
+pub struct ReverseGroups<'font> {
+    first: HashMap<&'font Name, &'font Name>,
+    second: HashMap<&'font Name, &'font Name>,
 }
 
-impl ReverseGroupsLookup {
+impl ReverseGroups<'_> {
     /// Get the group (if any) for the glyph name when it's first in a kerning
     /// pair.
     #[inline]
-    pub fn get_first(&self, glyph_name: &str) -> Option<Name> {
-        self.first.get(glyph_name).cloned()
+    pub fn get_first(&self, glyph_name: &str) -> Option<&Name> {
+        self.first.get(glyph_name).copied()
     }
 
     /// Get the group (if any) for the glyph name when it's second in a
     /// kerning pair.
     #[inline]
-    pub fn get_second(&self, glyph_name: &str) -> Option<Name> {
-        self.second.get(glyph_name).cloned()
+    pub fn get_second(&self, glyph_name: &str) -> Option<&Name> {
+        self.second.get(glyph_name).copied()
     }
 }
 
-impl From<&Groups> for ReverseGroupsLookup {
-    fn from(groups: &Groups) -> Self {
+impl<'font> From<&'font Groups> for ReverseGroups<'font> {
+    fn from(groups: &'font Groups) -> Self {
         groups.iter().fold(
-            ReverseGroupsLookup { first: HashMap::new(), second: HashMap::new() },
+            ReverseGroups { first: HashMap::new(), second: HashMap::new() },
             |mut rgl, (group_name, members)| {
-                let inverted = members.iter().map(|member| (member.clone(), group_name.clone()));
+                let inverted = members.iter().zip(iter::repeat(group_name));
                 if group_name.starts_with(FIRST_KERNING_GROUP_PREFIX) {
                     rgl.first.extend(inverted);
                 } else if group_name.starts_with(SECOND_KERNING_GROUP_PREFIX) {
@@ -185,11 +185,6 @@ mod tests {
                 font.kerning_lookup(&lookup, left, right),
                 Some(expected),
                 "kerning_lookup incorrect for /{left}/{right}"
-            );
-            assert_eq!(
-                font.kerning_lookup_slow(left, right),
-                Some(expected),
-                "kerning_lookup_slow incorrect for /{left}/{right}"
             );
         }
     }

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -22,6 +22,28 @@ pub type Kerning = BTreeMap<Name, BTreeMap<Name, f64>>;
 /// A utility struct to facilitate kerning lookups, including resolving group membership.
 ///
 /// Created by calling [`Font::kerning_resolver`](crate::Font::kerning_resolver).
+///
+/// ```
+/// # use norad::{Font, Name};
+/// use maplit::btreemap;
+///
+/// let mut font = Font::new();
+/// font.groups = btreemap! {
+///     Name::new("public.kern1.A").unwrap() => vec![
+///         Name::new("A").unwrap(),
+///     ],
+/// };
+/// font.kerning = btreemap! {
+///     Name::new("public.kern1.A").unwrap() => btreemap! {
+///         Name::new("V").unwrap() => -15.0,
+///     },
+/// };
+/// let resolver = font.kerning_resolver();
+/// assert_eq!(
+///     resolver.get("A", "V"),
+///     Some(-15.0),
+/// );
+/// ```
 #[derive(Debug)]
 pub struct KerningResolver<'font> {
     pub(crate) kerning: &'font Kerning,

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -1,14 +1,14 @@
 //! Helper types for working with kerning.
 //!
-//! To find the kerning value for a glyph/group pair, see [`Font::kerning_lookup`](crate::Font::kerning_lookup).
+//! To find the kerning value for a glyph/group pair, see
+//! [`Font::kerning_resolver`](crate::Font::kerning_resolver) and then
+//! [`KerningResolver::get`].
 
 use serde::ser::{SerializeMap, Serializer};
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap};
-use std::iter;
 
-use crate::groups::{FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
-use crate::{Groups, Name};
+use crate::Name;
 
 /// A map of kerning pairs.
 ///
@@ -19,43 +19,73 @@ use crate::{Groups, Name};
 /// We use a [`BTreeMap`] because we need sorting for serialization.
 pub type Kerning = BTreeMap<Name, BTreeMap<Name, f64>>;
 
-/// Maps glyph names to group names; the inverse of a `groups.plist` file.
+/// A utility struct to facilitate kerning lookups, including resolving group membership.
+///
+/// Created by calling [`Font::kerning_resolver`](crate::Font::kerning_resolver).
 #[derive(Debug)]
-pub struct ReverseGroups<'font> {
-    first: HashMap<&'font Name, &'font Name>,
-    second: HashMap<&'font Name, &'font Name>,
+pub struct KerningResolver<'font> {
+    pub(crate) kerning: &'font Kerning,
+    pub(crate) first: HashMap<Name, Name>,
+    pub(crate) second: HashMap<Name, Name>,
 }
 
-impl ReverseGroups<'_> {
+impl KerningResolver<'_> {
     /// Get the group (if any) for the glyph name when it's first in a kerning
     /// pair.
     #[inline]
-    pub fn get_first(&self, glyph_name: &str) -> Option<&Name> {
-        self.first.get(glyph_name).copied()
+    pub fn get_first_group(&self, glyph_name: &str) -> Option<Name> {
+        self.first.get(glyph_name).cloned()
     }
 
     /// Get the group (if any) for the glyph name when it's second in a
     /// kerning pair.
     #[inline]
-    pub fn get_second(&self, glyph_name: &str) -> Option<&Name> {
-        self.second.get(glyph_name).copied()
+    pub fn get_second_group(&self, glyph_name: &str) -> Option<Name> {
+        self.second.get(glyph_name).cloned()
     }
-}
 
-impl<'font> From<&'font Groups> for ReverseGroups<'font> {
-    fn from(groups: &'font Groups) -> Self {
-        groups.iter().fold(
-            ReverseGroups { first: HashMap::new(), second: HashMap::new() },
-            |mut rgl, (group_name, members)| {
-                let inverted = members.iter().zip(iter::repeat(group_name));
-                if group_name.starts_with(FIRST_KERNING_GROUP_PREFIX) {
-                    rgl.first.extend(inverted);
-                } else if group_name.starts_with(SECOND_KERNING_GROUP_PREFIX) {
-                    rgl.second.extend(inverted);
-                }
-                rgl
-            },
-        )
+    /// Retrieve the kerning value (if any) between a pair of elements.
+    ///
+    /// The elements can be either individual glyphs (by name) or kerning groups
+    /// (by name), or any combination of the two.
+    //  ^ note: this works without any special consideration in the code
+    //          because glyph names are forbidden from using the group prefix,
+    //          thus meaning the group name lookup will always fail if a group
+    //          was passed in
+    pub fn get(&self, first: &str, second: &str) -> Option<f64> {
+        let kerning_lookup = |first: &str, second: &str| {
+            self.kerning.get(first).and_then(|first| first.get(second)).copied()
+        };
+
+        // glyph name glyph name
+        if let Some(kern) = kerning_lookup(first, second) {
+            return Some(kern);
+        }
+
+        // glyph name group name
+        let second_group = self.get_second_group(second);
+        if let Some(second_group) = &second_group {
+            if let Some(kern) = kerning_lookup(first, second_group.as_str()) {
+                return Some(kern);
+            }
+        }
+
+        // group name glyph name
+        let first_group = self.get_first_group(first);
+        if let Some(first_group) = &first_group {
+            if let Some(kern) = kerning_lookup(first_group.as_str(), second) {
+                return Some(kern);
+            }
+        }
+
+        // group name group name
+        if let Some((first_group, second_group)) = first_group.zip(second_group) {
+            if let Some(kern) = kerning_lookup(first_group.as_str(), second_group.as_str()) {
+                return Some(kern);
+            }
+        }
+
+        None
     }
 }
 
@@ -172,7 +202,7 @@ mod tests {
             ..Default::default()
         };
 
-        let lookup = font.get_reverse_groups_lookup();
+        let resolver = font.kerning_resolver();
         for (left, right, expected) in [
             ("O", "E", -100f64),
             ("O", "F", -200f64),
@@ -182,7 +212,7 @@ mod tests {
             ("Q", "F", -250f64),
         ] {
             assert_eq!(
-                font.kerning_lookup(&lookup, left, right),
+                resolver.get(left, right),
                 Some(expected),
                 "kerning_lookup incorrect for /{left}/{right}"
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod glyph;
 mod groups;
 mod guideline;
 mod identifier;
-mod kerning;
+pub mod kerning;
 mod layer;
 mod name;
 mod names;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub mod error;
 mod font;
 pub mod fontinfo;
 mod glyph;
-mod groups;
+pub mod groups;
 mod guideline;
 mod identifier;
 pub mod kerning;

--- a/src/name.rs
+++ b/src/name.rs
@@ -93,6 +93,12 @@ impl std::borrow::Borrow<str> for Name {
     }
 }
 
+impl std::borrow::Borrow<str> for &Name {
+    fn borrow(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
 impl FromStr for Name {
     type Err = NamingError;
 

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use crate::error::FontLoadError;
 use crate::font::LIB_FILE;
 use crate::fontinfo::FontInfo;
-use crate::groups::Groups;
-use crate::kerning::{Kerning, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
+use crate::groups::{Groups, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
+use crate::kerning::Kerning;
 use crate::names::NameList;
 use crate::Name;
 

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -7,7 +7,7 @@ use crate::error::FontLoadError;
 use crate::font::LIB_FILE;
 use crate::fontinfo::FontInfo;
 use crate::groups::Groups;
-use crate::kerning::Kerning;
+use crate::kerning::{Kerning, FIRST_KERNING_GROUP_PREFIX, SECOND_KERNING_GROUP_PREFIX};
 use crate::names::NameList;
 use crate::Name;
 
@@ -31,14 +31,14 @@ pub(crate) fn upconvert_kerning(
     for (first, seconds) in kerning {
         if groups.contains_key(first)
             && !glyph_set.contains(first)
-            && !first.starts_with("public.kern1.")
+            && !first.starts_with(FIRST_KERNING_GROUP_PREFIX)
         {
             groups_first.insert(first.clone());
         }
         for second in seconds.keys() {
             if groups.contains_key(second)
                 && !glyph_set.contains(second)
-                && !second.starts_with("public.kern2.")
+                && !second.starts_with(SECOND_KERNING_GROUP_PREFIX)
             {
                 groups_second.insert(second.clone());
             }
@@ -51,7 +51,8 @@ pub(crate) fn upconvert_kerning(
     let mut groups_first_old_to_new: HashMap<Name, Name> = HashMap::new();
     for first in &groups_first {
         let first_new = make_unique_group_name(
-            Name::new(&format!("public.kern1.{}", first.replace("@MMK_L_", ""))).unwrap(),
+            Name::new(&format!("{FIRST_KERNING_GROUP_PREFIX}{}", first.replace("@MMK_L_", "")))
+                .unwrap(),
             &groups_new,
         );
         groups_first_old_to_new.insert(first.clone(), first_new.clone());
@@ -60,7 +61,8 @@ pub(crate) fn upconvert_kerning(
     let mut groups_second_old_to_new: HashMap<Name, Name> = HashMap::new();
     for second in &groups_second {
         let second_new = make_unique_group_name(
-            Name::new(&format!("public.kern2.{}", second.replace("@MMK_R_", ""))).unwrap(),
+            Name::new(&format!("{SECOND_KERNING_GROUP_PREFIX}{}", second.replace("@MMK_R_", "")))
+                .unwrap(),
             &groups_new,
         );
         groups_second_old_to_new.insert(second.clone(), second_new.clone());


### PR DESCRIPTION
Every so often I get surprised that this isn't already part of norad, so I threw something together.

I've made a slow version for people only doing a couple kerning lookups and don't want the overhead of generating the reverse group lookup, and then there's also a `ReverseGroupsLookup` struct now which does exactly what it says on the tin and can get used to accelerate kerning lookups.

There is currently no check that you are using the `ReverseGroupsLookup` that corresponds to the `Font` you're calling the lookup on, but I'll document that caveat when I throw together some documentation ("garbage in, garbage out" or words to that effect). I could tie the two together with ✨ fancy ✨ API/types if we wanted.

I also made constants for the kerning group prefixes and did a quick & dirty replace throughout the codebase, so I can let autocomplete do the work instead of worrying that I've typo'd. Bikeshedding encouraged, I don't like how long their names are.