### PR TITLE
Skip empty glyph names in groups

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -624,8 +624,7 @@ fn load_fontinfo(
 }
 
 fn load_groups(groups_path: &Path) -> Result<Groups, FontLoadError> {
-    let groups: Groups = plist::from_file(groups_path)
-        .map_err(|source| FontLoadError::ParsePlist { name: GROUPS_FILE, source })?;
+    let groups: Groups = crate::groups::deserialize_groups(groups_path)?;
     validate_groups(&groups).map_err(FontLoadError::InvalidGroups)?;
     Ok(groups)
 }

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,12 +1,40 @@
 use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
 
-use crate::error::GroupsValidationError;
+use crate::error::{FontLoadError, GroupsValidationError};
 use crate::Name;
 
 /// A map of group name to a list of glyph names.
 ///
 /// We use a [`BTreeMap`] because we need sorting for serialization.
 pub type Groups = BTreeMap<Name, Vec<Name>>;
+
+pub(crate) fn deserialize_groups<P: AsRef<Path>>(path: P) -> Result<Groups, FontLoadError> {
+    struct GroupsDeHelper(Groups);
+
+    impl<'de> serde::Deserialize<'de> for GroupsDeHelper {
+        fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            // Values decoded as Vec<String> so Name validation doesn't reject empty entries;
+            // we filter them out and parse the rest, using serde's error type throughout.
+            BTreeMap::<Name, Vec<String>>::deserialize(deserializer)?
+                .into_iter()
+                .map(|(k, v)| {
+                    let members = v
+                        .into_iter()
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.parse::<Name>().map_err(serde::de::Error::custom))
+                        .collect::<Result<_, _>>()?;
+                    Ok((k, members))
+                })
+                .collect::<Result<Groups, _>>()
+                .map(GroupsDeHelper)
+        }
+    }
+
+    plist::from_file::<_, GroupsDeHelper>(path.as_ref())
+        .map(|h| h.0)
+        .map_err(|source| FontLoadError::ParsePlist { name: "groups.plist", source })
+}
 
 /// Validate the contents of the groups.plist file according to the rules in the
 /// [Unified Font Object v3 specification for groups.plist](http://unifiedfontobject.org/versions/ufo3/groups.plist/#specification).
@@ -48,4 +76,15 @@ pub(crate) fn validate_groups(groups_map: &Groups) -> Result<(), GroupsValidatio
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_skip_empty_group_member() {
+        let group = deserialize_groups("testdata/groups_empty_entries.plist").unwrap();
+        assert_eq!(group.get("derpy_group").unwrap()[0], "hi");
+    }
 }

--- a/testdata/groups_empty_entries.plist
+++ b/testdata/groups_empty_entries.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>derpy_group</key>
+	<array>
+		<string></string>
+		<string>hi</string>
+	</array>
+	</dict>
+</plist>


### PR DESCRIPTION
This shows up in some real-world fonts, and doesn't seem like a helpful thing to error on.