### PR TITLE
Add verticalOrigin accessor method

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -662,6 +662,11 @@ impl From<IoError> for StoreError {
 #[non_exhaustive]
 pub enum LibRetrievalError {
     /// A lib key has unexpected data.
-    #[error("the glif lib key '{0}' has invalid data, expected {1}")]
-    InvalidData(&'static str, &'static str),
+    #[error("the glif lib key '{key}' has invalid data, expected {expectation}")]
+    InvalidData {
+        /// They sought after lib key.
+        key: &'static str,
+        /// What data type was expected.
+        expectation: &'static str,
+    },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -661,12 +661,10 @@ impl From<IoError> for StoreError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum LibRetrievalError {
-    /// A lib key has unexpected data.
-    #[error("the glif lib key '{key}' has invalid data, expected {expectation}")]
-    InvalidData {
-        /// They sought after lib key.
-        key: &'static str,
-        /// What data type was expected.
-        expectation: &'static str,
+    /// The `public.verticalOrigin` key has unexpected data.
+    #[error("'public.verticalOrigin' must be a number of reasonable size, but was '{value:?}'")]
+    BadVerticalOrigin {
+        /// The unexpected value.
+        value: plist::Value,
     },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -656,3 +656,12 @@ impl From<IoError> for StoreError {
         StoreError::Io(std::sync::Arc::new(src))
     }
 }
+
+/// Errors for when retrieving lib data.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LibRetrievalError {
+    /// A lib key has unexpected data.
+    #[error("the glif lib key '{0}' has invalid data, expected {1}")]
+    InvalidData(&'static str, &'static str),
+}

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -247,28 +247,31 @@ impl Glyph {
     }
 
     /// Set the vertical origin of the glyph, and returns an attempted parse of
-    /// its previous value, if present. See `public.verticalOrigin` in the
-    /// [Common Key Registry].
+    /// its previous value, if present. If passing None, remove the vertical
+    /// origin of the glyph, and returns an attempted parse of its previous
+    /// value, if present. See `public.verticalOrigin` in the [Common Key
+    /// Registry].
     ///
     /// [Common Key Registry]:
     ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
-    pub fn set_vertical_origin(&mut self, value: f64) -> Option<Result<f64, LibRetrievalError>> {
-        let plist = if (value - value.round()).abs() < f64::EPSILON {
-            plist::Value::Integer((value as i64).into())
+    pub fn set_vertical_origin(
+        &mut self,
+        value: impl Into<Option<f64>>,
+    ) -> Option<Result<f64, LibRetrievalError>> {
+        let value = value.into();
+        if let Some(value) = value {
+            let plist = if value.fract() == 0.0 {
+                plist::Value::Integer((value as i64).into())
+            } else {
+                plist::Value::Real(value)
+            };
+            self.lib
+                .insert(PUBLIC_VERTICAL_ORIGIN.into(), plist)
+                .as_ref()
+                .map(plist_to_vertical_origin)
         } else {
-            plist::Value::Real(value)
-        };
-        self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist).as_ref().map(plist_to_vertical_origin)
-    }
-
-    /// Remove the vertical origin of the glyph, and returns an attempted parse
-    /// of its previous value, if present. See `public.verticalOrigin` in the
-    /// [Common Key Registry].
-    ///
-    /// [Common Key Registry]:
-    ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
-    pub fn remove_vertical_origin(&mut self) -> Option<Result<f64, LibRetrievalError>> {
-        self.lib.remove(PUBLIC_VERTICAL_ORIGIN).as_ref().map(plist_to_vertical_origin)
+            self.lib.remove(PUBLIC_VERTICAL_ORIGIN).as_ref().map(plist_to_vertical_origin)
+        }
     }
 }
 

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -259,19 +259,17 @@ impl Glyph {
         value: impl Into<Option<f64>>,
     ) -> Option<Result<f64, LibRetrievalError>> {
         let value = value.into();
-        if let Some(value) = value {
+        let old = if let Some(value) = value {
             let plist = if value.fract() == 0.0 {
                 plist::Value::Integer((value as i64).into())
             } else {
                 plist::Value::Real(value)
             };
-            self.lib
-                .insert(PUBLIC_VERTICAL_ORIGIN.into(), plist)
-                .as_ref()
-                .map(plist_to_vertical_origin)
+            self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist)
         } else {
-            self.lib.remove(PUBLIC_VERTICAL_ORIGIN).as_ref().map(plist_to_vertical_origin)
-        }
+            self.lib.remove(PUBLIC_VERTICAL_ORIGIN)
+        };
+        old.as_ref().map(plist_to_vertical_origin)
     }
 }
 

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -248,10 +248,10 @@ impl Glyph {
             plist::Value::Integer(integer) => integer.as_signed().map(|v| v as f64),
             _ => None,
         };
-        Some(parsed.ok_or(LibRetrievalError::InvalidData(
-            PUBLIC_VERTICAL_ORIGIN,
-            "an integer or float of reasonable size",
-        )))
+        Some(parsed.ok_or(LibRetrievalError::InvalidData {
+            key: PUBLIC_VERTICAL_ORIGIN,
+            expectation: "an integer or float of reasonable size",
+        }))
     }
 
     /// Set the vertical origin of the glyph. Use a value of `None` to unset it.

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -237,7 +237,7 @@ impl Glyph {
     }
 
     /// Try parsing the vertical origin from the lib data of the glyph, if it
-    /// exists. See `public.verticalOrigin` in the  [Common Key Registry].
+    /// exists. See `public.verticalOrigin` in the [Common Key Registry].
     ///
     /// [Common Key Registry]:
     ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
@@ -254,24 +254,29 @@ impl Glyph {
         }))
     }
 
-    /// Set the vertical origin of the glyph. Use a value of `None` to unset it.
-    /// See `public.verticalOrigin` in the [Common Key Registry].
+    /// Set the vertical origin of the glyph and return the old number, if any
+    /// and if it can be parsed. See `public.verticalOrigin` in the [Common Key
+    /// Registry].
     ///
     /// [Common Key Registry]:
     ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
-    pub fn set_vertical_origin(&mut self, value: f64) {
+    pub fn set_vertical_origin(&mut self, value: f64) -> Option<f64> {
         let plist = if (value - value.round()).abs() < f64::EPSILON {
             plist::Value::Integer((value as i64).into())
         } else {
             plist::Value::Real(value)
         };
-        self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist);
+        match self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist) {
+            Some(plist::Value::Real(real)) => Some(real),
+            Some(plist::Value::Integer(integer)) => integer.as_signed().map(|v| v as f64),
+            _ => None,
+        }
     }
 
     /// Remove the vertical origin lib key data and return its value, if any.
     ///
     /// Returns None if the data cannot be parsed into a number of reasonable
-    /// size.
+    /// size, but will remove the data anyway.
     pub fn remove_vertical_origin(&mut self) -> Option<f64> {
         match self.lib.remove(PUBLIC_VERTICAL_ORIGIN) {
             Some(plist::Value::Real(real)) => Some(real),

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -259,16 +259,24 @@ impl Glyph {
     ///
     /// [Common Key Registry]:
     ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
-    pub fn set_vertical_origin(&mut self, value: Option<f64>) {
-        if let Some(real) = value {
-            let plist = if (real - real.round()).abs() < f64::EPSILON {
-                plist::Value::Integer((real as i64).into())
-            } else {
-                plist::Value::Real(real)
-            };
-            self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist);
+    pub fn set_vertical_origin(&mut self, value: f64) {
+        let plist = if (value - value.round()).abs() < f64::EPSILON {
+            plist::Value::Integer((value as i64).into())
         } else {
-            self.lib.remove(PUBLIC_VERTICAL_ORIGIN);
+            plist::Value::Real(value)
+        };
+        self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist);
+    }
+
+    /// Remove the vertical origin lib key data and return its value, if any.
+    ///
+    /// Returns None if the data cannot be parsed into a number of reasonable
+    /// size.
+    pub fn remove_vertical_origin(&mut self) -> Option<f64> {
+        match self.lib.remove(PUBLIC_VERTICAL_ORIGIN) {
+            Some(plist::Value::Real(real)) => Some(real),
+            Some(plist::Value::Integer(integer)) => integer.as_signed().map(|v| v as f64),
+            _ => None,
         }
     }
 }

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -279,10 +279,7 @@ fn plist_to_vertical_origin(plist: &plist::Value) -> Result<f64, LibRetrievalErr
         plist::Value::Integer(integer) => integer.as_signed().map(|v| v as f64),
         _ => None,
     };
-    parsed.ok_or(LibRetrievalError::InvalidData {
-        key: PUBLIC_VERTICAL_ORIGIN,
-        expectation: "an integer or float of reasonable size",
-    })
+    parsed.ok_or(LibRetrievalError::BadVerticalOrigin { value: plist.clone() })
 }
 
 /// A reference position in a glyph, such as for attaching accents.

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -12,12 +12,14 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "kurbo")]
 use crate::error::ConvertContourError;
 
-use crate::error::{ErrorKind, GlifLoadError, GlifWriteError, StoreError};
+use crate::error::{ErrorKind, GlifLoadError, GlifWriteError, LibRetrievalError, StoreError};
 use crate::name::Name;
 use crate::shared_types::PUBLIC_OBJECT_LIBS_KEY;
 use crate::{Color, Guideline, Identifier, Line, Plist, WriteOptions};
 
 pub use codepoints::Codepoints;
+
+pub static PUBLIC_VERTICAL_ORIGIN: &str = "public.verticalOrigin";
 
 /// A glyph, loaded from a [`.glif` file][glif].
 ///
@@ -232,6 +234,42 @@ impl Glyph {
         }
 
         object_libs
+    }
+
+    /// Try parsing the vertical origin from the lib data of the glyph, if it
+    /// exists. See `public.verticalOrigin` in the  [Common Key Registry].
+    ///
+    /// [Common Key Registry]:
+    ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
+    pub fn vertical_origin(&self) -> Option<Result<f64, LibRetrievalError>> {
+        let plist = self.lib.get(PUBLIC_VERTICAL_ORIGIN)?;
+        let parsed = match plist {
+            plist::Value::Real(real) => Some(*real),
+            plist::Value::Integer(integer) => integer.as_signed().map(|v| v as f64),
+            _ => None,
+        };
+        Some(parsed.ok_or(LibRetrievalError::InvalidData(
+            PUBLIC_VERTICAL_ORIGIN,
+            "an integer or float of reasonable size",
+        )))
+    }
+
+    /// Set the vertical origin of the glyph. Use a value of `None` to unset it.
+    /// See `public.verticalOrigin` in the [Common Key Registry].
+    ///
+    /// [Common Key Registry]:
+    ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
+    pub fn set_vertical_origin(&mut self, value: Option<f64>) {
+        if let Some(real) = value {
+            let plist = if (real - real.round()).abs() < f64::EPSILON {
+                plist::Value::Integer((real as i64).into())
+            } else {
+                plist::Value::Real(real)
+            };
+            self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist);
+        } else {
+            self.lib.remove(PUBLIC_VERTICAL_ORIGIN);
+        }
     }
 }
 

--- a/src/glyph/mod.rs
+++ b/src/glyph/mod.rs
@@ -236,54 +236,52 @@ impl Glyph {
         object_libs
     }
 
-    /// Try parsing the vertical origin from the lib data of the glyph, if it
-    /// exists. See `public.verticalOrigin` in the [Common Key Registry].
+    /// Try parsing the vertical origin of the glyph, if present. See
+    /// `public.verticalOrigin` in the [Common Key Registry].
     ///
     /// [Common Key Registry]:
     ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
+    #[must_use]
     pub fn vertical_origin(&self) -> Option<Result<f64, LibRetrievalError>> {
-        let plist = self.lib.get(PUBLIC_VERTICAL_ORIGIN)?;
-        let parsed = match plist {
-            plist::Value::Real(real) => Some(*real),
-            plist::Value::Integer(integer) => integer.as_signed().map(|v| v as f64),
-            _ => None,
-        };
-        Some(parsed.ok_or(LibRetrievalError::InvalidData {
-            key: PUBLIC_VERTICAL_ORIGIN,
-            expectation: "an integer or float of reasonable size",
-        }))
+        self.lib.get(PUBLIC_VERTICAL_ORIGIN).map(plist_to_vertical_origin)
     }
 
-    /// Set the vertical origin of the glyph and return the old number, if any
-    /// and if it can be parsed. See `public.verticalOrigin` in the [Common Key
-    /// Registry].
+    /// Set the vertical origin of the glyph, and returns an attempted parse of
+    /// its previous value, if present. See `public.verticalOrigin` in the
+    /// [Common Key Registry].
     ///
     /// [Common Key Registry]:
     ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
-    pub fn set_vertical_origin(&mut self, value: f64) -> Option<f64> {
+    pub fn set_vertical_origin(&mut self, value: f64) -> Option<Result<f64, LibRetrievalError>> {
         let plist = if (value - value.round()).abs() < f64::EPSILON {
             plist::Value::Integer((value as i64).into())
         } else {
             plist::Value::Real(value)
         };
-        match self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist) {
-            Some(plist::Value::Real(real)) => Some(real),
-            Some(plist::Value::Integer(integer)) => integer.as_signed().map(|v| v as f64),
-            _ => None,
-        }
+        self.lib.insert(PUBLIC_VERTICAL_ORIGIN.into(), plist).as_ref().map(plist_to_vertical_origin)
     }
 
-    /// Remove the vertical origin lib key data and return its value, if any.
+    /// Remove the vertical origin of the glyph, and returns an attempted parse
+    /// of its previous value, if present. See `public.verticalOrigin` in the
+    /// [Common Key Registry].
     ///
-    /// Returns None if the data cannot be parsed into a number of reasonable
-    /// size, but will remove the data anyway.
-    pub fn remove_vertical_origin(&mut self) -> Option<f64> {
-        match self.lib.remove(PUBLIC_VERTICAL_ORIGIN) {
-            Some(plist::Value::Real(real)) => Some(real),
-            Some(plist::Value::Integer(integer)) => integer.as_signed().map(|v| v as f64),
-            _ => None,
-        }
+    /// [Common Key Registry]:
+    ///     https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#publicverticalorigin
+    pub fn remove_vertical_origin(&mut self) -> Option<Result<f64, LibRetrievalError>> {
+        self.lib.remove(PUBLIC_VERTICAL_ORIGIN).as_ref().map(plist_to_vertical_origin)
     }
+}
+
+fn plist_to_vertical_origin(plist: &plist::Value) -> Result<f64, LibRetrievalError> {
+    let parsed = match plist {
+        plist::Value::Real(real) => Some(*real),
+        plist::Value::Integer(integer) => integer.as_signed().map(|v| v as f64),
+        _ => None,
+    };
+    parsed.ok_or(LibRetrievalError::InvalidData {
+        key: PUBLIC_VERTICAL_ORIGIN,
+        expectation: "an integer or float of reasonable size",
+    })
 }
 
 /// A reference position in a glyph, such as for attaching accents.

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -923,7 +923,7 @@ fn get_vertical_origin() {
 
     assert_eq!(glyph.vertical_origin().unwrap().unwrap(), 880.);
 
-    glyph.set_vertical_origin(Some(1234.));
+    glyph.set_vertical_origin(1234.);
 
     assert_eq!(glyph.vertical_origin().unwrap().unwrap(), 1234.);
 
@@ -943,7 +943,7 @@ fn set_vertical_origin() {
 "#;
     let mut glyph = parse_glyph(glyph_xml.as_bytes()).unwrap();
 
-    glyph.set_vertical_origin(Some(1234.));
+    glyph.set_vertical_origin(1234.);
     let output = glyph.encode_xml().unwrap();
     let output = std::str::from_utf8(&output).unwrap();
 
@@ -963,7 +963,7 @@ fn set_vertical_origin() {
         .trim_start()
     );
 
-    glyph.set_vertical_origin(Some(1234.5678));
+    glyph.set_vertical_origin(1234.5678);
     let output = glyph.encode_xml().unwrap();
     let output = std::str::from_utf8(&output).unwrap();
 
@@ -978,6 +978,21 @@ fn set_vertical_origin() {
 			<real>1234.5678</real>
 		</dict>
 	</lib>
+</glyph>
+"#
+        .trim_start()
+    );
+
+    let value = glyph.remove_vertical_origin();
+    let output = glyph.encode_xml().unwrap();
+    let output = std::str::from_utf8(&output).unwrap();
+
+    assert_eq!(value, Some(1234.5678));
+    assert_eq!(
+        output,
+        r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hello" format="2">
 </glyph>
 "#
         .trim_start()

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -987,7 +987,7 @@ fn set_vertical_origin() {
     let output = glyph.encode_xml().unwrap();
     let output = std::str::from_utf8(&output).unwrap();
 
-    assert_eq!(value, Some(1234.5678));
+    assert_eq!(value.unwrap().unwrap(), 1234.5678);
     assert_eq!(
         output,
         r#"

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -915,3 +915,71 @@ fn v1_glyph_with_note() {
     let glyph = parse_glyph(glyph_xml.as_bytes()).unwrap();
     assert!(glyph.note.is_none());
 }
+
+#[test]
+fn get_vertical_orgin() {
+    let bytes = include_bytes!("../../testdata/cid61855.glif");
+    let mut glyph = parse_glyph(bytes).unwrap();
+
+    assert_eq!(glyph.vertical_origin().unwrap().unwrap(), 880.);
+
+    glyph.set_vertical_origin(Some(1234.));
+
+    assert_eq!(glyph.vertical_origin().unwrap().unwrap(), 1234.);
+
+    glyph
+        .lib
+        .insert(crate::glyph::PUBLIC_VERTICAL_ORIGIN.into(), plist::Value::String("hello".into()));
+
+    assert!(glyph.vertical_origin().unwrap().is_err());
+}
+
+#[test]
+fn set_vertical_origin() {
+    let glyph_xml = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hello" format="1">
+</glyph>
+"#;
+    let mut glyph = parse_glyph(glyph_xml.as_bytes()).unwrap();
+
+    glyph.set_vertical_origin(Some(1234.));
+    let output = glyph.encode_xml().unwrap();
+    let output = std::str::from_utf8(&output).unwrap();
+
+    assert_eq!(
+        output,
+        r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hello" format="2">
+	<lib>
+		<dict>
+			<key>public.verticalOrigin</key>
+			<integer>1234</integer>
+		</dict>
+	</lib>
+</glyph>
+"#
+        .trim_start()
+    );
+
+    glyph.set_vertical_origin(Some(1234.5678));
+    let output = glyph.encode_xml().unwrap();
+    let output = std::str::from_utf8(&output).unwrap();
+
+    assert_eq!(
+        output,
+        r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hello" format="2">
+	<lib>
+		<dict>
+			<key>public.verticalOrigin</key>
+			<real>1234.5678</real>
+		</dict>
+	</lib>
+</glyph>
+"#
+        .trim_start()
+    );
+}

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -917,7 +917,7 @@ fn v1_glyph_with_note() {
 }
 
 #[test]
-fn get_vertical_orgin() {
+fn get_vertical_origin() {
     let bytes = include_bytes!("../../testdata/cid61855.glif");
     let mut glyph = parse_glyph(bytes).unwrap();
 

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -983,7 +983,7 @@ fn set_vertical_origin() {
         .trim_start()
     );
 
-    let value = glyph.remove_vertical_origin();
+    let value = glyph.set_vertical_origin(None);
     let output = glyph.encode_xml().unwrap();
     let output = std::str::from_utf8(&output).unwrap();
 


### PR DESCRIPTION
We thought we could have an official accessor for a glyph's vertical origin. Feel free to code golf this.

Harry helped flesh this out :)