### PR TITLE
Preserve newlines around notes

### DIFF
--- a/src/glyph/serialize.rs
+++ b/src/glyph/serialize.rs
@@ -121,15 +121,19 @@ impl Glyph {
         }
 
         if let Some(ref note) = self.note {
-            writer
-                .write_event(Event::Start(BytesStart::new("note")))
-                .map_err(GlifWriteError::Buffer)?;
-            writer
-                .write_event(Event::Text(BytesText::new(note)))
-                .map_err(GlifWriteError::Buffer)?;
-            writer
-                .write_event(Event::End(BytesEnd::new("note")))
-                .map_err(GlifWriteError::Buffer)?;
+            // fontTools's ufoLib will trim a note and wrap it in newlines
+            // before writing it out, do the same here. They are stripped out on
+            // load, like in ufoLib.
+            // https://github.com/fonttools/fonttools/blob/c5d5359f7ab9989306ee0ff5897d834d0f1b5c29/Lib/fontTools/ufoLib/glifLib.py#L949-L956
+            for event in [
+                Event::Start(BytesStart::new("note")),
+                Event::Text(BytesText::new("\n")),
+                Event::Text(BytesText::new(note.trim())),
+                Event::Text(BytesText::new("\n")),
+                Event::End(BytesEnd::new("note")),
+            ] {
+                writer.write_event(event).map_err(GlifWriteError::Buffer)?;
+            }
         }
 
         writer.write_event(Event::End(BytesEnd::new("glyph"))).map_err(GlifWriteError::Buffer)?;

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -94,7 +94,9 @@ fn serialize_with_default_formatting() {
 			<string>I am a creative professional :)</string>
 		</dict>
 	</lib>
-	<note>durp</note>
+	<note>
+durp
+</note>
 </glyph>
 "#
     );
@@ -125,7 +127,9 @@ fn serialize_with_custom_whitespace() {
       <string>I am a creative professional :)</string>
     </dict>
   </lib>
-  <note>durp</note>
+  <note>
+durp
+</note>
 </glyph>
 "#
     );
@@ -155,7 +159,9 @@ fn serialize_with_single_quote_style() {
 			<string>I am a creative professional :)</string>
 		</dict>
 	</lib>
-	<note>durp</note>
+	<note>
+durp
+</note>
 </glyph>
 "#
     );
@@ -187,7 +193,9 @@ fn serialize_with_custom_whitespace_and_single_quote_style() {
       <string>I am a creative professional :)</string>
     </dict>
   </lib>
-  <note>durp</note>
+  <note>
+durp
+</note>
 </glyph>
 "#
     );

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -408,7 +408,7 @@ fn roundtrip_note() {
     let buf = glyph.encode_xml().expect("encode failed");
     let buf = std::str::from_utf8(&buf).unwrap();
     assert!(
-        buf.find("<note>\n.notdef\n</note>").is_some(),
+        buf.contains("<note>\n.notdef\n</note>"),
         "Notes should have newlines like ufoLib does it."
     );
 }

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -392,10 +392,17 @@ fn if_no_one_uses_your_lib_is_it_broken() {
 }
 
 #[test]
-fn parse_note() {
+fn roundtrip_note() {
     let bytes = include_bytes!("../../testdata/note.glif");
     let glyph = parse_glyph(bytes).unwrap();
     assert_eq!(glyph.note, Some(".notdef".to_string()));
+
+    let buf = glyph.encode_xml().expect("encode failed");
+    let buf = std::str::from_utf8(&buf).unwrap();
+    assert!(
+        buf.find("<note>\n.notdef\n</note>").is_some(),
+        "Notes should have newlines like ufoLib does it."
+    );
 }
 
 #[test]

--- a/testdata/sample_period_normalized.glif
+++ b/testdata/sample_period_normalized.glif
@@ -122,5 +122,7 @@
 			</dict>
 		</dict>
 	</lib>
-	<note>I äm a note.</note>
+	<note>
+I äm a note.
+</note>
 </glyph>


### PR DESCRIPTION
@hoolean found an unfortunate roundtripping hindrance:

1. [ufoLib adds newlines around notes](https://github.com/fonttools/fonttools/blob/06e266ce70ec578d549c2df0e180a84d9323baf2/Lib/fontTools/ufoLib/glifLib.py#L949-L956)
2. [ufonormalizer preserves them](https://github.com/unified-font-object/ufoNormalizer/pull/86)
3. Norad strips them
4. ufonormalizer preserves that, too.

Norad trims all text in the .glif XML on read: https://github.com/linebender/norad/blob/fe37cc9427ce0f981fb63c6e83d9a60be264e9cb/src/glyph/parse.rs#L47

Maybe it should be more selective in its trimming, see https://docs.rs/quick-xml/latest/quick_xml/reader/struct.Config.html#method.trim_text.