### PR TITLE
Add ufoz support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ default = ["object-libs"]
 object-libs = ["uuid"]
 kurbo = ["dep:kurbo"]
 rayon = ["dep:rayon"]
+ufoz = ["zip"]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 uuid = { version = "1.2", features = ["v4"], optional = true }
@@ -43,6 +44,7 @@ base64 = "0.22"
 close_already = "0.3"
 log = "0.4"
 smol_str = { version = "0.3", features = ["serde"] }
+zip = { version = "2", default-features = false, features = ["deflate"], optional = true }
 
 [dev-dependencies]
 failure = "0.1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,16 @@ exclude = [
 ]
 
 [package.metadata.docs.rs]
-features = ["kurbo"]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["object-libs"]
 # allow us to add libs to objects, which requires potentially creating identifiers
-object-libs = ["uuid"]
+object-libs = ["dep:uuid"]
 kurbo = ["dep:kurbo"]
 rayon = ["dep:rayon"]
-ufoz = ["zip"]
+ufoz = ["dep:zip"]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 uuid = { version = "1.2", features = ["v4"], optional = true }

--- a/examples/load_save.rs
+++ b/examples/load_save.rs
@@ -1,7 +1,6 @@
 //! A small program that times the loading and saving of a UFO file.
 
 use std::env;
-use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -58,11 +57,7 @@ struct Args {
 impl Args {
     fn get_from_env_or_exit() -> Self {
         let mut args = env::args().skip(1);
-        let path = match args.next().map(PathBuf::from) {
-            Some(ref p) if p.exists() && p.extension() == Some(OsStr::new("ufo")) => p.to_owned(),
-            Some(ref p) => exit_err!("path {:?} is not an existing .ufo file, exiting", p),
-            None => exit_err!("Please supply a path to a .ufo file"),
-        };
+        let path = args.next().map(PathBuf::from).expect("missing path argument");
 
         let outpath = args.next().map(PathBuf::from);
         if outpath.as_ref().map(|p| p.exists()).unwrap_or(false) {

--- a/src/data_request.rs
+++ b/src/data_request.rs
@@ -79,9 +79,47 @@ impl LayerFilter<'_> {
     pub(crate) fn includes_default_layer(&self) -> bool {
         self.all || self.load_default
     }
+
+    /// `true` if this glyph-layer directory should be loaded, judged by path
+    /// alone (conservatively `true` for custom filters).
+    #[cfg(feature = "ufoz")]
+    fn should_load_dir(&self, dir: &Path) -> bool {
+        self.all || self.custom.is_some() || (self.load_default && dir == Path::new("glyphs"))
+    }
 }
 
 impl<'a> DataRequest<'a> {
+    /// `true` if the file at this UFO-relative path is needed for this request.
+    ///
+    /// Judged by path alone, and conservative: it keeps root-level files and
+    /// anything it can't rule out, so a caller (e.g. the zip loader) never
+    /// skips data that would later be read.
+    #[cfg(feature = "ufoz")]
+    pub(crate) fn should_load_path(&self, path: &Path) -> bool {
+        let mut components = path.components();
+        let Some(first) = components.next() else { return false };
+
+        // Root-level file: always keep (cheap, and gating filenames buys nothing).
+        if components.next().is_none() {
+            return true;
+        }
+
+        let first = Path::new(first.as_os_str());
+        if first == Path::new("data") {
+            return self.data;
+        }
+        if first == Path::new("images") {
+            return self.images;
+        }
+        // UFO3 glyph-set directories are named "glyphs" or "glyphs.*".
+        if first == Path::new("glyphs") || first.to_str().is_some_and(|s| s.starts_with("glyphs."))
+        {
+            return self.layers.should_load_dir(first);
+        }
+        // Unknown subdirectory: keep, to stay safe.
+        true
+    }
+
     fn from_bool(b: bool) -> Self {
         DataRequest {
             layers: LayerFilter::from_bool(b),

--- a/src/error.rs
+++ b/src/error.rs
@@ -143,6 +143,10 @@ pub enum FontLoadError {
         /// The underlying error.
         source: PlistError,
     },
+    /// The file is not a valid zip archive.
+    #[cfg(feature = "ufoz")]
+    #[error("failed to open UFO as zip archive")]
+    InvalidZipFile(#[source] zip::result::ZipError),
     /// Norad can currently only open UFO (directory) packages.
     #[error("only UFO (directory) packages are supported")]
     UfoNotADir,

--- a/src/font.rs
+++ b/src/font.rs
@@ -217,11 +217,17 @@ impl Font {
 
     fn load_impl(path: &Path, request: DataRequest) -> Result<Font, FontLoadError> {
         let metadata = path.metadata().map_err(FontLoadError::AccessUfoDir)?;
-        if !metadata.is_dir() {
-            return Err(FontLoadError::UfoNotADir);
+        if metadata.is_dir() {
+            return Self::load_from_source(&request, &path);
         }
 
-        Self::load_from_source(&request, &path)
+        #[cfg(feature = "ufoz")]
+        if metadata.is_file() {
+            let source = crate::zip_source::ZipSource::open(path)?;
+            return Self::load_from_source(&request, &source);
+        }
+
+        Err(FontLoadError::UfoNotADir)
     }
 
     /// Returns a [`Font`] loaded from the given [`FontSource`].

--- a/src/font.rs
+++ b/src/font.rs
@@ -223,7 +223,7 @@ impl Font {
 
         #[cfg(feature = "ufoz")]
         if metadata.is_file() {
-            let source = crate::zip_source::ZipSource::open(path)?;
+            let source = crate::zip_source::ZipSource::open(path, &request)?;
             return Self::load_from_source(&request, &source);
         }
 

--- a/src/font_source.rs
+++ b/src/font_source.rs
@@ -92,7 +92,7 @@ pub trait FontSource: Sync {
 }
 
 /// The name of a file or directory, relative to a parent (not a full path!)
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DirEntry {
     /// A file, carrying its name relative to the parent directory.
     File(PathBuf),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ mod shared_types;
 mod upconversion;
 pub(crate) mod util;
 mod write;
+#[cfg(feature = "ufoz")]
+mod zip_source;
 
 pub use data_request::DataRequest;
 pub use font::{Font, FormatVersion, MetaInfo};

--- a/src/zip_source.rs
+++ b/src/zip_source.rs
@@ -1,0 +1,124 @@
+//! [`FontSource`] implementation for reading UFO data from zip archives.
+
+use std::collections::{HashMap, HashSet};
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use crate::error::FontLoadError;
+use crate::font_source::{DirEntry, FontSource};
+
+/// A UFO source backed by a zip archive loaded into memory.
+pub(crate) struct ZipSource {
+    entries: HashMap<PathBuf, Vec<u8>>,
+}
+
+impl ZipSource {
+    /// Open a zip archive at the given path and load all file entries into memory.
+    pub fn open(path: &Path) -> Result<Self, FontLoadError> {
+        let file = std::fs::File::open(path).map_err(FontLoadError::AccessUfoDir)?;
+        let mut archive = zip::ZipArchive::new(file).map_err(FontLoadError::InvalidZipFile)?;
+
+        let prefix = detect_zip_root(&mut archive);
+
+        let mut entries = HashMap::new();
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i).map_err(FontLoadError::InvalidZipFile)?;
+
+            if entry.is_dir() {
+                continue;
+            }
+
+            let raw_path = PathBuf::from(entry.name().to_string());
+
+            let rel_path = if let Some(ref pfx) = prefix {
+                match raw_path.strip_prefix(pfx) {
+                    Ok(stripped) => stripped.to_path_buf(),
+                    Err(_) => continue,
+                }
+            } else {
+                raw_path
+            };
+
+            if rel_path.as_os_str().is_empty() {
+                continue;
+            }
+
+            let mut data = Vec::with_capacity(entry.size() as usize);
+            entry.read_to_end(&mut data).map_err(FontLoadError::AccessUfoDir)?;
+            entries.insert(rel_path, data);
+        }
+
+        Ok(ZipSource { entries })
+    }
+}
+
+impl FontSource for ZipSource {
+    fn try_read(&self, path: &Path) -> Option<Result<Vec<u8>, io::Error>> {
+        self.entries.get(path).cloned().map(Ok)
+    }
+
+    fn list_dir(&self, path: &Path) -> Result<Vec<DirEntry>, io::Error> {
+        let mut dirs = HashSet::new();
+        let mut files = Vec::new();
+
+        for key in self.entries.keys() {
+            let rel = match key.strip_prefix(path) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+
+            let mut components = rel.components();
+            let first = match components.next() {
+                Some(c) => c,
+                None => continue,
+            };
+
+            if components.next().is_some() {
+                // Has more components — first is a directory.
+                dirs.insert(PathBuf::from(first.as_os_str()));
+            } else {
+                // Single component — it's a file.
+                files.push(DirEntry::File(PathBuf::from(first.as_os_str())));
+            }
+        }
+
+        let mut result: Vec<DirEntry> = dirs.into_iter().map(DirEntry::Dir).collect();
+        result.append(&mut files);
+        Ok(result)
+    }
+}
+
+/// Detect if the zip has a single top-level directory wrapping all contents.
+///
+/// If so, return that directory name as the prefix to strip. Otherwise return
+/// `None`, meaning the zip contents are at the root level.
+fn detect_zip_root<R: io::Read + io::Seek>(archive: &mut zip::ZipArchive<R>) -> Option<PathBuf> {
+    let mut top_level_dirs = HashSet::new();
+    let mut has_root_files = false;
+
+    for i in 0..archive.len() {
+        let Ok(entry) = archive.by_index_raw(i) else { continue };
+        let name = entry.name();
+
+        // Skip macOS metadata.
+        if name.starts_with("__MACOSX") {
+            continue;
+        }
+
+        let path = PathBuf::from(name);
+        let mut components = path.components();
+        if let Some(first) = components.next() {
+            if components.next().is_none() && !entry.is_dir() {
+                has_root_files = true;
+            } else {
+                top_level_dirs.insert(PathBuf::from(first.as_os_str()));
+            }
+        }
+    }
+
+    if !has_root_files && top_level_dirs.len() == 1 {
+        top_level_dirs.into_iter().next()
+    } else {
+        None
+    }
+}

--- a/src/zip_source.rs
+++ b/src/zip_source.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::FontLoadError;
 use crate::font_source::{DirEntry, FontSource};
+use crate::DataRequest;
 
 /// A UFO source backed by a zip archive loaded into memory.
 pub(crate) struct ZipSource {
@@ -13,8 +14,13 @@ pub(crate) struct ZipSource {
 }
 
 impl ZipSource {
-    /// Open a zip archive at the given path and load all file entries into memory.
-    pub fn open(path: &Path) -> Result<Self, FontLoadError> {
+    /// Open a zip archive at the given path and load file entries into memory.
+    ///
+    /// Only entries the `request` may read are decompressed: the heavy subtrees
+    /// (`data/`, `images/`, and unwanted glyph layers) are skipped when the
+    /// request excludes them, so a sparse request doesn't pay to inflate data it
+    /// will never use. See [`DataRequest::should_load_path`].
+    pub(crate) fn open(path: &Path, request: &DataRequest) -> Result<Self, FontLoadError> {
         let file = std::fs::File::open(path).map_err(FontLoadError::AccessUfoDir)?;
         let mut archive = zip::ZipArchive::new(file).map_err(FontLoadError::InvalidZipFile)?;
 
@@ -28,11 +34,11 @@ impl ZipSource {
                 continue;
             }
 
-            let raw_path = PathBuf::from(entry.name().to_string());
+            let raw_path = Path::new(entry.name());
 
             let rel_path = if let Some(ref pfx) = prefix {
                 match raw_path.strip_prefix(pfx) {
-                    Ok(stripped) => stripped.to_path_buf(),
+                    Ok(stripped) => stripped,
                     Err(_) => continue,
                 }
             } else {
@@ -43,7 +49,14 @@ impl ZipSource {
                 continue;
             }
 
+            // Skip entries this request will never read, so we don't pay to
+            // decompress or buffer them.
+            if !request.should_load_path(rel_path) {
+                continue;
+            }
+
             let mut data = Vec::with_capacity(entry.size() as usize);
+            let rel_path = rel_path.to_path_buf();
             entry.read_to_end(&mut data).map_err(FontLoadError::AccessUfoDir)?;
             entries.insert(rel_path, data);
         }
@@ -92,11 +105,8 @@ impl FontSource for ZipSource {
 ///
 /// If so, return that directory name as the prefix to strip. Otherwise return
 /// `None`, meaning the zip contents are at the root level.
-pub(crate) fn detect_zip_root<R: io::Read + io::Seek>(
-    archive: &mut zip::ZipArchive<R>,
-) -> Option<PathBuf> {
-    let mut top_level_dirs = HashSet::new();
-    let mut has_root_files = false;
+fn detect_zip_root<R: io::Read + io::Seek>(archive: &mut zip::ZipArchive<R>) -> Option<PathBuf> {
+    let mut prefix: Option<PathBuf> = None;
 
     for i in 0..archive.len() {
         let Ok(entry) = archive.by_index_raw(i) else { continue };
@@ -107,22 +117,24 @@ pub(crate) fn detect_zip_root<R: io::Read + io::Seek>(
             continue;
         }
 
-        let path = PathBuf::from(name);
+        let path = Path::new(name);
         let mut components = path.components();
-        if let Some(first) = components.next() {
-            if components.next().is_none() && !entry.is_dir() {
-                has_root_files = true;
-            } else {
-                top_level_dirs.insert(PathBuf::from(first.as_os_str()));
-            }
+        let Some(first) = components.next() else { continue };
+
+        // A root-level file means there's no single wrapping directory.
+        if components.next().is_none() && !entry.is_dir() {
+            return None;
+        }
+
+        let first = Path::new(first.as_os_str());
+        match &prefix {
+            None => prefix = Some(first.to_path_buf()),
+            Some(p) if *p != first => return None,
+            Some(_) => (),
         }
     }
 
-    if !has_root_files && top_level_dirs.len() == 1 {
-        top_level_dirs.into_iter().next()
-    } else {
-        None
-    }
+    prefix
 }
 
 #[cfg(test)]
@@ -182,7 +194,7 @@ mod tests {
             ("glyphs/contents.plist", &contents),
         ]);
 
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         assert_eq!(source.entries.len(), 3);
         assert!(source.entries.contains_key(Path::new("metainfo.plist")));
         assert!(source.entries.contains_key(Path::new("layercontents.plist")));
@@ -197,7 +209,7 @@ mod tests {
             ("MyFont.ufo/glyphs/contents.plist", &minimal_contents()),
         ]);
 
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         assert!(source.entries.contains_key(Path::new("metainfo.plist")));
         assert!(source.entries.contains_key(Path::new("glyphs/contents.plist")));
         assert!(!source.entries.keys().any(|k| k.starts_with("MyFont.ufo")));
@@ -206,7 +218,7 @@ mod tests {
     #[test]
     fn detect_root_no_strip_when_multiple_top_dirs() {
         let tmp = write_zip_to_tempfile(&[("A/file1", b"a"), ("B/file2", b"b")]);
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         assert!(source.entries.contains_key(Path::new("A/file1")));
         assert!(source.entries.contains_key(Path::new("B/file2")));
     }
@@ -215,7 +227,7 @@ mod tests {
     fn detect_root_no_strip_when_root_files_exist() {
         let tmp =
             write_zip_to_tempfile(&[("readme.txt", b"hi"), ("MyFont.ufo/metainfo.plist", b"x")]);
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         assert!(source.entries.contains_key(Path::new("readme.txt")));
         assert!(source.entries.contains_key(Path::new("MyFont.ufo/metainfo.plist")));
     }
@@ -223,7 +235,7 @@ mod tests {
     #[test]
     fn try_read_missing() {
         let tmp = write_zip_to_tempfile(&[("metainfo.plist", b"x")]);
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         assert!(source.try_read(Path::new("nonexistent")).is_none());
     }
 
@@ -240,7 +252,7 @@ mod tests {
             ("data/foo.txt", b"hello"),
         ]);
 
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         let entries = source.list_dir(Path::new("")).unwrap();
         assert!(entries.contains(&DirEntry::Dir("data".into())));
         assert!(entries.contains(&DirEntry::Dir("glyphs".into())));
@@ -256,7 +268,7 @@ mod tests {
             ("glyphs/A_.glif", b"y"),
         ]);
 
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         let mut entries = source.list_dir(Path::new("glyphs")).unwrap();
         entries.sort();
 
@@ -268,7 +280,7 @@ mod tests {
     #[test]
     fn list_dir_empty() {
         let tmp = write_zip_to_tempfile(&[("metainfo.plist", b"x")]);
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         let entries = source.list_dir(Path::new("images")).unwrap();
         assert!(entries.is_empty());
     }
@@ -277,13 +289,14 @@ mod tests {
     fn open_invalid_zip() {
         let tmp = NamedTempFile::new().unwrap();
         std::fs::write(tmp.path(), b"not a zip file at all").unwrap();
-        let result = ZipSource::open(tmp.path());
+        let result = ZipSource::open(tmp.path(), &DataRequest::all());
         assert!(matches!(result, Err(FontLoadError::InvalidZipFile(_))));
     }
 
     #[test]
     fn open_nonexistent_file() {
-        let result = ZipSource::open(Path::new("/tmp/norad_test_nonexistent_ufoz.zip"));
+        let result =
+            ZipSource::open(Path::new("/tmp/norad_test_nonexistent_ufoz.zip"), &DataRequest::all());
         assert!(matches!(result, Err(FontLoadError::AccessUfoDir(_))));
     }
 
@@ -320,10 +333,65 @@ mod tests {
             writer.finish().unwrap();
         }
 
-        let source = ZipSource::open(tmp.path()).unwrap();
+        let source = ZipSource::open(tmp.path(), &DataRequest::all()).unwrap();
         // Should have only file entries, not directory entries.
         assert_eq!(source.entries.len(), 2);
         assert!(source.entries.contains_key(Path::new("glyphs/A_.glif")));
         assert!(source.entries.contains_key(Path::new("metainfo.plist")));
+    }
+
+    #[test]
+    fn open_skips_unrequested_data_and_images() {
+        let mut request = DataRequest::all();
+        request.data = false;
+        request.images = false;
+        let tmp = write_zip_to_tempfile(&[
+            ("metainfo.plist", b"meta"),
+            ("glyphs/contents.plist", b"c"),
+            ("data/foo.txt", b"hello"),
+            ("images/bar.png", b"png"),
+        ]);
+
+        let source = ZipSource::open(tmp.path(), &request).unwrap();
+        // Root plists and glyphs are still requested.
+        assert!(source.entries.contains_key(Path::new("metainfo.plist")));
+        assert!(source.entries.contains_key(Path::new("glyphs/contents.plist")));
+        // The excluded subtrees are never decompressed.
+        assert!(!source.entries.contains_key(Path::new("data/foo.txt")));
+        assert!(!source.entries.contains_key(Path::new("images/bar.png")));
+    }
+
+    #[test]
+    fn open_none_skips_glyphs_but_keeps_root() {
+        let tmp = write_zip_to_tempfile(&[
+            ("metainfo.plist", b"meta"),
+            ("layercontents.plist", b"lc"),
+            ("glyphs/contents.plist", b"c"),
+            ("glyphs/A_.glif", b"g"),
+            ("data/foo.txt", b"hello"),
+        ]);
+
+        let source = ZipSource::open(tmp.path(), &DataRequest::none()).unwrap();
+        // Root files are always kept, regardless of the request.
+        assert!(source.entries.contains_key(Path::new("metainfo.plist")));
+        assert!(source.entries.contains_key(Path::new("layercontents.plist")));
+        // No layers, data, or images requested — those entries are skipped.
+        assert!(!source.entries.contains_key(Path::new("glyphs/contents.plist")));
+        assert!(!source.entries.contains_key(Path::new("glyphs/A_.glif")));
+        assert!(!source.entries.contains_key(Path::new("data/foo.txt")));
+    }
+
+    #[test]
+    fn open_default_layer_keeps_glyphs_skips_other_layers() {
+        let tmp = write_zip_to_tempfile(&[
+            ("metainfo.plist", b"meta"),
+            ("glyphs/A_.glif", b"g"),
+            ("glyphs.background/A_.glif", b"bg"),
+        ]);
+
+        let source = ZipSource::open(tmp.path(), &DataRequest::none().default_layer(true)).unwrap();
+        // The default layer is kept; non-default glyph layers are skipped.
+        assert!(source.entries.contains_key(Path::new("glyphs/A_.glif")));
+        assert!(!source.entries.contains_key(Path::new("glyphs.background/A_.glif")));
     }
 }

--- a/src/zip_source.rs
+++ b/src/zip_source.rs
@@ -92,7 +92,9 @@ impl FontSource for ZipSource {
 ///
 /// If so, return that directory name as the prefix to strip. Otherwise return
 /// `None`, meaning the zip contents are at the root level.
-fn detect_zip_root<R: io::Read + io::Seek>(archive: &mut zip::ZipArchive<R>) -> Option<PathBuf> {
+pub(crate) fn detect_zip_root<R: io::Read + io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+) -> Option<PathBuf> {
     let mut top_level_dirs = HashSet::new();
     let mut has_root_files = false;
 
@@ -120,5 +122,208 @@ fn detect_zip_root<R: io::Read + io::Seek>(archive: &mut zip::ZipArchive<R>) -> 
         top_level_dirs.into_iter().next()
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use tempfile::NamedTempFile;
+
+    /// Write a zip archive containing the given entries to a temp file.
+    fn write_zip_to_tempfile(entries: &[(&str, &[u8])]) -> NamedTempFile {
+        let tmp = NamedTempFile::new().unwrap();
+        let mut writer = zip::ZipWriter::new(std::fs::File::create(tmp.path()).unwrap());
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        for (name, data) in entries {
+            writer.start_file(*name, options).unwrap();
+            std::io::Write::write_all(&mut writer, data).unwrap();
+        }
+        writer.finish().unwrap();
+        tmp
+    }
+
+    fn minimal_metainfo() -> Vec<u8> {
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>creator</key><string>org.linebender.norad</string>
+<key>formatVersion</key><integer>3</integer>
+</dict></plist>"#
+            .to_vec()
+    }
+
+    fn minimal_layercontents() -> Vec<u8> {
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><array>
+<array><string>public.default</string><string>glyphs</string></array>
+</array></plist>"#
+            .to_vec()
+    }
+
+    fn minimal_contents() -> Vec<u8> {
+        br#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict></dict></plist>"#
+            .to_vec()
+    }
+
+    #[test]
+    fn open_minimal_zip() {
+        let meta = minimal_metainfo();
+        let lc = minimal_layercontents();
+        let contents = minimal_contents();
+        let tmp = write_zip_to_tempfile(&[
+            ("metainfo.plist", &meta),
+            ("layercontents.plist", &lc),
+            ("glyphs/contents.plist", &contents),
+        ]);
+
+        let source = ZipSource::open(tmp.path()).unwrap();
+        assert_eq!(source.entries.len(), 3);
+        assert!(source.entries.contains_key(Path::new("metainfo.plist")));
+        assert!(source.entries.contains_key(Path::new("layercontents.plist")));
+        assert!(source.entries.contains_key(Path::new("glyphs/contents.plist")));
+    }
+
+    #[test]
+    fn detect_root_strips_single_dir() {
+        let meta = minimal_metainfo();
+        let tmp = write_zip_to_tempfile(&[
+            ("MyFont.ufo/metainfo.plist", &meta),
+            ("MyFont.ufo/glyphs/contents.plist", &minimal_contents()),
+        ]);
+
+        let source = ZipSource::open(tmp.path()).unwrap();
+        assert!(source.entries.contains_key(Path::new("metainfo.plist")));
+        assert!(source.entries.contains_key(Path::new("glyphs/contents.plist")));
+        assert!(!source.entries.keys().any(|k| k.starts_with("MyFont.ufo")));
+    }
+
+    #[test]
+    fn detect_root_no_strip_when_multiple_top_dirs() {
+        let tmp = write_zip_to_tempfile(&[("A/file1", b"a"), ("B/file2", b"b")]);
+        let source = ZipSource::open(tmp.path()).unwrap();
+        assert!(source.entries.contains_key(Path::new("A/file1")));
+        assert!(source.entries.contains_key(Path::new("B/file2")));
+    }
+
+    #[test]
+    fn detect_root_no_strip_when_root_files_exist() {
+        let tmp =
+            write_zip_to_tempfile(&[("readme.txt", b"hi"), ("MyFont.ufo/metainfo.plist", b"x")]);
+        let source = ZipSource::open(tmp.path()).unwrap();
+        assert!(source.entries.contains_key(Path::new("readme.txt")));
+        assert!(source.entries.contains_key(Path::new("MyFont.ufo/metainfo.plist")));
+    }
+
+    #[test]
+    fn try_read_missing() {
+        let tmp = write_zip_to_tempfile(&[("metainfo.plist", b"x")]);
+        let source = ZipSource::open(tmp.path()).unwrap();
+        assert!(source.try_read(Path::new("nonexistent")).is_none());
+    }
+
+    #[test]
+    fn list_dir_root() {
+        let meta = minimal_metainfo();
+        let lc = minimal_layercontents();
+        let contents = minimal_contents();
+        let tmp = write_zip_to_tempfile(&[
+            ("metainfo.plist", &meta),
+            ("layercontents.plist", &lc),
+            ("glyphs/contents.plist", &contents),
+            ("glyphs/A_.glif", b"<glyph/>"),
+            ("data/foo.txt", b"hello"),
+        ]);
+
+        let source = ZipSource::open(tmp.path()).unwrap();
+        let entries = source.list_dir(Path::new("")).unwrap();
+        assert!(entries.contains(&DirEntry::Dir("data".into())));
+        assert!(entries.contains(&DirEntry::Dir("glyphs".into())));
+        assert!(entries.contains(&DirEntry::File("metainfo.plist".into())));
+        assert!(entries.contains(&DirEntry::File("layercontents.plist".into())));
+    }
+
+    #[test]
+    fn list_dir_subdirectory() {
+        let tmp = write_zip_to_tempfile(&[
+            ("metainfo.plist", b"meta"),
+            ("glyphs/contents.plist", b"x"),
+            ("glyphs/A_.glif", b"y"),
+        ]);
+
+        let source = ZipSource::open(tmp.path()).unwrap();
+        let mut entries = source.list_dir(Path::new("glyphs")).unwrap();
+        entries.sort();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0], DirEntry::File("A_.glif".into()));
+        assert_eq!(entries[1], DirEntry::File("contents.plist".into()));
+    }
+
+    #[test]
+    fn list_dir_empty() {
+        let tmp = write_zip_to_tempfile(&[("metainfo.plist", b"x")]);
+        let source = ZipSource::open(tmp.path()).unwrap();
+        let entries = source.list_dir(Path::new("images")).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn open_invalid_zip() {
+        let tmp = NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"not a zip file at all").unwrap();
+        let result = ZipSource::open(tmp.path());
+        assert!(matches!(result, Err(FontLoadError::InvalidZipFile(_))));
+    }
+
+    #[test]
+    fn open_nonexistent_file() {
+        let result = ZipSource::open(Path::new("/tmp/norad_test_nonexistent_ufoz.zip"));
+        assert!(matches!(result, Err(FontLoadError::AccessUfoDir(_))));
+    }
+
+    #[test]
+    fn detect_root_direct() {
+        // Test detect_zip_root directly with an in-memory zip.
+        let mut buf = Cursor::new(Vec::new());
+        {
+            let mut writer = zip::ZipWriter::new(&mut buf);
+            let opts = zip::write::SimpleFileOptions::default();
+            writer.start_file("Root.ufo/metainfo.plist", opts).unwrap();
+            std::io::Write::write_all(&mut writer, b"data").unwrap();
+            writer.start_file("Root.ufo/glyphs/A_.glif", opts).unwrap();
+            std::io::Write::write_all(&mut writer, b"glyph").unwrap();
+            writer.finish().unwrap();
+        }
+        buf.set_position(0);
+        let mut archive = zip::ZipArchive::new(buf).unwrap();
+        assert_eq!(detect_zip_root(&mut archive), Some(PathBuf::from("Root.ufo")));
+    }
+
+    #[test]
+    fn dir_entries_skipped() {
+        // Create a zip with explicit directory entries.
+        let tmp = NamedTempFile::new().unwrap();
+        {
+            let mut writer = zip::ZipWriter::new(std::fs::File::create(tmp.path()).unwrap());
+            let opts = zip::write::SimpleFileOptions::default();
+            writer.add_directory("glyphs/", opts).unwrap();
+            writer.start_file("glyphs/A_.glif", opts).unwrap();
+            std::io::Write::write_all(&mut writer, b"glyph").unwrap();
+            writer.start_file("metainfo.plist", opts).unwrap();
+            std::io::Write::write_all(&mut writer, b"meta").unwrap();
+            writer.finish().unwrap();
+        }
+
+        let source = ZipSource::open(tmp.path()).unwrap();
+        // Should have only file entries, not directory entries.
+        assert_eq!(source.entries.len(), 2);
+        assert!(source.entries.contains_key(Path::new("glyphs/A_.glif")));
+        assert!(source.entries.contains_key(Path::new("metainfo.plist")));
     }
 }

--- a/tests/ufoz.rs
+++ b/tests/ufoz.rs
@@ -1,0 +1,185 @@
+#![cfg(feature = "ufoz")]
+
+use std::path::{Path, PathBuf};
+
+use norad::error::FontLoadError;
+use norad::{DataRequest, Font};
+use tempfile::NamedTempFile;
+
+/// Walk a `.ufo` directory on disk and write all files into a zip archive.
+/// If `wrap_in_dir` is `Some("Foo.ufo")`, every entry is prefixed with that directory.
+fn ufo_dir_to_zip(ufo_path: &Path, wrap_in_dir: Option<&str>) -> NamedTempFile {
+    let tmp = NamedTempFile::new().unwrap();
+    let mut writer = zip::ZipWriter::new(std::fs::File::create(tmp.path()).unwrap());
+    let opts =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+    for entry in walkdir(ufo_path) {
+        let rel = entry.strip_prefix(ufo_path).unwrap();
+        let zip_name = match wrap_in_dir {
+            Some(dir) => format!("{}/{}", dir, rel.to_string_lossy()),
+            None => rel.to_string_lossy().to_string(),
+        };
+        writer.start_file(&zip_name, opts).unwrap();
+        let data = std::fs::read(&entry).unwrap();
+        std::io::Write::write_all(&mut writer, &data).unwrap();
+    }
+    writer.finish().unwrap();
+    tmp
+}
+
+/// Recursively collect all file paths under `dir`.
+fn walkdir(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    walk_recursive(dir, &mut files);
+    files.sort();
+    files
+}
+
+fn walk_recursive(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            walk_recursive(&path, out);
+        } else {
+            out.push(path);
+        }
+    }
+}
+
+/// Create a zip with extra __MACOSX entries injected.
+fn ufo_dir_to_zip_with_macosx(ufo_path: &Path, wrap_dir: &str) -> NamedTempFile {
+    let tmp = NamedTempFile::new().unwrap();
+    let mut writer = zip::ZipWriter::new(std::fs::File::create(tmp.path()).unwrap());
+    let opts =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+    // Inject __MACOSX junk entries first.
+    writer.start_file("__MACOSX/._DS_Store", opts).unwrap();
+    std::io::Write::write_all(&mut writer, b"junk").unwrap();
+    writer.start_file(format!("__MACOSX/{}/._fontinfo.plist", wrap_dir), opts).unwrap();
+    std::io::Write::write_all(&mut writer, b"more junk").unwrap();
+
+    for entry in walkdir(ufo_path) {
+        let rel = entry.strip_prefix(ufo_path).unwrap();
+        let zip_name = format!("{}/{}", wrap_dir, rel.to_string_lossy());
+        writer.start_file(&zip_name, opts).unwrap();
+        let data = std::fs::read(&entry).unwrap();
+        std::io::Write::write_all(&mut writer, &data).unwrap();
+    }
+    writer.finish().unwrap();
+    tmp
+}
+
+fn minimal_zip_entries(entries: &[(&str, &[u8])]) -> NamedTempFile {
+    let tmp = NamedTempFile::new().unwrap();
+    let mut writer = zip::ZipWriter::new(std::fs::File::create(tmp.path()).unwrap());
+    let opts =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (name, data) in entries {
+        writer.start_file(*name, opts).unwrap();
+        std::io::Write::write_all(&mut writer, data).unwrap();
+    }
+    writer.finish().unwrap();
+    tmp
+}
+
+// --- Tests ---
+
+#[test]
+fn load_ufoz_matches_directory() {
+    let ufo_path = Path::new("testdata/MutatorSansLightWide.ufo");
+    let dir_font = Font::load(ufo_path).unwrap();
+
+    let zip_file = ufo_dir_to_zip(ufo_path, None);
+    let zip_font = Font::load(zip_file.path()).unwrap();
+
+    assert_eq!(dir_font, zip_font);
+
+    // Spot-check fields that Store::PartialEq doesn't deeply compare.
+    assert_eq!(zip_font.glyph_count(), dir_font.glyph_count());
+    assert_eq!(zip_font.iter_layers().count(), dir_font.iter_layers().count());
+    assert_eq!(zip_font.kerning, dir_font.kerning);
+    assert_eq!(zip_font.groups, dir_font.groups);
+    assert_eq!(zip_font.features, dir_font.features);
+    assert_eq!(zip_font.lib, dir_font.lib);
+    assert_eq!(zip_font.font_info, dir_font.font_info);
+}
+
+#[test]
+fn load_ufoz_with_wrapper_dir() {
+    let ufo_path = Path::new("testdata/MutatorSansLightWide.ufo");
+    let dir_font = Font::load(ufo_path).unwrap();
+
+    let zip_file = ufo_dir_to_zip(ufo_path, Some("MutatorSansLightWide.ufo"));
+    let zip_font = Font::load(zip_file.path()).unwrap();
+
+    assert_eq!(dir_font, zip_font);
+    assert_eq!(zip_font.glyph_count(), dir_font.glyph_count());
+    assert_eq!(zip_font.features, dir_font.features);
+}
+
+#[test]
+fn load_ufoz_with_macosx_entries() {
+    let ufo_path = Path::new("testdata/MutatorSansLightWide.ufo");
+    let dir_font = Font::load(ufo_path).unwrap();
+
+    let zip_file = ufo_dir_to_zip_with_macosx(ufo_path, "MutatorSansLightWide.ufo");
+    let zip_font = Font::load(zip_file.path()).unwrap();
+
+    assert_eq!(dir_font, zip_font);
+}
+
+#[test]
+fn load_ufoz_data_request_none() {
+    let ufo_path = Path::new("testdata/MutatorSansLightWide.ufo");
+    let zip_file = ufo_dir_to_zip(ufo_path, None);
+
+    let font = Font::load_requested_data(zip_file.path(), DataRequest::none()).unwrap();
+
+    assert_eq!(font.iter_layers().count(), 1);
+    assert!(font.default_layer().is_empty());
+    assert!(font.lib.is_empty());
+    assert!(font.groups.is_empty());
+    assert!(font.kerning.is_empty());
+    assert!(font.features.is_empty());
+}
+
+#[test]
+fn load_ufoz_data_and_images() {
+    let ufo_path = Path::new("testdata/dataimagetest.ufo");
+    let dir_font = Font::load(ufo_path).unwrap();
+
+    let zip_file = ufo_dir_to_zip(ufo_path, None);
+    let zip_font = Font::load(zip_file.path()).unwrap();
+
+    assert_eq!(dir_font, zip_font);
+
+    // Verify data store contents.
+    assert_eq!(zip_font.data.len(), dir_font.data.len());
+    assert_eq!(zip_font.images.len(), dir_font.images.len());
+
+    // Spot-check actual data content.
+    let zip_data = zip_font.data.get(Path::new("a.txt")).unwrap().unwrap();
+    let dir_data = dir_font.data.get(Path::new("a.txt")).unwrap().unwrap();
+    assert_eq!(&*zip_data, &*dir_data);
+}
+
+#[test]
+fn load_zip_missing_metainfo() {
+    let lc = br#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><array>
+<array><string>public.default</string><string>glyphs</string></array>
+</array></plist>"#;
+    let contents = br#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict></dict></plist>"#;
+
+    let tmp =
+        minimal_zip_entries(&[("layercontents.plist", lc), ("glyphs/contents.plist", contents)]);
+
+    let result = Font::load(tmp.path());
+    assert!(matches!(result, Err(FontLoadError::MissingMetaInfoFile)));
+}


### PR DESCRIPTION
If passed a file (not a directory) and with the 'ufoz' feature enabled, norad will attempt to treat the file as a zip'd ufo directory.


- this is based on top of #405 
- closes #262 