### PR TITLE
Treat empty guideline names as no name

### DIFF
--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -1725,6 +1725,16 @@ mod tests {
     }
 
     #[test]
+    fn fontinfo_empty_guideline_name() {
+        let path = "testdata/fontinfo_empty_guideline_name.plist";
+        let font_info: FontInfo = plist::from_file(path).expect("failed to load fontinfo");
+        let guidelines = font_info.guidelines.expect("guidelines should be present");
+        assert_eq!(guidelines.len(), 2);
+        assert_eq!(guidelines[0].name, None);
+        assert_eq!(guidelines[1].name, Some(Name::new_raw("ascender")));
+    }
+
+    #[test]
     fn fontinfo2() {
         let path = "testdata/fontinfotest.ufo/fontinfo.plist";
         let font_info: FontInfo = plist::from_file(path).expect("failed to load fontinfo");

--- a/src/glyph/parse.rs
+++ b/src/glyph/parse.rs
@@ -504,6 +504,9 @@ impl GlifParser {
                     }
                     angle = Some(angle_value);
                 }
+                // The name is optional, and some real-world fonts write it as
+                // an explicit empty string; treat that as no name.
+                b"name" if value.is_empty() => (),
                 b"name" => name = Some(Name::new(&value).map_err(|_| ErrorKind::InvalidName)?),
                 b"color" => color = Some(value.parse().map_err(|_| ErrorKind::BadColor)?),
                 b"identifier" => {

--- a/src/glyph/tests.rs
+++ b/src/glyph/tests.rs
@@ -254,6 +254,19 @@ fn guidelines() {
 }
 
 #[test]
+fn empty_guideline_name() {
+    let data = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="period" format="2">
+  <guideline y="495" name=""/>
+</glyph>
+"#;
+    let glyph = parse_glyph(data.as_bytes()).unwrap();
+    assert_eq!(glyph.guidelines.len(), 1);
+    assert_eq!(glyph.guidelines[0].name, None);
+}
+
+#[test]
 #[should_panic(expected = "MissingClose")]
 fn missing_close() {
     let data = r#"

--- a/src/guideline.rs
+++ b/src/guideline.rs
@@ -94,9 +94,22 @@ struct RawGuideline {
     x: Option<f64>,
     y: Option<f64>,
     angle: Option<f64>,
+    #[serde(default, deserialize_with = "deserialize_optional_name")]
     name: Option<Name>,
     color: Option<Color>,
     identifier: Option<Identifier>,
+}
+
+// The name is optional, and some real-world fonts write it as an explicit
+// empty string; treat that as no name instead of failing the load.
+fn deserialize_optional_name<'de, D>(deserializer: D) -> Result<Option<Name>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Option::<String>::deserialize(deserializer)? {
+        Some(name) if !name.is_empty() => name.parse::<Name>().map(Some).map_err(de::Error::custom),
+        _ => Ok(None),
+    }
 }
 
 impl Serialize for Guideline {
@@ -171,7 +184,7 @@ impl<'de> Deserialize<'de> for Guideline {
 mod tests {
     use super::*;
 
-    use serde_test::{assert_tokens, Token};
+    use serde_test::{assert_de_tokens, assert_tokens, Token};
 
     #[test]
     fn guideline_parsing() {
@@ -203,6 +216,24 @@ mod tests {
                 Token::Str("identifier"),
                 Token::Some,
                 Token::Str("abcABC123"),
+                Token::StructEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn empty_guideline_name_is_no_name() {
+        let expected = Guideline::new(Line::Vertical(495.0), None, None, None);
+        assert_de_tokens(
+            &expected,
+            &[
+                Token::Struct { name: "RawGuideline", len: 2 },
+                Token::Str("x"),
+                Token::Some,
+                Token::F64(495.0),
+                Token::Str("name"),
+                Token::Some,
+                Token::Str(""),
                 Token::StructEnd,
             ],
         );

--- a/testdata/fontinfo_empty_guideline_name.plist
+++ b/testdata/fontinfo_empty_guideline_name.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>familyName</key>
+	<string>Test</string>
+	<key>guidelines</key>
+	<array>
+		<dict>
+			<key>name</key>
+			<string></string>
+			<key>y</key>
+			<integer>495</integer>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>ascender</string>
+			<key>y</key>
+			<integer>750</integer>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Norad failed to parse a real-world UFO that has a guideline with an empty name. This patch allows empty guideline names.

See: https://github.com/googlefonts/roboto-serif/blob/8346c2b0ecec6bf539be222ea84de5906ef1ade8/sources/Roboto_Serif_Micro_Cond-Super.ufo/fontinfo.plist#L22-L23