### PR TITLE
Add FontSource trait for source-agnostic UFO loading

### DIFF
--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use crate::error::{StoreEntryError, StoreError};
-use crate::font_source::FontSource;
+use crate::font_source::{DirEntry, FontSource};
 
 /// A generic file store for UFO [data][spec_data] and [images][spec_images],
 /// mapping [`PathBuf`] keys to [`Vec<u8>`] values.
@@ -141,13 +141,14 @@ impl DataType for Data {
                 .list_dir(&dir_path)
                 .map_err(|e| StoreEntryError::new(dir_path.clone(), e.into()))?;
 
-            for (entry_name, is_dir) in entries {
-                let full_rel = dir_path.join(&entry_name);
-                if is_dir {
-                    dir_queue.push(full_rel);
-                } else {
-                    let key = full_rel.strip_prefix(source_root).unwrap().to_path_buf();
-                    paths.push(key);
+            for entry in entries {
+                match entry {
+                    DirEntry::Dir(name) => dir_queue.push(dir_path.join(name)),
+                    DirEntry::File(name) => {
+                        let full_rel = dir_path.join(name);
+                        let key = full_rel.strip_prefix(source_root).unwrap().to_path_buf();
+                        paths.push(key);
+                    }
                 }
             }
         }
@@ -190,14 +191,11 @@ impl DataType for Image {
             .list_dir(source_root)
             .map_err(|e| StoreEntryError::new(source_root.to_path_buf(), e.into()))?;
 
-        for (entry_name, is_dir) in entries {
-            let full_rel = source_root.join(&entry_name);
-            if is_dir {
+        for entry in entries {
+            match entry {
                 // The spec forbids directories.
-                return Err(StoreEntryError::new(full_rel, StoreError::Subdir));
-            } else {
-                let key = full_rel.strip_prefix(source_root).unwrap().to_path_buf();
-                paths.push(key);
+                DirEntry::Dir(name) => return Err(StoreEntryError::new(name, StoreError::Subdir)),
+                DirEntry::File(name) => paths.push(name),
             }
         }
 
@@ -806,21 +804,18 @@ mod tests {
 
     /// A FontSource backed by in-memory data, with `as_path() -> None`.
     /// This triggers the eager-loading branch in `Store::new`.
+    #[derive(Default)]
     struct MemorySource {
         files: HashMap<PathBuf, Vec<u8>>,
-        dirs: HashMap<PathBuf, Vec<(PathBuf, bool)>>,
+        dirs: HashMap<PathBuf, Vec<DirEntry>>,
     }
 
     impl MemorySource {
-        fn new() -> Self {
-            MemorySource { files: HashMap::new(), dirs: HashMap::new() }
-        }
-
         fn add_file(&mut self, path: impl Into<PathBuf>, data: Vec<u8>) {
             self.files.insert(path.into(), data);
         }
 
-        fn add_dir(&mut self, path: impl Into<PathBuf>, entries: Vec<(PathBuf, bool)>) {
+        fn add_dir(&mut self, path: impl Into<PathBuf>, entries: Vec<DirEntry>) {
             self.dirs.insert(path.into(), entries);
         }
     }
@@ -830,7 +825,7 @@ mod tests {
             self.files.get(path).cloned().map(Ok)
         }
 
-        fn list_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, std::io::Error> {
+        fn list_dir(&self, path: &Path) -> Result<Vec<DirEntry>, std::io::Error> {
             self.dirs.get(path).cloned().ok_or_else(|| {
                 std::io::Error::new(std::io::ErrorKind::NotFound, format!("{path:?} not found"))
             })
@@ -841,11 +836,9 @@ mod tests {
 
     #[test]
     fn data_eager_loading_from_memory_source() {
-        let mut source = MemorySource::new();
-        source.add_dir(
-            "data",
-            vec![(PathBuf::from("a.txt"), false), (PathBuf::from("b.txt"), false)],
-        );
+        let mut source = MemorySource::default();
+        source
+            .add_dir("data", vec![DirEntry::File("a.txt".into()), DirEntry::File("b.txt".into())]);
         source.add_file("data/a.txt", b"aaa".to_vec());
         source.add_file("data/b.txt", b"bbb".to_vec());
 
@@ -865,8 +858,8 @@ mod tests {
     #[test]
     fn image_eager_loading_from_memory_source() {
         let img = png_data(b"test");
-        let mut source = MemorySource::new();
-        source.add_dir("images", vec![(PathBuf::from("x.png"), false)]);
+        let mut source = MemorySource::default();
+        source.add_dir("images", vec![DirEntry::File("x.png".into())]);
         source.add_file("images/x.png", img.clone());
 
         let store = ImageStore::new(&source).unwrap();
@@ -879,8 +872,8 @@ mod tests {
 
     #[test]
     fn eager_load_invalid_image_fails_at_construction() {
-        let mut source = MemorySource::new();
-        source.add_dir("images", vec![(PathBuf::from("bad.png"), false)]);
+        let mut source = MemorySource::default();
+        source.add_dir("images", vec![DirEntry::File("bad.png".into())]);
         source.add_file("images/bad.png", b"not a png".to_vec());
 
         // Eager loading validates during construction, so this should fail.
@@ -890,10 +883,9 @@ mod tests {
 
     #[test]
     fn eager_load_nested_data_from_memory_source() {
-        let mut source = MemorySource::new();
-        source
-            .add_dir("data", vec![(PathBuf::from("top.txt"), false), (PathBuf::from("sub"), true)]);
-        source.add_dir("data/sub", vec![(PathBuf::from("deep.txt"), false)]);
+        let mut source = MemorySource::default();
+        source.add_dir("data", vec![DirEntry::File("top.txt".into()), DirEntry::Dir("sub".into())]);
+        source.add_dir("data/sub", vec![DirEntry::File("deep.txt".into())]);
         source.add_file("data/top.txt", b"top".to_vec());
         source.add_file("data/sub/deep.txt", b"deep".to_vec());
 

--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -8,15 +8,15 @@ use std::{
 };
 
 use crate::error::{StoreEntryError, StoreError};
+use crate::font_source::FontSource;
 
 /// A generic file store for UFO [data][spec_data] and [images][spec_images],
 /// mapping [`PathBuf`] keys to [`Vec<u8>`] values.
 ///
 /// The store provides a basic HashMap-like interface for checking data in and out.
-/// If initialized from disk, data can be loaded eagerly or lazily, as in, on access.
-/// It will remember the root data directory for this purpose. This complicates the
-/// accessor methods somewhat, because 1. access can fail with an IO error and 2.
-/// insertion can fail. Data is wrapped in a [`std::sync::Arc`] to help on-demand loading.
+/// If initialized from a filesystem-backed source, data is loaded lazily on access.
+/// Otherwise, data is loaded eagerly during construction.
+/// Data is wrapped in a [`std::sync::Arc`] to help on-demand loading.
 ///
 /// Note that it tracks files, not directories. Data paths you insert must not have
 /// any existing path in the store as an ancestor, or you would nest a file under a
@@ -67,7 +67,9 @@ use crate::error::{StoreEntryError, StoreError};
 #[derive(Debug, Clone)]
 pub struct Store<T> {
     items: HashMap<PathBuf, RefCell<Item>>,
-    ufo_root: PathBuf,
+    /// When `Some`, the source is filesystem-backed and lazy loading is used.
+    /// When `None`, all items were eagerly loaded during construction.
+    ufo_root: Option<PathBuf>,
     impl_type: T,
 }
 
@@ -90,8 +92,8 @@ pub type ImageStore = Store<Image>;
 /// Defines custom behavior for data and images stores.
 #[doc(hidden)]
 pub trait DataType: Default {
-    fn try_list_contents(&self, ufo_root: &Path) -> Result<Vec<PathBuf>, StoreEntryError>;
-    fn try_load_item(&self, ufo_root: &Path, path: &Path) -> Result<Vec<u8>, StoreError>;
+    fn try_list_contents(&self, source: &dyn FontSource) -> Result<Vec<PathBuf>, StoreEntryError>;
+    fn try_load_item(&self, source: &dyn FontSource, path: &Path) -> Result<Vec<u8>, StoreError>;
     fn validate_entry(
         &self,
         path: &Path,
@@ -116,7 +118,7 @@ where
     T: Default,
 {
     fn default() -> Self {
-        Self { items: Default::default(), ufo_root: Default::default(), impl_type: T::default() }
+        Self { items: Default::default(), ufo_root: None, impl_type: T::default() }
     }
 }
 
@@ -129,29 +131,23 @@ impl<T: DataType> PartialEq for Store<T> {
 }
 
 impl DataType for Data {
-    fn try_list_contents(&self, ufo_root: &Path) -> Result<Vec<PathBuf>, StoreEntryError> {
-        let source_root = ufo_root.join(crate::font::DATA_DIR);
+    fn try_list_contents(&self, source: &dyn FontSource) -> Result<Vec<PathBuf>, StoreEntryError> {
+        let source_root = Path::new(crate::font::DATA_DIR);
         let mut paths = Vec::new();
 
-        let mut dir_queue: Vec<PathBuf> = vec![source_root.clone()];
+        let mut dir_queue: Vec<PathBuf> = vec![source_root.to_path_buf()];
         while let Some(dir_path) = dir_queue.pop() {
-            for entry in std::fs::read_dir(&dir_path)
-                .map_err(|e| StoreEntryError::new(dir_path.clone(), e.into()))?
-            {
-                let entry = entry.map_err(|e| StoreEntryError::new(dir_path.clone(), e.into()))?;
-                let path = entry.path();
-                let attributes = entry
-                    .metadata() // "will not traverse symlinks"
-                    .map_err(|e| StoreEntryError::new(entry.path(), e.into()))?;
+            let entries = source
+                .list_dir(&dir_path)
+                .map_err(|e| StoreEntryError::new(dir_path.clone(), e.into()))?;
 
-                if attributes.is_file() {
-                    let key = path.strip_prefix(&source_root).unwrap().to_path_buf();
-                    paths.push(key);
-                } else if attributes.is_dir() {
-                    dir_queue.push(path);
+            for (entry_name, is_dir) in entries {
+                let full_rel = dir_path.join(&entry_name);
+                if is_dir {
+                    dir_queue.push(full_rel);
                 } else {
-                    // The spec forbids symlinks.
-                    return Err(StoreEntryError::new(path, StoreError::NotPlainFileOrDir));
+                    let key = full_rel.strip_prefix(source_root).unwrap().to_path_buf();
+                    paths.push(key);
                 }
             }
         }
@@ -159,8 +155,8 @@ impl DataType for Data {
         Ok(paths)
     }
 
-    fn try_load_item(&self, ufo_root: &Path, path: &Path) -> Result<Vec<u8>, StoreError> {
-        std::fs::read(ufo_root.join(crate::font::DATA_DIR).join(path)).map_err(|e| e.into())
+    fn try_load_item(&self, source: &dyn FontSource, path: &Path) -> Result<Vec<u8>, StoreError> {
+        source.read(&Path::new(crate::font::DATA_DIR).join(path)).map_err(Into::into)
     }
 
     fn validate_entry(
@@ -186,36 +182,30 @@ impl DataType for Data {
 }
 
 impl DataType for Image {
-    fn try_list_contents(&self, ufo_root: &Path) -> Result<Vec<PathBuf>, StoreEntryError> {
-        let source_root = ufo_root.join(crate::font::IMAGES_DIR);
+    fn try_list_contents(&self, source: &dyn FontSource) -> Result<Vec<PathBuf>, StoreEntryError> {
+        let source_root = Path::new(crate::font::IMAGES_DIR);
         let mut paths = Vec::new();
 
-        for entry in std::fs::read_dir(&source_root)
-            .map_err(|e| StoreEntryError::new(source_root.clone(), e.into()))?
-        {
-            let entry = entry.map_err(|e| StoreEntryError::new(source_root.clone(), e.into()))?;
-            let path = entry.path();
-            let attributes = entry
-                .metadata() // "will not traverse symlinks"
-                .map_err(|e| StoreEntryError::new(path.clone(), e.into()))?;
+        let entries = source
+            .list_dir(source_root)
+            .map_err(|e| StoreEntryError::new(source_root.to_path_buf(), e.into()))?;
 
-            if attributes.is_file() {
-                let key = path.strip_prefix(&source_root).unwrap().to_path_buf();
-                paths.push(key);
-            } else if attributes.is_dir() {
-                // The spec forbids directories...
-                return Err(StoreEntryError::new(path, StoreError::Subdir));
+        for (entry_name, is_dir) in entries {
+            let full_rel = source_root.join(&entry_name);
+            if is_dir {
+                // The spec forbids directories.
+                return Err(StoreEntryError::new(full_rel, StoreError::Subdir));
             } else {
-                // ... and symlinks.
-                return Err(StoreEntryError::new(path, StoreError::NotPlainFile));
+                let key = full_rel.strip_prefix(source_root).unwrap().to_path_buf();
+                paths.push(key);
             }
         }
 
         Ok(paths)
     }
 
-    fn try_load_item(&self, ufo_root: &Path, path: &Path) -> Result<Vec<u8>, StoreError> {
-        std::fs::read(ufo_root.join(crate::font::IMAGES_DIR).join(path)).map_err(|e| e.into())
+    fn try_load_item(&self, source: &dyn FontSource, path: &Path) -> Result<Vec<u8>, StoreError> {
+        source.read(&Path::new(crate::font::IMAGES_DIR).join(path)).map_err(Into::into)
     }
 
     fn validate_entry(
@@ -243,12 +233,28 @@ impl DataType for Image {
 }
 
 impl<T: DataType> Store<T> {
-    pub(crate) fn new(ufo_root: &Path) -> Result<Self, StoreEntryError> {
+    pub(crate) fn new(source: &dyn FontSource) -> Result<Self, StoreEntryError> {
         let impl_type = T::default();
-        let dir_contents = impl_type.try_list_contents(ufo_root)?;
-        let items =
-            dir_contents.into_iter().map(|path| (path, RefCell::new(Item::default()))).collect();
-        Ok(Store { items, ufo_root: ufo_root.to_path_buf(), impl_type })
+        let paths = impl_type.try_list_contents(source)?;
+
+        if let Some(ufo_root) = source.as_path() {
+            // Filesystem-backed: record paths as NotLoaded, defer reading to access time.
+            let items = paths.into_iter().map(|p| (p, RefCell::new(Item::NotLoaded))).collect();
+            Ok(Store { items, ufo_root: Some(ufo_root.to_path_buf()), impl_type })
+        } else {
+            // Non-filesystem: eagerly load everything now.
+            let mut items = HashMap::new();
+            for path in paths {
+                let data = impl_type
+                    .try_load_item(source, &path)
+                    .map_err(|e| StoreEntryError::new(path.clone(), e))?;
+                impl_type
+                    .validate_entry(&path, &items, &data)
+                    .map_err(|e| StoreEntryError::new(path.clone(), e))?;
+                items.insert(path, RefCell::new(Item::Loaded(data.into())));
+            }
+            Ok(Store { items, ufo_root: None, impl_type })
+        }
     }
 
     /// Returns `true` if the store contains data for the specified path.
@@ -280,12 +286,12 @@ impl<T: DataType> Store<T> {
     pub fn get(&self, path: &Path) -> Option<Result<Arc<[u8]>, StoreError>> {
         let cell = self.items.get(path)?;
 
-        // If item isn't loaded, try to load it, saving the data or the error
+        // If item isn't loaded, try to load it, saving the data or the error.
         // NOTE: Figure out whether the item is unloaded and immediately drop the
         //       read borrow so we can take the write borrow. Otherwise, we panic.
         if matches!(*cell.borrow(), Item::NotLoaded) {
-            *cell.borrow_mut() =
-                Self::load_item(&self.impl_type, &self.ufo_root, path, &self.items);
+            let ufo_root = self.ufo_root.as_deref().expect("NotLoaded item without ufo_root");
+            *cell.borrow_mut() = Self::load_item(&self.impl_type, &ufo_root, path, &self.items);
         }
 
         match &*cell.borrow() {
@@ -297,11 +303,11 @@ impl<T: DataType> Store<T> {
 
     fn load_item(
         impl_type: &T,
-        ufo_root: &Path,
+        source: &dyn FontSource,
         path: &Path,
         items: &HashMap<PathBuf, RefCell<Item>>,
     ) -> Item {
-        match impl_type.try_load_item(ufo_root, path) {
+        match impl_type.try_load_item(source, path) {
             Ok(data) => match impl_type.validate_entry(path, items, &data) {
                 Ok(_) => Item::Loaded(data.into()),
                 Err(e) => Item::Error(e),
@@ -473,7 +479,8 @@ mod tests {
 
     #[test]
     fn lazy_data_loading() {
-        let mut store = DataStore::new(UFO_DATA_IMAGE_TEST_PATH.as_ref()).unwrap();
+        let source = Path::new(UFO_DATA_IMAGE_TEST_PATH);
+        let mut store = DataStore::new(&source).unwrap();
 
         let mut paths: Vec<&Path> = store.keys().map(|p| p.as_ref()).collect();
         paths.sort();
@@ -522,7 +529,8 @@ mod tests {
 
     #[test]
     fn lazy_image_loading() {
-        let mut store = ImageStore::new(UFO_DATA_IMAGE_TEST_PATH.as_ref()).unwrap();
+        let source = Path::new(UFO_DATA_IMAGE_TEST_PATH);
+        let mut store = ImageStore::new(&source).unwrap();
 
         assert!(!store.is_empty());
         let mut paths: Vec<_> = store.keys().collect();
@@ -546,9 +554,9 @@ mod tests {
 
     #[test]
     fn store_equality() {
-        let ufo_path = UFO_DATA_IMAGE_TEST_PATH.as_ref();
-        let store1 = DataStore::new(ufo_path).unwrap();
-        let store2 = DataStore::new(ufo_path).unwrap();
+        let source = Path::new(UFO_DATA_IMAGE_TEST_PATH);
+        let store1 = DataStore::new(&source).unwrap();
+        let store2 = DataStore::new(&source).unwrap();
 
         assert_eq!(store1, store2);
     }
@@ -594,7 +602,7 @@ mod tests {
     #[test]
     fn data_items_not_loaded_until_accessed() {
         let dir = make_data_dir(&[("file1.txt", b"hello"), ("file2.txt", b"world")]);
-        let store = DataStore::new(dir.path()).unwrap();
+        let store = DataStore::new(&dir.path()).unwrap();
 
         assert_eq!(store.len(), 2);
         for cell in store.items.values() {
@@ -619,7 +627,7 @@ mod tests {
         let img1 = png_data(b"img1");
         let img2 = png_data(b"img2");
         let dir = make_images_dir(&[("a.png", &img1), ("b.png", &img2)]);
-        let store = ImageStore::new(dir.path()).unwrap();
+        let store = ImageStore::new(&dir.path()).unwrap();
 
         assert_eq!(store.len(), 2);
         for cell in store.items.values() {
@@ -635,7 +643,7 @@ mod tests {
     #[test]
     fn contains_key_does_not_trigger_load() {
         let dir = make_data_dir(&[("file.txt", b"data")]);
-        let store = DataStore::new(dir.path()).unwrap();
+        let store = DataStore::new(&dir.path()).unwrap();
 
         assert!(store.contains_key(Path::new("file.txt")));
         assert!(!store.contains_key(Path::new("nope.txt")));
@@ -649,7 +657,7 @@ mod tests {
     #[test]
     fn iter_forces_loading_all_items() {
         let dir = make_data_dir(&[("a.txt", b"aaa"), ("b.txt", b"bbb")]);
-        let store = DataStore::new(dir.path()).unwrap();
+        let store = DataStore::new(&dir.path()).unwrap();
 
         for cell in store.items.values() {
             assert!(matches!(*cell.borrow(), Item::NotLoaded));
@@ -668,7 +676,7 @@ mod tests {
     #[test]
     fn data_error_cached_on_load_failure() {
         let dir = make_data_dir(&[("ephemeral.txt", b"will vanish")]);
-        let store = DataStore::new(dir.path()).unwrap();
+        let store = DataStore::new(&dir.path()).unwrap();
 
         assert!(store.contains_key(Path::new("ephemeral.txt")));
 
@@ -691,7 +699,7 @@ mod tests {
     #[test]
     fn image_invalid_png_returns_error_on_access() {
         let dir = make_images_dir(&[("bad.png", b"not a png at all")]);
-        let store = ImageStore::new(dir.path()).unwrap();
+        let store = ImageStore::new(&dir.path()).unwrap();
 
         assert!(store.contains_key(Path::new("bad.png")));
 
@@ -706,7 +714,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::create_dir(dir.path().join(crate::font::DATA_DIR)).unwrap();
 
-        let store = DataStore::new(dir.path()).unwrap();
+        let store = DataStore::new(&dir.path()).unwrap();
         assert!(store.is_empty());
         assert_eq!(store.len(), 0);
         assert_eq!(store.keys().count(), 0);
@@ -717,7 +725,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::create_dir(dir.path().join(crate::font::IMAGES_DIR)).unwrap();
 
-        let store = ImageStore::new(dir.path()).unwrap();
+        let store = ImageStore::new(&dir.path()).unwrap();
         assert!(store.is_empty());
         assert_eq!(store.len(), 0);
     }
@@ -725,13 +733,13 @@ mod tests {
     #[test]
     fn missing_data_directory_is_error() {
         let dir = TempDir::new().unwrap();
-        assert!(DataStore::new(dir.path()).is_err());
+        assert!(DataStore::new(&dir.path()).is_err());
     }
 
     #[test]
     fn missing_images_directory_is_error() {
         let dir = TempDir::new().unwrap();
-        assert!(ImageStore::new(dir.path()).is_err());
+        assert!(ImageStore::new(&dir.path()).is_err());
     }
 
     // --- Nested data directories ---
@@ -743,7 +751,7 @@ mod tests {
             ("a/middle.txt", b"middle"),
             ("a/b/c/deep.txt", b"deep"),
         ]);
-        let store = DataStore::new(dir.path()).unwrap();
+        let store = DataStore::new(&dir.path()).unwrap();
 
         assert_eq!(store.len(), 3);
         assert!(store.contains_key(Path::new("top.txt")));
@@ -760,7 +768,7 @@ mod tests {
     #[test]
     fn data_store_clear_resets() {
         let dir = make_data_dir(&[("a.txt", b"aaa"), ("b.txt", b"bbb")]);
-        let mut store = DataStore::new(dir.path()).unwrap();
+        let mut store = DataStore::new(&dir.path()).unwrap();
 
         assert_eq!(store.len(), 2);
         store.clear();
@@ -774,16 +782,16 @@ mod tests {
         let dir1 = make_data_dir(&[("a.txt", b"aaa")]);
         let dir2 = make_data_dir(&[("b.txt", b"bbb")]);
 
-        let store1 = DataStore::new(dir1.path()).unwrap();
-        let store2 = DataStore::new(dir2.path()).unwrap();
+        let store1 = DataStore::new(&dir1.path()).unwrap();
+        let store2 = DataStore::new(&dir2.path()).unwrap();
         assert_ne!(store1, store2);
     }
 
     #[test]
     fn equality_ignores_load_state() {
         let dir = make_data_dir(&[("x.txt", b"xxx")]);
-        let store1 = DataStore::new(dir.path()).unwrap();
-        let store2 = DataStore::new(dir.path()).unwrap();
+        let store1 = DataStore::new(&dir.path()).unwrap();
+        let store2 = DataStore::new(&dir.path()).unwrap();
 
         // Load in store1 but not store2.
         let _ = store1.get(Path::new("x.txt"));
@@ -792,5 +800,114 @@ mod tests {
 
         // Equality is path-based, so they're still equal.
         assert_eq!(store1, store2);
+    }
+
+    // --- MemorySource for testing eager (non-filesystem) loading ---
+
+    /// A FontSource backed by in-memory data, with `as_path() -> None`.
+    /// This triggers the eager-loading branch in `Store::new`.
+    struct MemorySource {
+        files: HashMap<PathBuf, Vec<u8>>,
+        dirs: HashMap<PathBuf, Vec<(PathBuf, bool)>>,
+    }
+
+    impl MemorySource {
+        fn new() -> Self {
+            MemorySource { files: HashMap::new(), dirs: HashMap::new() }
+        }
+
+        fn add_file(&mut self, path: impl Into<PathBuf>, data: Vec<u8>) {
+            self.files.insert(path.into(), data);
+        }
+
+        fn add_dir(&mut self, path: impl Into<PathBuf>, entries: Vec<(PathBuf, bool)>) {
+            self.dirs.insert(path.into(), entries);
+        }
+    }
+
+    impl FontSource for MemorySource {
+        fn try_read(&self, path: &Path) -> Option<Result<Vec<u8>, std::io::Error>> {
+            self.files.get(path).cloned().map(Ok)
+        }
+
+        fn list_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, std::io::Error> {
+            self.dirs.get(path).cloned().ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::NotFound, format!("{path:?} not found"))
+            })
+        }
+    }
+
+    // --- Eager loading tests ---
+
+    #[test]
+    fn data_eager_loading_from_memory_source() {
+        let mut source = MemorySource::new();
+        source.add_dir(
+            "data",
+            vec![(PathBuf::from("a.txt"), false), (PathBuf::from("b.txt"), false)],
+        );
+        source.add_file("data/a.txt", b"aaa".to_vec());
+        source.add_file("data/b.txt", b"bbb".to_vec());
+
+        let store = DataStore::new(&source).unwrap();
+
+        // All items should be Loaded immediately (no lazy loading).
+        assert_eq!(store.len(), 2);
+        assert!(store.ufo_root.is_none());
+        for cell in store.items.values() {
+            assert!(matches!(*cell.borrow(), Item::Loaded(_)));
+        }
+
+        assert_eq!(&*store.get(Path::new("a.txt")).unwrap().unwrap(), b"aaa");
+        assert_eq!(&*store.get(Path::new("b.txt")).unwrap().unwrap(), b"bbb");
+    }
+
+    #[test]
+    fn image_eager_loading_from_memory_source() {
+        let img = png_data(b"test");
+        let mut source = MemorySource::new();
+        source.add_dir("images", vec![(PathBuf::from("x.png"), false)]);
+        source.add_file("images/x.png", img.clone());
+
+        let store = ImageStore::new(&source).unwrap();
+
+        assert_eq!(store.len(), 1);
+        assert!(store.ufo_root.is_none());
+        assert!(matches!(*store.items.get(Path::new("x.png")).unwrap().borrow(), Item::Loaded(_)));
+        assert_eq!(&*store.get(Path::new("x.png")).unwrap().unwrap(), &img[..]);
+    }
+
+    #[test]
+    fn eager_load_invalid_image_fails_at_construction() {
+        let mut source = MemorySource::new();
+        source.add_dir("images", vec![(PathBuf::from("bad.png"), false)]);
+        source.add_file("images/bad.png", b"not a png".to_vec());
+
+        // Eager loading validates during construction, so this should fail.
+        let result = ImageStore::new(&source);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn eager_load_nested_data_from_memory_source() {
+        let mut source = MemorySource::new();
+        source
+            .add_dir("data", vec![(PathBuf::from("top.txt"), false), (PathBuf::from("sub"), true)]);
+        source.add_dir("data/sub", vec![(PathBuf::from("deep.txt"), false)]);
+        source.add_file("data/top.txt", b"top".to_vec());
+        source.add_file("data/sub/deep.txt", b"deep".to_vec());
+
+        let store = DataStore::new(&source).unwrap();
+
+        assert_eq!(store.len(), 2);
+        assert_eq!(&*store.get(Path::new("top.txt")).unwrap().unwrap(), b"top");
+        assert_eq!(&*store.get(Path::new("sub/deep.txt")).unwrap().unwrap(), b"deep");
+    }
+
+    #[test]
+    fn closure_source_returns_unsupported() {
+        let source = |_path: &Path| -> Option<Result<Vec<u8>, std::io::Error>> { None };
+        let result = DataStore::new(&source);
+        assert!(result.is_err());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -162,6 +162,9 @@ pub enum LayerLoadError {
         /// The underlying error.
         source: GlifLoadError,
     },
+    /// An [`std::io::Error`].
+    #[error("failed to read layer data")]
+    Io(#[from] IoError),
     /// Could not find the layer's contents.plist.
     #[error("cannot find the contents.plist file")]
     MissingContentsFile,
@@ -188,6 +191,9 @@ pub enum FontInfoLoadError {
     /// The fontinfo.plist file contains invalid data.
     #[error("fontinfo.plist contains invalid data: {0}")]
     InvalidData(FontInfoErrorKind),
+    /// An [`std::io::Error`].
+    #[error("failed to read fontinfo.plist file")]
+    Io(#[from] IoError),
     /// Could not parse the UFO's fontinfo.plist.
     #[error("failed to parse fontinfo.plist file")]
     ParsePlist(#[source] PlistError),
@@ -302,6 +308,13 @@ impl StoreEntryError {
     /// Returns a new [`StoreEntryError`].
     pub(crate) fn new(path: PathBuf, source: StoreError) -> Self {
         Self { path, source }
+    }
+
+    /// Returns `true` if the store could not be populated because the source
+    /// does not support directory listing or the directory does not exist.
+    pub(crate) fn is_missing_or_unsupported(&self) -> bool {
+        matches!(&self.source, StoreError::Io(e)
+            if matches!(e.kind(), std::io::ErrorKind::Unsupported | std::io::ErrorKind::NotFound))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -163,7 +163,7 @@ pub enum LayerLoadError {
         source: GlifLoadError,
     },
     /// An [`std::io::Error`].
-    #[error("failed to read layer data")]
+    #[error("failed to read layer data: '{0}'")]
     Io(#[from] IoError),
     /// Could not find the layer's contents.plist.
     #[error("cannot find the contents.plist file")]
@@ -192,7 +192,7 @@ pub enum FontInfoLoadError {
     #[error("fontinfo.plist contains invalid data: {0}")]
     InvalidData(FontInfoErrorKind),
     /// An [`std::io::Error`].
-    #[error("failed to read fontinfo.plist file")]
+    #[error("failed to read fontinfo.plist file: '{0}'")]
     Io(#[from] IoError),
     /// Could not parse the UFO's fontinfo.plist.
     #[error("failed to parse fontinfo.plist file")]
@@ -313,8 +313,11 @@ impl StoreEntryError {
     /// Returns `true` if the store could not be populated because the source
     /// does not support directory listing or the directory does not exist.
     pub(crate) fn is_missing_or_unsupported(&self) -> bool {
-        matches!(&self.source, StoreError::Io(e)
-            if matches!(e.kind(), std::io::ErrorKind::Unsupported | std::io::ErrorKind::NotFound))
+        if let StoreError::Io(e) = &self.source {
+            matches!(e.kind(), std::io::ErrorKind::Unsupported | std::io::ErrorKind::NotFound)
+        } else {
+            false
+        }
     }
 }
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -12,6 +12,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::data_request::LayerFilter;
 use crate::datastore::{DataStore, ImageStore};
 use crate::error::{FontLoadError, FontWriteError};
+use crate::font_source::FontSource;
 use crate::fontinfo::FontInfo;
 use crate::glyph::Glyph;
 use crate::groups::{
@@ -220,58 +221,96 @@ impl Font {
             return Err(FontLoadError::UfoNotADir);
         }
 
-        let meta_path = path.join(METAINFO_FILE);
-        if !meta_path.exists() {
-            return Err(FontLoadError::MissingMetaInfoFile);
-        }
-        let mut meta: MetaInfo = plist::from_file(&meta_path)
+        Self::load_from_source(&request, &path)
+    }
+
+    /// Returns a [`Font`] loaded from the given [`FontSource`].
+    ///
+    /// This allows loading a UFO from any source that implements the
+    /// [`FontSource`] trait, such as an in-memory store or a zip archive.
+    ///
+    /// Data and image stores are populated if the source supports directory
+    /// enumeration (i.e. [`FontSource::list_dir`]). Sources that do not
+    /// support enumeration will have empty data/image stores.
+    pub fn load_from_source(
+        request: &DataRequest,
+        source: &dyn FontSource,
+    ) -> Result<Font, FontLoadError> {
+        let meta_path = Path::new(METAINFO_FILE);
+        let meta_data = source
+            .try_read(meta_path)
+            .ok_or(FontLoadError::MissingMetaInfoFile)?
+            .map_err(FontLoadError::AccessUfoDir)?;
+        let mut meta: MetaInfo = plist::from_bytes(&meta_data)
             .map_err(|source| FontLoadError::ParsePlist { name: METAINFO_FILE, source })?;
 
-        let lib_path = path.join(LIB_FILE);
-        let mut lib =
-            if request.lib && lib_path.exists() { load_lib(&lib_path)? } else { Plist::new() };
-
-        let fontinfo_path = path.join(FONTINFO_FILE);
-        let mut font_info = if fontinfo_path.exists() {
-            load_fontinfo(&fontinfo_path, &meta, &mut lib)?
+        let lib_path = Path::new(LIB_FILE);
+        let mut lib = if request.lib {
+            match source.try_read(lib_path) {
+                Some(data) => load_lib(&data.map_err(FontLoadError::AccessUfoDir)?)?,
+                None => Plist::new(),
+            }
         } else {
-            Default::default()
+            Plist::new()
         };
 
-        let groups_path = path.join(GROUPS_FILE);
-        let groups = if request.groups && groups_path.exists() {
-            Some(load_groups(&groups_path)?)
-        } else {
-            None
-        };
-
-        let kerning_path = path.join(KERNING_FILE);
-        let kerning = if request.kerning && kerning_path.exists() {
-            Some(load_kerning(&kerning_path)?)
+        // Keep the raw lib bytes around for the v1 upconversion path.
+        let lib_bytes = if meta.format_version == FormatVersion::V1 {
+            match source.try_read(lib_path) {
+                Some(data) => Some(data.map_err(FontLoadError::AccessUfoDir)?),
+                None => None,
+            }
         } else {
             None
         };
 
-        let features_path = path.join(FEATURES_FILE);
-        let mut features = if request.features && features_path.exists() {
-            load_features(&features_path)?
+        let fontinfo_path = Path::new(FONTINFO_FILE);
+        let mut font_info = match source.try_read(fontinfo_path) {
+            Some(data) => {
+                load_fontinfo(&data.map_err(FontLoadError::AccessUfoDir)?, &meta, &mut lib)?
+            }
+            None => Default::default(),
+        };
+
+        let groups_path = Path::new(GROUPS_FILE);
+        let groups = if request.groups {
+            match source.try_read(groups_path) {
+                Some(data) => Some(load_groups(&data.map_err(FontLoadError::AccessUfoDir)?)?),
+                None => None,
+            }
+        } else {
+            None
+        };
+
+        let kerning_path = Path::new(KERNING_FILE);
+        let kerning = if request.kerning {
+            match source.try_read(kerning_path) {
+                Some(data) => Some(load_kerning(&data.map_err(FontLoadError::AccessUfoDir)?)?),
+                None => None,
+            }
+        } else {
+            None
+        };
+
+        let features_path = Path::new(FEATURES_FILE);
+        let mut features = if request.features {
+            match source.try_read(features_path) {
+                Some(data) => {
+                    let data = data.map_err(FontLoadError::FeatureFile)?;
+                    String::from_utf8(data).map_err(|e| {
+                        FontLoadError::FeatureFile(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            e,
+                        ))
+                    })?
+                }
+                None => Default::default(),
+            }
         } else {
             Default::default()
         };
 
-        let layers = load_layer_set(path, &meta, &request.layers)?;
-
-        let data = if request.data && path.join(DATA_DIR).exists() {
-            DataStore::new(path).map_err(FontLoadError::DataStore)?
-        } else {
-            Default::default()
-        };
-
-        let images = if request.images && path.join(IMAGES_DIR).exists() {
-            ImageStore::new(path).map_err(FontLoadError::ImagesStore)?
-        } else {
-            Default::default()
-        };
+        let layers = load_layer_set(source, &meta, &request.layers)?;
 
         // Upconvert UFO v1 or v2 kerning data if necessary. To upconvert, we need at least
         // a groups.plist file, while a kerning.plist is optional.
@@ -290,9 +329,9 @@ impl Font {
 
         // The v1 format stores some Postscript hinting related data in the lib,
         // which we only import into fontinfo if we're reading a v1 UFO.
-        if meta.format_version == FormatVersion::V1 && lib_path.exists() {
+        if let Some(lib_bytes) = lib_bytes {
             if let Some(features_upgraded) =
-                upconversion::upconvert_ufov1_robofab_data(&lib_path, &mut lib, &mut font_info)?
+                upconversion::upconvert_ufov1_robofab_data(&lib_bytes, &mut lib, &mut font_info)?
             {
                 if !features_upgraded.is_empty() {
                     features = features_upgraded;
@@ -301,6 +340,26 @@ impl Font {
         }
 
         meta.format_version = FormatVersion::V3;
+
+        let data = if request.data {
+            match DataStore::new(source) {
+                Ok(store) => store,
+                Err(e) if e.is_missing_or_unsupported() => Default::default(),
+                Err(e) => return Err(FontLoadError::DataStore(e)),
+            }
+        } else {
+            Default::default()
+        };
+
+        let images = if request.images {
+            match ImageStore::new(source) {
+                Ok(store) => store,
+                Err(e) if e.is_missing_or_unsupported() => Default::default(),
+                Err(e) => return Err(FontLoadError::ImagesStore(e)),
+            }
+        } else {
+            Default::default()
+        };
 
         Ok(Font {
             layers,
@@ -655,50 +714,47 @@ impl Font {
     }
 }
 
-fn load_lib(lib_path: &Path) -> Result<plist::Dictionary, FontLoadError> {
-    plist::Value::from_file(lib_path)
+fn load_lib(data: &[u8]) -> Result<plist::Dictionary, FontLoadError> {
+    plist::Value::from_reader_xml(std::io::Cursor::new(data))
         .map_err(|source| FontLoadError::ParsePlist { name: LIB_FILE, source })?
         .into_dictionary()
         .ok_or(FontLoadError::LibFileMustBeDictionary)
 }
 
 fn load_fontinfo(
-    fontinfo_path: &Path,
+    data: &[u8],
     meta: &MetaInfo,
     lib: &mut plist::Dictionary,
 ) -> Result<FontInfo, FontLoadError> {
-    let font_info: FontInfo = FontInfo::from_file(fontinfo_path, meta.format_version, lib)
-        .map_err(FontLoadError::FontInfo)?;
+    let font_info: FontInfo =
+        FontInfo::from_bytes(data, meta.format_version, lib).map_err(FontLoadError::FontInfo)?;
     Ok(font_info)
 }
 
-fn load_groups(groups_path: &Path) -> Result<Groups, FontLoadError> {
-    let groups: Groups = crate::groups::deserialize_groups(groups_path)?;
+fn load_groups(data: &[u8]) -> Result<Groups, FontLoadError> {
+    let groups: Groups = crate::groups::deserialize_groups(data)?;
     validate_groups(&groups).map_err(FontLoadError::InvalidGroups)?;
     Ok(groups)
 }
 
-fn load_kerning(kerning_path: &Path) -> Result<Kerning, FontLoadError> {
-    let kerning: Kerning = plist::from_file(kerning_path)
+fn load_kerning(data: &[u8]) -> Result<Kerning, FontLoadError> {
+    let kerning: Kerning = plist::from_bytes(data)
         .map_err(|source| FontLoadError::ParsePlist { name: KERNING_FILE, source })?;
     Ok(kerning)
 }
 
-fn load_features(features_path: &Path) -> Result<String, FontLoadError> {
-    let features = fs::read_to_string(features_path).map_err(FontLoadError::FeatureFile)?;
-    Ok(features)
-}
-
 fn load_layer_set(
-    ufo_path: &Path,
+    source: &dyn FontSource,
     meta: &MetaInfo,
     filter: &LayerFilter,
 ) -> Result<LayerContents, FontLoadError> {
-    let layercontents_path = ufo_path.join(LAYER_CONTENTS_FILE);
-    if meta.format_version == FormatVersion::V3 && !layercontents_path.exists() {
-        return Err(FontLoadError::MissingLayerContentsFile);
+    if meta.format_version == FormatVersion::V3 {
+        let layercontents_path = Path::new(LAYER_CONTENTS_FILE);
+        if source.try_read(layercontents_path).is_none() {
+            return Err(FontLoadError::MissingLayerContentsFile);
+        }
     }
-    LayerContents::load(ufo_path, filter)
+    LayerContents::load(source, filter)
 }
 
 #[cfg(test)]

--- a/src/font_source.rs
+++ b/src/font_source.rs
@@ -1,0 +1,113 @@
+//! The [`FontSource`] trait for source-agnostic UFO loading.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// A source of UFO file data for loading.
+///
+/// This trait abstracts over how UFO files are accessed, allowing fonts to be
+/// loaded from directories on disk, zip archives, in-memory stores, or any
+/// other source.
+///
+/// Paths passed to methods are always relative to the UFO root, e.g.
+/// `"metainfo.plist"`, `"glyphs/contents.plist"`, `"glyphs/A_.glif"`.
+///
+/// A filesystem directory (a `&Path`) implements this trait directly, so you
+/// can pass a path wherever a `FontSource` is expected.
+///
+/// # Implementing
+///
+/// A simple in-memory implementation:
+///
+/// ```
+/// use std::collections::HashMap;
+/// use std::io;
+/// use std::path::{Path, PathBuf};
+/// use norad::FontSource;
+///
+/// struct MemorySource(HashMap<PathBuf, Vec<u8>>);
+///
+/// impl FontSource for MemorySource {
+///     fn try_read(&self, path: &Path) -> Option<Result<Vec<u8>, io::Error>> {
+///         self.0.get(path).cloned().map(Ok)
+///     }
+/// }
+/// ```
+pub trait FontSource: Sync {
+    /// Try to read the contents of a file at the given relative path.
+    ///
+    /// Returns `None` if the file does not exist, `Some(Ok(data))` if the
+    /// file was read successfully, or `Some(Err(..))` if the file exists but
+    /// could not be read.
+    fn try_read(&self, path: &Path) -> Option<Result<Vec<u8>, io::Error>>;
+
+    /// Read the contents of a file, returning [`io::ErrorKind::NotFound`] if
+    /// the file does not exist.
+    fn read(&self, path: &Path) -> Result<Vec<u8>, io::Error> {
+        self.try_read(path).unwrap_or_else(|| {
+            Err(io::Error::new(io::ErrorKind::NotFound, path.display().to_string()))
+        })
+    }
+
+    /// If this source is backed by a directory on disk, return the root path.
+    ///
+    /// This is used by data/image stores to enable lazy loading: when a path
+    /// is available, the store records it and defers reading until access time.
+    /// The default returns `None`, meaning the store will eagerly load all data.
+    fn as_path(&self) -> Option<&Path> {
+        None
+    }
+
+    /// List entries in a directory at the given relative path.
+    ///
+    /// Returns `(entry_name, is_dir)` pairs, where `entry_name` is the name
+    /// of each entry (not a full path). Callers should join with the directory
+    /// path to get the full relative path.
+    ///
+    /// The default implementation returns [`io::ErrorKind::Unsupported`],
+    /// meaning this source does not support directory enumeration. Data and
+    /// image stores will be empty for such sources.
+    fn list_dir(&self, _path: &Path) -> Result<Vec<(PathBuf, bool)>, io::Error> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "this FontSource does not support directory listing",
+        ))
+    }
+}
+
+/// A directory on disk implements [`FontSource`] directly.
+impl FontSource for &Path {
+    fn try_read(&self, path: &Path) -> Option<Result<Vec<u8>, io::Error>> {
+        match std::fs::read(self.join(path)) {
+            Ok(data) => Some(Ok(data)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+
+    fn as_path(&self) -> Option<&Path> {
+        Some(self)
+    }
+
+    fn list_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, io::Error> {
+        let full = self.join(path);
+        let mut entries = Vec::new();
+        for entry in std::fs::read_dir(&full)? {
+            let entry = entry?;
+            let metadata = entry.metadata()?;
+            let name = PathBuf::from(entry.file_name());
+            entries.push((name, metadata.is_dir()));
+        }
+        Ok(entries)
+    }
+}
+
+// Allow closures as FontSource for convenience.
+impl<F> FontSource for F
+where
+    F: Fn(&Path) -> Option<Result<Vec<u8>, io::Error>> + Sync,
+{
+    fn try_read(&self, path: &Path) -> Option<Result<Vec<u8>, io::Error>> {
+        self(path)
+    }
+}

--- a/src/font_source.rs
+++ b/src/font_source.rs
@@ -12,8 +12,24 @@ use std::path::{Path, PathBuf};
 /// Paths passed to methods are always relative to the UFO root, e.g.
 /// `"metainfo.plist"`, `"glyphs/contents.plist"`, `"glyphs/A_.glif"`.
 ///
-/// A filesystem directory (a `&Path`) implements this trait directly, so you
-/// can pass a path wherever a `FontSource` is expected.
+/// Two implementations are provided out of the box:
+///
+/// - A filesystem directory (a `&Path`) implements this trait directly, so you
+///   can pass a path wherever a `FontSource` is expected.
+/// - Any closure `Fn(&Path) -> Option<Result<Vec<u8>, io::Error>>` implements it
+///   too, which is handy for a quick ad-hoc source without defining a type:
+///
+/// ```
+/// use std::io;
+/// use std::path::Path;
+/// use norad::{DataRequest, Font};
+///
+/// # fn example(lookup: impl Fn(&Path) -> Option<Vec<u8>> + Sync) -> Result<(), Box<dyn std::error::Error>> {
+/// let source = |path: &Path| lookup(path).map(Ok::<_, io::Error>);
+/// let font = Font::load_from_source(&DataRequest::all(), &source)?;
+/// # Ok(())
+/// # }
+/// ```
 ///
 /// # Implementing
 ///
@@ -60,19 +76,28 @@ pub trait FontSource: Sync {
 
     /// List entries in a directory at the given relative path.
     ///
-    /// Returns `(entry_name, is_dir)` pairs, where `entry_name` is the name
-    /// of each entry (not a full path). Callers should join with the directory
-    /// path to get the full relative path.
+    /// Returns a [`DirEntry`] for each entry, carrying the entry name (not a
+    /// full path). Callers should join with the directory path to get the full
+    /// relative path.
     ///
     /// The default implementation returns [`io::ErrorKind::Unsupported`],
     /// meaning this source does not support directory enumeration. Data and
     /// image stores will be empty for such sources.
-    fn list_dir(&self, _path: &Path) -> Result<Vec<(PathBuf, bool)>, io::Error> {
+    fn list_dir(&self, _path: &Path) -> Result<Vec<DirEntry>, io::Error> {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
             "this FontSource does not support directory listing",
         ))
     }
+}
+
+/// The name of a file or directory, relative to a parent (not a full path!)
+#[derive(Clone, Debug)]
+pub enum DirEntry {
+    /// A file, carrying its name relative to the parent directory.
+    File(PathBuf),
+    /// A subdirectory, carrying its name relative to the parent directory.
+    Dir(PathBuf),
 }
 
 /// A directory on disk implements [`FontSource`] directly.
@@ -89,14 +114,18 @@ impl FontSource for &Path {
         Some(self)
     }
 
-    fn list_dir(&self, path: &Path) -> Result<Vec<(PathBuf, bool)>, io::Error> {
+    fn list_dir(&self, path: &Path) -> Result<Vec<DirEntry>, io::Error> {
         let full = self.join(path);
         let mut entries = Vec::new();
         for entry in std::fs::read_dir(&full)? {
             let entry = entry?;
             let metadata = entry.metadata()?;
             let name = PathBuf::from(entry.file_name());
-            entries.push((name, metadata.is_dir()));
+            entries.push(if metadata.is_dir() {
+                DirEntry::Dir(name)
+            } else {
+                DirEntry::File(name)
+            });
         }
         Ok(entries)
     }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -2,7 +2,6 @@
 //!
 //! [`fontinfo.plist`]: https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/
 
-use std::path::Path;
 use std::{collections::HashSet, convert::TryFrom, ops::Deref};
 
 use serde::de::Deserializer;
@@ -492,24 +491,6 @@ struct FontInfoV1 {
 }
 
 impl FontInfo {
-    /// Returns [`FontInfo`] from a file, upgrading from the supplied `format_version` to the highest
-    /// internally supported version.
-    ///
-    /// The conversion follows what ufoLib and defcon are doing, e.g. various fields that were
-    /// implicitly signed integers before and are unsigned integers in the newest spec, are
-    /// converted by taking their absolute value. Fields that could be floats before and are
-    /// integers now are rounded. Fields that could be floats before and are unsigned integers
-    /// now are rounded before taking their absolute value.
-    #[allow(dead_code)]
-    pub(crate) fn from_file<P: AsRef<Path>>(
-        path: P,
-        format_version: FormatVersion,
-        lib: &mut Plist,
-    ) -> Result<Self, FontInfoLoadError> {
-        let data = std::fs::read(path.as_ref()).map_err(FontInfoLoadError::Io)?;
-        Self::from_bytes(&data, format_version, lib)
-    }
-
     pub(crate) fn from_bytes(
         data: &[u8],
         format_version: FormatVersion,

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -500,23 +500,32 @@ impl FontInfo {
     /// converted by taking their absolute value. Fields that could be floats before and are
     /// integers now are rounded. Fields that could be floats before and are unsigned integers
     /// now are rounded before taking their absolute value.
+    #[allow(dead_code)]
     pub(crate) fn from_file<P: AsRef<Path>>(
         path: P,
         format_version: FormatVersion,
         lib: &mut Plist,
     ) -> Result<Self, FontInfoLoadError> {
-        let path = path.as_ref();
+        let data = std::fs::read(path.as_ref()).map_err(FontInfoLoadError::Io)?;
+        Self::from_bytes(&data, format_version, lib)
+    }
+
+    pub(crate) fn from_bytes(
+        data: &[u8],
+        format_version: FormatVersion,
+        lib: &mut Plist,
+    ) -> Result<Self, FontInfoLoadError> {
         match format_version {
             FormatVersion::V3 => {
                 let mut fontinfo: FontInfo =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParsePlist)?;
+                    plist::from_bytes(data).map_err(FontInfoLoadError::ParsePlist)?;
                 fontinfo.validate().map_err(FontInfoLoadError::InvalidData)?;
                 fontinfo.load_object_libs(lib)?;
                 Ok(fontinfo)
             }
             FormatVersion::V2 => {
                 let fontinfo_v2: FontInfoV2 =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParsePlist)?;
+                    plist::from_bytes(data).map_err(FontInfoLoadError::ParsePlist)?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v2.ascender,
                     cap_height: fontinfo_v2.capHeight,
@@ -671,7 +680,7 @@ impl FontInfo {
             }
             FormatVersion::V1 => {
                 let fontinfo_v1: FontInfoV1 =
-                    plist::from_file(path).map_err(FontInfoLoadError::ParsePlist)?;
+                    plist::from_bytes(data).map_err(FontInfoLoadError::ParsePlist)?;
                 let fontinfo = FontInfo {
                     ascender: fontinfo_v1.ascender,
                     cap_height: fontinfo_v1.capHeight,

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -73,6 +73,11 @@ impl Glyph {
         parse::GlifParser::from_xml(xml)
     }
 
+    /// Parse a glyph from raw XML bytes.
+    pub(crate) fn parse(data: &[u8]) -> Result<Self, GlifLoadError> {
+        parse::GlifParser::from_xml(data)
+    }
+
     #[doc(hidden)]
     pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), GlifWriteError> {
         let path = path.as_ref();

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,7 +1,6 @@
 //! Helper types & constants for working with groups.
 
 use std::collections::{BTreeMap, HashSet};
-use std::path::Path;
 
 use crate::error::{FontLoadError, GroupsValidationError};
 use crate::Name;
@@ -16,7 +15,7 @@ pub const SECOND_KERNING_GROUP_PREFIX: &str = "public.kern2.";
 /// We use a [`BTreeMap`] because we need sorting for serialization.
 pub type Groups = BTreeMap<Name, Vec<Name>>;
 
-pub(crate) fn deserialize_groups<P: AsRef<Path>>(path: P) -> Result<Groups, FontLoadError> {
+pub(crate) fn deserialize_groups(data: &[u8]) -> Result<Groups, FontLoadError> {
     struct GroupsDeHelper(Groups);
 
     impl<'de> serde::Deserialize<'de> for GroupsDeHelper {
@@ -38,7 +37,7 @@ pub(crate) fn deserialize_groups<P: AsRef<Path>>(path: P) -> Result<Groups, Font
         }
     }
 
-    plist::from_file::<_, GroupsDeHelper>(path.as_ref())
+    plist::from_bytes::<GroupsDeHelper>(data)
         .map(|h| h.0)
         .map_err(|source| FontLoadError::ParsePlist { name: "groups.plist", source })
 }
@@ -91,7 +90,8 @@ mod tests {
 
     #[test]
     fn deserialize_skip_empty_group_member() {
-        let group = deserialize_groups("testdata/groups_empty_entries.plist").unwrap();
+        let data = std::fs::read("testdata/groups_empty_entries.plist").unwrap();
+        let group = deserialize_groups(&data).unwrap();
         assert_eq!(group.get("derpy_group").unwrap()[0], "hi");
     }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -8,7 +8,8 @@ use rayon::prelude::*;
 use serde::Deserialize;
 
 use crate::data_request::LayerFilter;
-use crate::error::{FontLoadError, LayerLoadError, LayerWriteError, NamingError};
+use crate::error::{FontLoadError, GlifLoadError, LayerLoadError, LayerWriteError, NamingError};
+use crate::font_source::FontSource;
 use crate::shared_types::Color;
 use crate::Name;
 use crate::{util, Glyph, Plist, WriteOptions};
@@ -53,26 +54,33 @@ impl LayerContents {
     /// we will assume the pre-UFOv3 behaviour, and expect a single glyphs dir.
     ///
     pub(crate) fn load(
-        base_dir: &Path,
+        source: &dyn FontSource,
         filter: &LayerFilter,
     ) -> Result<LayerContents, FontLoadError> {
-        let layer_contents_path = base_dir.join(LAYER_CONTENTS_FILE);
-        let to_load: Vec<(Name, PathBuf)> = if layer_contents_path.exists() {
-            plist::from_file(&layer_contents_path)
-                .map_err(|source| FontLoadError::ParsePlist { name: LAYER_CONTENTS_FILE, source })?
-        } else {
-            vec![(Name::new_raw(DEFAULT_LAYER_NAME), PathBuf::from(DEFAULT_GLYPHS_DIRNAME))]
+        let layer_contents_path = Path::new(LAYER_CONTENTS_FILE);
+        let to_load: Vec<(Name, PathBuf)> = match source.try_read(layer_contents_path) {
+            Some(data) => {
+                let data = data.map_err(FontLoadError::AccessUfoDir)?;
+                plist::from_bytes(&data).map_err(|source| FontLoadError::ParsePlist {
+                    name: LAYER_CONTENTS_FILE,
+                    source,
+                })?
+            }
+            None => {
+                vec![(Name::new_raw(DEFAULT_LAYER_NAME), PathBuf::from(DEFAULT_GLYPHS_DIRNAME))]
+            }
         };
 
         let mut layers: Vec<_> = to_load
             .into_iter()
             .filter(|(name, path)| filter.should_load(name, path))
             .map(|(name, path)| {
-                let layer_path = base_dir.join(path);
-                Layer::load_impl(&layer_path, name.clone()).map_err(|source| FontLoadError::Layer {
-                    name: name.to_string(),
-                    path: layer_path,
-                    source: Box::new(source),
+                Layer::load_impl(source, &path, name.clone()).map_err(|source| {
+                    FontLoadError::Layer {
+                        name: name.to_string(),
+                        path: path.clone(),
+                        source: Box::new(source),
+                    }
                 })
             })
             .collect::<Result<_, _>>()?;
@@ -300,19 +308,28 @@ impl Layer {
     #[cfg(test)]
     pub(crate) fn load(path: impl AsRef<Path>, name: &str) -> Result<Layer, LayerLoadError> {
         let path = path.as_ref();
+        // The path points to the layer directory (e.g. "testdata/font.ufo/glyphs").
+        // We need a FontSource rooted at the parent, and the layer_dir is the last component.
+        let parent = path.parent().unwrap_or(path);
+        let layer_dir = Path::new(path.file_name().unwrap());
         let name = Name::new_raw(name);
-        Layer::load_impl(path, name)
+        Layer::load_impl(&parent, layer_dir, name)
     }
 
     /// The actual loading logic.
-    pub(crate) fn load_impl(path: &Path, name: Name) -> Result<Layer, LayerLoadError> {
-        let contents_path = path.join(CONTENTS_FILE);
-        if !contents_path.exists() {
-            return Err(LayerLoadError::MissingContentsFile);
-        }
+    pub(crate) fn load_impl(
+        source: &dyn FontSource,
+        layer_dir: &Path,
+        name: Name,
+    ) -> Result<Layer, LayerLoadError> {
+        let contents_rel = layer_dir.join(CONTENTS_FILE);
+        let contents_data = source
+            .try_read(&contents_rel)
+            .ok_or(LayerLoadError::MissingContentsFile)?
+            .map_err(LayerLoadError::Io)?;
         // these keys are never used; a future optimization would be to skip the
         // names and deserialize to a vec; that would not be a one-liner, though.
-        let contents: BTreeMap<Name, PathBuf> = plist::from_file(&contents_path)
+        let contents: BTreeMap<Name, PathBuf> = plist::from_bytes(&contents_data)
             .map_err(|source| LayerLoadError::ParsePlist { name: CONTENTS_FILE, source })?;
         let path_set = contents.values().map(|p| p.to_string_lossy().to_lowercase()).collect();
 
@@ -324,12 +341,15 @@ impl Layer {
         let glyphs = iter
             .map(|(name, glyph_path)| {
                 let name = name.clone();
-                let glyph_path = path.join(glyph_path);
+                let full_path = layer_dir.join(glyph_path);
 
-                Glyph::load(&glyph_path)
+                source
+                    .read(&full_path)
+                    .map_err(GlifLoadError::Io)
+                    .and_then(|data| Glyph::parse(&data))
                     .map_err(|source| LayerLoadError::Glyph {
                         name: name.to_string(),
-                        path: glyph_path,
+                        path: full_path,
                         source,
                     })
                     .map(|mut glyph| {
@@ -339,20 +359,18 @@ impl Layer {
             })
             .collect::<Result<_, _>>()?;
 
-        let layerinfo_path = path.join(LAYER_INFO_FILE);
-        let (color, lib) = if layerinfo_path.exists() {
-            Self::parse_layer_info(&layerinfo_path)?
-        } else {
-            (None, Plist::new())
+        let layerinfo_rel = layer_dir.join(LAYER_INFO_FILE);
+        let (color, lib) = match source.try_read(&layerinfo_rel) {
+            Some(data) => Self::parse_layer_info(&data.map_err(LayerLoadError::Io)?)?,
+            None => (None, Plist::new()),
         };
 
-        // for us to get this far, the path must have a file name
-        let path = path.file_name().unwrap().into();
+        let path = layer_dir.into();
 
         Ok(Layer { glyphs, name, path, contents, path_set, color, lib })
     }
 
-    fn parse_layer_info(path: &Path) -> Result<(Option<Color>, Plist), LayerLoadError> {
+    fn parse_layer_info(data: &[u8]) -> Result<(Option<Color>, Plist), LayerLoadError> {
         // Pluck apart the data found in the file, as we want to insert it into `Layer`.
         #[derive(Deserialize)]
         struct LayerInfoHelper {
@@ -360,7 +378,7 @@ impl Layer {
             #[serde(default)]
             lib: Plist,
         }
-        let layerinfo: LayerInfoHelper = plist::from_file(path)
+        let layerinfo: LayerInfoHelper = plist::from_bytes(data)
             .map_err(|source| LayerLoadError::ParsePlist { name: LAYER_INFO_FILE, source })?;
         Ok((layerinfo.color, layerinfo.lib))
     }
@@ -850,35 +868,34 @@ mod tests {
 
     #[test]
     fn test_filter() {
-        static UFO_DIR: &str = "testdata/MutatorSansLightWide.ufo/";
-        let ufo_path = Path::new(UFO_DIR);
+        let ufo_path = Path::new("testdata/MutatorSansLightWide.ufo");
 
         let request = DataRequest::all();
-        let layerset = LayerContents::load(ufo_path, &request.layers).unwrap();
+        let layerset = LayerContents::load(&ufo_path, &request.layers).unwrap();
         assert_eq!(layerset.len(), 2);
         assert_eq!(layerset.default_layer().len(), 48);
 
         let request = DataRequest::none();
-        let layerset = LayerContents::load(ufo_path, &request.layers).unwrap();
+        let layerset = LayerContents::load(&ufo_path, &request.layers).unwrap();
         // default layer is always present
         assert_eq!(layerset.len(), 1);
         assert_eq!(layerset.default_layer().len(), 0);
 
         let request = DataRequest::none().default_layer(true);
-        let layerset = LayerContents::load(ufo_path, &request.layers).unwrap();
+        let layerset = LayerContents::load(&ufo_path, &request.layers).unwrap();
         assert_eq!(layerset.len(), 1);
         assert_eq!(layerset.default_layer().len(), 48);
 
         // all is overridden by default_layer
         let request = DataRequest::all().default_layer(true);
-        let layerset = LayerContents::load(ufo_path, &request.layers).unwrap();
+        let layerset = LayerContents::load(&ufo_path, &request.layers).unwrap();
         // default layer is always present
         assert_eq!(layerset.len(), 1);
         assert_eq!(layerset.default_layer().len(), 48);
 
         let layer_name = String::from("background");
         let request = DataRequest::none().filter_layers(|name, _path| name == layer_name);
-        let layerset = LayerContents::load(ufo_path, &request.layers).unwrap();
+        let layerset = LayerContents::load(&ufo_path, &request.layers).unwrap();
         // default layer is always present
         assert_eq!(layerset.len(), 2);
         assert_eq!(layerset.default_layer().len(), 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod write;
 
 pub use data_request::DataRequest;
 pub use font::{Font, FormatVersion, MetaInfo};
-pub use font_source::FontSource;
+pub use font_source::{DirEntry, FontSource};
 pub use fontinfo::FontInfo;
 pub use glyph::{
     AffineTransform, Anchor, Codepoints, Component, Contour, ContourPoint, Glyph, Image, PointType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod datastore;
 pub mod designspace;
 pub mod error;
 mod font;
+mod font_source;
 pub mod fontinfo;
 mod glyph;
 pub mod groups;
@@ -24,6 +25,7 @@ mod write;
 
 pub use data_request::DataRequest;
 pub use font::{Font, FormatVersion, MetaInfo};
+pub use font_source::FontSource;
 pub use fontinfo::FontInfo;
 pub use glyph::{
     AffineTransform, Anchor, Codepoints, Component, Contour, ContourPoint, Glyph, Image, PointType,

--- a/src/upconversion.rs
+++ b/src/upconversion.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::path::Path;
 
 use serde::Deserialize;
 
@@ -120,7 +119,7 @@ fn find_known_kerning_groups(groups: &Groups) -> (HashSet<Name>, HashSet<Name>) 
 ///
 /// [1]: https://github.com/robotools/defcon/blob/76a7ac408e62f68c09eaf24ca6d9ad04523dd19c/Lib/defcon/objects/font.py#L1571-L1629
 pub(crate) fn upconvert_ufov1_robofab_data(
-    lib_path: &Path,
+    lib_bytes: &[u8],
     lib: &mut plist::Dictionary,
     font_info: &mut FontInfo,
 ) -> Result<Option<String>, FontLoadError> {
@@ -152,8 +151,8 @@ pub(crate) fn upconvert_ufov1_robofab_data(
         v_stems: Option<Vec<f64>>,
     }
 
-    // Read lib.plist again because it is easier than pulling out the data manually.
-    let lib_data: LibData = plist::from_file(lib_path)
+    // Re-parse lib.plist because it is easier than pulling out the data manually.
+    let lib_data: LibData = plist::from_bytes(lib_bytes)
         .map_err(|source| FontLoadError::ParsePlist { name: LIB_FILE, source })?;
 
     // Convert features.

--- a/tests/load_from_source.rs
+++ b/tests/load_from_source.rs
@@ -1,0 +1,95 @@
+//! Integration tests for loading fonts from a non-filesystem FontSource.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use norad::{DataRequest, Font, FontSource};
+
+/// A simple in-memory source that wraps a HashMap.
+struct MemorySource(HashMap<PathBuf, Vec<u8>>);
+
+impl FontSource for MemorySource {
+    fn try_read(&self, path: &Path) -> Option<Result<Vec<u8>, io::Error>> {
+        self.0.get(path).cloned().map(Ok)
+    }
+}
+
+/// Build a MemorySource by walking a real UFO directory on disk.
+fn source_from_ufo_dir(ufo_path: &str) -> MemorySource {
+    let root = Path::new(ufo_path);
+    let mut map = HashMap::new();
+    walk_dir(root, root, &mut map);
+    MemorySource(map)
+}
+
+fn walk_dir(root: &Path, dir: &Path, map: &mut HashMap<PathBuf, Vec<u8>>) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            walk_dir(root, &path, map);
+        } else {
+            let rel = path.strip_prefix(root).unwrap().to_path_buf();
+            let contents = std::fs::read(&path).unwrap();
+            map.insert(rel, contents);
+        }
+    }
+}
+
+#[test]
+fn load_from_source_matches_filesystem() {
+    let ufo_path = "testdata/MutatorSansLightWide.ufo";
+    let source = source_from_ufo_dir(ufo_path);
+
+    let font_fs = Font::load(ufo_path).unwrap();
+    let font_src = Font::load_from_source(&DataRequest::all(), &source).unwrap();
+
+    // Core data should match
+    assert_eq!(font_fs.meta, font_src.meta);
+    assert_eq!(font_fs.font_info, font_src.font_info);
+    assert_eq!(font_fs.lib, font_src.lib);
+    assert_eq!(font_fs.groups, font_src.groups);
+    assert_eq!(font_fs.kerning, font_src.kerning);
+    assert_eq!(font_fs.features, font_src.features);
+
+    // Layers and glyphs
+    assert_eq!(font_fs.iter_layers().count(), font_src.iter_layers().count());
+    assert_eq!(font_fs.glyph_count(), font_src.glyph_count());
+    for layer_fs in font_fs.iter_layers() {
+        let layer_src = font_src.layers.get(layer_fs.name()).unwrap();
+        assert_eq!(layer_fs, layer_src, "layer '{}' mismatch", layer_fs.name());
+    }
+}
+
+#[test]
+fn load_from_source_with_closure() {
+    let ufo_path = "testdata/MutatorSansLightWide.ufo";
+    let source = source_from_ufo_dir(ufo_path);
+
+    let reader =
+        |path: &Path| -> Option<Result<Vec<u8>, io::Error>> { source.0.get(path).cloned().map(Ok) };
+    let font = Font::load_from_source(&DataRequest::all(), &reader).unwrap();
+
+    assert_eq!(font.glyph_count(), 48);
+}
+
+#[test]
+fn load_from_source_data_request_none() {
+    let ufo_path = "testdata/MutatorSansLightWide.ufo";
+    let source = source_from_ufo_dir(ufo_path);
+
+    let font = Font::load_from_source(&DataRequest::none(), &source).unwrap();
+
+    assert!(font.groups.is_empty());
+    assert!(font.kerning.is_empty());
+    assert!(font.features.is_empty());
+    assert!(font.default_layer().is_empty());
+}
+
+#[test]
+fn load_from_source_missing_metainfo() {
+    let source = MemorySource(HashMap::new());
+    let result = Font::load_from_source(&DataRequest::all(), &source);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Okay so after thinking about this more I realized that supporting this functionality would be a good opportunity for us to also implement #262, by generally decoupling reading from the file-system.

This PR does that; it closes #401.

@yanone sorry for the runaround, but this ultimately feels like the right approach, let me know if it works for your purposes?
